### PR TITLE
Define MVP game rules and scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,3 +360,7 @@ This would create a foundation that can later expand into longer time horizons, 
 ## Project Intent
 
 HerbieGo aims to be both a game and a systems-thinking simulation: a place where players can experience the tension between local decisions and global outcomes inside a plant that evolves over time. The project should be designed so that the gameplay remains understandable to humans, playable from the terminal, and open to experimentation with both human and AI decision-makers.
+
+## Design Docs
+
+- [MVP Game Design](docs/mvp-game-design.md)

--- a/docs/mvp-game-design.md
+++ b/docs/mvp-game-design.md
@@ -61,7 +61,7 @@ Responsibilities:
 
 Legal actions each round:
 
-- set selling price for each customer-product offer
+- set market price for each product
 - set offer quantity for each customer-product offer
 - attach a short rationale/comment
 
@@ -166,6 +166,7 @@ Each player receives:
 - current week number
 - current cash and debt
 - current parts inventory
+- current shop floor inventory and work-in-progress by product and workstation stage
 - current finished goods inventory
 - current customer backlog by customer and product
 - current customer sentiment by customer
@@ -208,18 +209,20 @@ Rules:
 
 ### Phase 6: Production resolution
 
-The plant resolves production actions using on-hand parts inventory and finite workstation capacity.
+The plant resolves production actions using on-hand parts inventory, carried work-in-progress, and finite workstation capacity.
 
 Rules:
 
 - production cannot consume more parts than exist
 - production cannot use more workstation capacity than exists at either workstation
-- if the Production Manager requests more units than can be completed, the plant completes the maximum legal quantity
-- completed units are added to finished goods inventory
+- released units first consume required purchased parts and enter shop floor inventory at `Fabrication`
+- units that complete `Fabrication` move into intermediate work-in-progress before `Assembly`
+- units that complete `Assembly` move into finished goods inventory
+- if the Production Manager requests more units than can be advanced, the plant advances the maximum legal quantity
 - consumed parts are removed from parts inventory
 - any overtime or operating cost is charged to cash and may create debt within the debt ceiling
 
-The MVP resolves production as completed units within the same round instead of carrying work-in-progress between rounds.
+Shop floor inventory and work-in-progress carry from one round to the next until they are completed, blocked, or scrapped by a future ruleset.
 
 ### Phase 7: Sales resolution
 
@@ -227,8 +230,9 @@ The plant converts pricing decisions into customer-level demand, applies backlog
 
 Rules:
 
-- each customer may receive separate price and quantity offers per product
-- demand depends on price set by the Sales Manager and current customer sentiment
+- the Sales Manager sets one market price per product for all customers
+- each customer may receive a separate offer quantity per product
+- demand depends on market price set by the Sales Manager, current customer sentiment, and customer-specific demand
 - new accepted demand is added to that customer-product backlog
 - shipments draw down backlog from oldest to newest
 - realized shipments cannot exceed finished goods inventory
@@ -261,6 +265,7 @@ The MVP uses a deliberately compact economic model.
 ### Inventory Rules
 
 - parts inventory cannot go negative
+- shop floor inventory and work-in-progress cannot go negative
 - finished goods inventory cannot go negative
 - no action can sell, consume, or move more units than exist
 
@@ -292,7 +297,9 @@ The plant may round demand to an integer after applying the formula.
 - the plant ages backlog at the end of each round
 - backlog older than `2` rounds expires into lost sales
 - each expired backlog event reduces that customer's sentiment score
-- lower sentiment reduces future demand until the customer is won back through better service
+- sentiment recovers very slowly over time
+- sentiment recovers more quickly through reliable service and on-time shipment behavior
+- lower sentiment biases future purchase decisions downward until the customer is won back through better service
 
 ### Cost Rules
 
@@ -326,7 +333,7 @@ This section is the canonical answer to "what can a player do in one MVP round?"
 
 ### Sales Manager
 
-- `set_price(customer_id, product_id, unit_price)`
+- `set_price(product_id, unit_price)`
 - `set_offer_quantity(customer_id, product_id, quantity)`
 
 ### Finance Controller
@@ -349,6 +356,7 @@ The plant should expose shared metrics every round.
 - revenue
 - procurement spend
 - production volume by product
+- shop floor inventory by product and workstation stage
 - units sold by product
 - backlog by customer and product
 - parts inventory by part
@@ -397,14 +405,15 @@ The first playable version uses a fixed-length match of `52` rounds, with each r
 
 - can only produce defined products
 - must respect available part inventory
+- must manage partially completed units already on the shop floor
 - must respect workstation capacity at both workstations
 - cannot create finished products directly without consuming required parts
 
 ### Sales Manager Logic
 
-- controls demand indirectly through customer-specific pricing and offer quantity
+- controls demand through market-wide product pricing and customer-specific offer quantity
 - cannot ship more than available inventory
-- works against both price sensitivity and customer sentiment
+- works against price sensitivity, customer sentiment, and customer-specific demand
 - must manage backlog quality because delayed orders damage future sales
 - cannot backdate sales into the current round after seeing production results
 
@@ -430,7 +439,6 @@ The MVP does not yet include:
 - long-term era progression
 - multiple scenarios or plants
 - supplier-specific lead times
-- work-in-progress carried between rounds
 - machine failures and stochastic disruptions
 - separate hidden personal victory conditions
 - maintenance, engineering, HR, or distribution roles
@@ -453,6 +461,5 @@ Issue `#1` is complete when:
 
 These questions are narrow enough to answer later without blocking implementation, but they are worth confirming before balancing the simulation:
 
-1. Should shipments always satisfy the oldest backlog first, or can the Sales Manager prioritize customers explicitly?
-2. Should customer sentiment recover automatically over time, or only through reliable service?
-3. Should customer offers be locked to one product each week, or can the Sales Manager set offers for every customer-product pair every round?
+1. How quickly should passive customer sentiment recovery occur relative to the stronger recovery from reliable service?
+2. Should customer offers be locked to one product each week, or can the Sales Manager set offers for every customer-product pair every round?

--- a/docs/mvp-game-design.md
+++ b/docs/mvp-game-design.md
@@ -11,6 +11,7 @@ The first playable version intentionally focuses on:
 - one plant scenario
 - three operating roles plus one finance control role
 - simultaneous hidden turns
+- 52 weekly rounds per match
 - two finished products
 - two purchased parts per product
 - two required workstations in the production route
@@ -60,8 +61,8 @@ Responsibilities:
 
 Legal actions each round:
 
-- set selling price for each product
-- set offer quantity for each product
+- set selling price for each customer-product offer
+- set offer quantity for each customer-product offer
 - attach a short rationale/comment
 
 ### Finance Controller
@@ -79,6 +80,12 @@ Legal actions each round:
 - set next-round sales target for revenue
 - set next-round plant target for cash floor or debt ceiling
 - attach a short rationale/comment
+
+Budget rules:
+
+- finance budgets are soft targets
+- procurement and production may exceed the active budget by up to `10%`
+- spending beyond `110%` of the active budget is illegal and must be trimmed by the plant
 
 ### Plant Role
 
@@ -108,6 +115,23 @@ The MVP uses one fixed starter scenario so the first implementation can stay det
 - purchased parts: `Body`, `Fastener Kit`
 - route: `Fabrication -> Assembly`
 
+### Customers
+
+The game engine manages multiple customers. The Sales Manager sells to those customers instead of selling into one anonymous market.
+
+The MVP should start with a small fixed customer list, such as:
+
+- `NorthBuild`
+- `PrairieFlow`
+- `AgriWorks`
+
+Each customer has:
+
+- product-specific base demand
+- product-specific price sensitivity
+- a sentiment score that affects future demand
+- a backlog record for unshipped orders
+
 ### Workstations
 
 #### Workstation 1: `Fabrication`
@@ -133,15 +157,18 @@ Exact numeric values belong in scenario data, not hard-coded into the rules text
 
 ## Round Structure
 
-One round represents one planning-and-execution cycle for the plant.
+One round represents one week of plant operation.
 
 ### Phase 1: Broadcast state
 
 Each player receives:
 
+- current week number
 - current cash and debt
 - current parts inventory
 - current finished goods inventory
+- current customer backlog by customer and product
+- current customer sentiment by customer
 - workstation capacities for the round
 - active budgets and targets set by finance from the previous round
 - recent round log and player commentary
@@ -162,16 +189,26 @@ The plant resolves purchase orders.
 
 Rules:
 
-- each ordered part type adds to parts inventory at the end of procurement resolution
+- each ordered part type becomes an in-transit purchase order instead of immediate inventory
 - purchase spend reduces cash immediately
 - procurement may spend beyond cash on hand if the plant remains within the debt ceiling
 - if an order would breach the debt ceiling, the order is reduced or rejected until the rule is satisfied
 
-For MVP simplicity, purchased parts arrive in the same round after procurement resolution and are available to production in that round.
+Purchased parts arrive at the end of the next round. In MVP, all suppliers use the same one-round lead time. Supplier-specific lead times are deferred.
 
-### Phase 5: Production resolution
+### Phase 5: Parts receipt update
 
-The plant resolves production actions using available parts inventory and finite workstation capacity.
+The plant receives any purchase orders whose one-round lead time has completed.
+
+Rules:
+
+- arriving parts move from in-transit supply into parts inventory
+- received parts become available for production after receipt
+- the event log records which orders arrived this week
+
+### Phase 6: Production resolution
+
+The plant resolves production actions using on-hand parts inventory and finite workstation capacity.
 
 Rules:
 
@@ -184,20 +221,22 @@ Rules:
 
 The MVP resolves production as completed units within the same round instead of carrying work-in-progress between rounds.
 
-### Phase 6: Sales resolution
+### Phase 7: Sales resolution
 
-The plant converts pricing decisions into market demand, then ships from finished goods inventory.
+The plant converts pricing decisions into customer-level demand, applies backlog rules, then ships from finished goods inventory.
 
 Rules:
 
-- demand depends on price set by the Sales Manager
-- realized sales cannot exceed offered quantity
-- realized sales cannot exceed demand
-- realized sales cannot exceed finished goods inventory
+- each customer may receive separate price and quantity offers per product
+- demand depends on price set by the Sales Manager and current customer sentiment
+- new accepted demand is added to that customer-product backlog
+- shipments draw down backlog from oldest to newest
+- realized shipments cannot exceed finished goods inventory
 - shipped units reduce finished goods inventory and increase cash through revenue
-- unmet demand becomes lost sales in the MVP
+- backlog entries that remain unshipped for more than `2` rounds become lost sales and are removed from backlog
+- expired backlog reduces the affected customer's sentiment, making future sales harder
 
-### Phase 7: End-of-round finance update
+### Phase 8: End-of-round finance update
 
 The plant applies round-end financial effects.
 
@@ -233,17 +272,27 @@ The MVP uses a deliberately compact economic model.
 
 ### Demand Rules
 
-Each product has:
+Each customer-product pair has:
 
 - a reference price
 - a base demand
 - a price sensitivity
+- a sentiment modifier
 
 The first implementation should use a simple demand function:
 
-`realized_demand = max(0, base_demand - price_sensitivity * (price - reference_price))`
+`realized_demand = max(0, (base_demand * sentiment_modifier) - price_sensitivity * (price - reference_price))`
 
 The plant may round demand to an integer after applying the formula.
+
+### Backlog And Sentiment Rules
+
+- accepted demand that is not shipped immediately becomes backlog
+- backlog is tracked by customer, product, quantity, and order age in rounds
+- the plant ages backlog at the end of each round
+- backlog older than `2` rounds expires into lost sales
+- each expired backlog event reduces that customer's sentiment score
+- lower sentiment reduces future demand until the customer is won back through better service
 
 ### Cost Rules
 
@@ -253,6 +302,14 @@ The first implementation should track:
 - optional production operating cost
 - inventory holding cost
 - debt carrying cost
+
+### Budget Rules
+
+- finance budgets apply starting next round
+- procurement and production are expected to stay at or below budget
+- the plant allows spending up to `110%` of budget
+- the plant trims any action that would exceed the `110%` hard cap
+- budget misses inside the allowed range are logged as soft-target misses
 
 ## Action Vocabulary
 
@@ -269,8 +326,8 @@ This section is the canonical answer to "what can a player do in one MVP round?"
 
 ### Sales Manager
 
-- `set_price(product_id, unit_price)`
-- `set_offer_quantity(product_id, quantity)`
+- `set_price(customer_id, product_id, unit_price)`
+- `set_offer_quantity(customer_id, product_id, quantity)`
 
 ### Finance Controller
 
@@ -293,10 +350,12 @@ The plant should expose shared metrics every round.
 - procurement spend
 - production volume by product
 - units sold by product
+- backlog by customer and product
 - parts inventory by part
 - finished goods inventory by product
 - workstation utilization by workstation
 - lost sales by product
+- customer sentiment by customer
 - holding cost
 - debt cost
 - round profit
@@ -324,7 +383,7 @@ The plant immediately loses if:
 - debt exceeds the active debt ceiling and cannot be corrected by trimming actions
 - a mandatory round cannot be resolved legally
 
-The first playable version should favor a fixed-length match, such as `8` or `12` rounds, instead of open-ended play.
+The first playable version uses a fixed-length match of `52` rounds, with each round representing one week.
 
 ## Rules And Logic By Role
 
@@ -343,8 +402,10 @@ The first playable version should favor a fixed-length match, such as `8` or `12
 
 ### Sales Manager Logic
 
-- controls demand indirectly through price
-- cannot sell more than available inventory
+- controls demand indirectly through customer-specific pricing and offer quantity
+- cannot ship more than available inventory
+- works against both price sensitivity and customer sentiment
+- must manage backlog quality because delayed orders damage future sales
 - cannot backdate sales into the current round after seeing production results
 
 ### Finance Controller Logic
@@ -368,7 +429,7 @@ The MVP does not yet include:
 - networked multiplayer
 - long-term era progression
 - multiple scenarios or plants
-- supplier lead times beyond same-round arrival
+- supplier-specific lead times
 - work-in-progress carried between rounds
 - machine failures and stochastic disruptions
 - separate hidden personal victory conditions
@@ -384,6 +445,7 @@ Issue `#1` is complete when:
 - a contributor can describe the exact phases of one round
 - a contributor can list every legal action for each MVP role
 - a contributor can explain how two products, two-part BOMs, and two workstations interact
+- a contributor can explain one-round procurement lead time, backlog aging, and customer sentiment effects
 - a contributor knows the hard constraints: finite capacity, no negative inventory, debt allowed within limits
 - a future implementation can turn this document into deterministic code without first inventing new rules
 
@@ -391,7 +453,6 @@ Issue `#1` is complete when:
 
 These questions are narrow enough to answer later without blocking implementation, but they are worth confirming before balancing the simulation:
 
-1. Should purchased parts arrive immediately, at end of round, or next round?
-2. Should finance-set budgets be hard caps, soft warnings, or only scoring targets?
-3. Should the first match length be `8`, `10`, or `12` rounds?
-4. Should unmet sales demand be pure lost sales, or should some demand backlog into the next round?
+1. Should shipments always satisfy the oldest backlog first, or can the Sales Manager prioritize customers explicitly?
+2. Should customer sentiment recover automatically over time, or only through reliable service?
+3. Should customer offers be locked to one product each week, or can the Sales Manager set offers for every customer-product pair every round?

--- a/docs/mvp-game-design.md
+++ b/docs/mvp-game-design.md
@@ -62,7 +62,6 @@ Responsibilities:
 Legal actions each round:
 
 - set market price for each product
-- set offer quantity for each customer-product offer
 - attach a short rationale/comment
 
 ### Finance Controller
@@ -231,7 +230,7 @@ The plant converts pricing decisions into customer-level demand, applies backlog
 Rules:
 
 - the Sales Manager sets one market price per product for all customers
-- each customer may receive a separate offer quantity per product
+- market prices changed this round affect customer purchase decisions in the subsequent round
 - demand depends on market price set by the Sales Manager, current customer sentiment, and customer-specific demand
 - new accepted demand is added to that customer-product backlog
 - shipments draw down backlog from oldest to newest
@@ -298,6 +297,7 @@ The plant may round demand to an integer after applying the formula.
 - backlog older than `2` rounds expires into lost sales
 - each expired backlog event reduces that customer's sentiment score
 - sentiment recovers very slowly over time
+- passive sentiment recovery is `5%` of the recovery rate granted by reliable service
 - sentiment recovers more quickly through reliable service and on-time shipment behavior
 - lower sentiment biases future purchase decisions downward until the customer is won back through better service
 
@@ -411,7 +411,8 @@ The first playable version uses a fixed-length match of `52` rounds, with each r
 
 ### Sales Manager Logic
 
-- controls demand through market-wide product pricing and customer-specific offer quantity
+- controls demand through market-wide product pricing only
+- pricing changes influence the subsequent round rather than the current round
 - cannot ship more than available inventory
 - works against price sensitivity, customer sentiment, and customer-specific demand
 - must manage backlog quality because delayed orders damage future sales
@@ -461,5 +462,4 @@ Issue `#1` is complete when:
 
 These questions are narrow enough to answer later without blocking implementation, but they are worth confirming before balancing the simulation:
 
-1. How quickly should passive customer sentiment recovery occur relative to the stronger recovery from reliable service?
-2. Should customer offers be locked to one product each week, or can the Sales Manager set offers for every customer-product pair every round?
+No open MVP rule questions remain for issue `#1`.

--- a/docs/mvp-game-design.md
+++ b/docs/mvp-game-design.md
@@ -1,0 +1,397 @@
+# MVP Game Design
+
+This document defines the first playable version of HerbieGo. It is the acceptance target for roadmap issue `#1`: define the MVP game rules and scope before simulation code spreads across the project.
+
+## MVP Goal
+
+The MVP should create a short, replayable plant-management game where role-specific decisions create tension between local optimization and total plant performance.
+
+The first playable version intentionally focuses on:
+
+- one plant scenario
+- three operating roles plus one finance control role
+- simultaneous hidden turns
+- two finished products
+- two purchased parts per product
+- two required workstations in the production route
+- one compact and deterministic round-resolution model
+
+The MVP does not yet try to simulate decades of evolution, deep supplier networks, multiple plants, or networked multiplayer.
+
+## Roles In MVP
+
+The MVP includes four player roles plus plant-owned resolution logic.
+
+### Procurement Manager
+
+Responsibilities:
+
+- buy parts for future production
+- protect against shortages
+- manage procurement spend within budget
+
+Legal actions each round:
+
+- place purchase orders for each part type
+- choose order quantity per part type
+- attach a short rationale/comment
+
+### Production Manager
+
+Responsibilities:
+
+- convert part inventory into finished products
+- allocate finite workstation capacity
+- fulfill the plant production plan
+
+Legal actions each round:
+
+- choose how many units of each product to release into production
+- assign workstation capacity between products
+- attach a short rationale/comment
+
+### Sales Manager
+
+Responsibilities:
+
+- set prices
+- choose how much demand to pursue
+- convert finished goods into revenue
+
+Legal actions each round:
+
+- set selling price for each product
+- set offer quantity for each product
+- attach a short rationale/comment
+
+### Finance Controller
+
+Responsibilities:
+
+- manage short-term liquidity pressure
+- set next-round budget limits and operating targets
+- surface financial tradeoffs to the rest of the plant
+
+Legal actions each round:
+
+- set next-round budget for procurement
+- set next-round budget for production overtime/capacity spend
+- set next-round sales target for revenue
+- set next-round plant target for cash floor or debt ceiling
+- attach a short rationale/comment
+
+### Plant Role
+
+The plant is not a player, but it is a rules-owning entity that resolves all actions.
+
+The plant enforces:
+
+- inventory cannot go negative
+- workstation capacity is finite
+- finished products can only be sold if they exist in inventory
+- part purchases and operating costs can push cash into short-term debt
+- debt cannot exceed the current debt ceiling
+
+## Starter Scenario
+
+The MVP uses one fixed starter scenario so the first implementation can stay deterministic and easy to reason about.
+
+### Products
+
+#### Product A: `Pump`
+
+- purchased parts: `Housing`, `Seal Kit`
+- route: `Fabrication -> Assembly`
+
+#### Product B: `Valve`
+
+- purchased parts: `Body`, `Fastener Kit`
+- route: `Fabrication -> Assembly`
+
+### Workstations
+
+#### Workstation 1: `Fabrication`
+
+- finite capacity per round
+- converts purchased parts into fabricated subassemblies
+
+#### Workstation 2: `Assembly`
+
+- finite capacity per round
+- converts fabricated subassemblies into finished goods
+
+### Initial Assumptions
+
+The initial implementation should start with visible scenario constants similar to the following:
+
+- `Pump` and `Valve` each require exactly one unit of each of their two purchased parts
+- both products require capacity at both workstations
+- `Pump` and `Valve` can consume different amounts of workstation time
+- each part, product, workstation capacity, and cash amount is represented as an integer
+
+Exact numeric values belong in scenario data, not hard-coded into the rules text.
+
+## Round Structure
+
+One round represents one planning-and-execution cycle for the plant.
+
+### Phase 1: Broadcast state
+
+Each player receives:
+
+- current cash and debt
+- current parts inventory
+- current finished goods inventory
+- workstation capacities for the round
+- active budgets and targets set by finance from the previous round
+- recent round log and player commentary
+
+### Phase 2: Hidden action selection
+
+All players choose actions simultaneously. Current-turn choices remain hidden until resolution starts.
+
+### Phase 3: Finance target update
+
+The Finance Controller's action creates the budgets and targets that will apply in the next round, not the current round.
+
+This keeps the turn deterministic and prevents finance from retroactively vetoing same-round actions.
+
+### Phase 4: Procurement resolution
+
+The plant resolves purchase orders.
+
+Rules:
+
+- each ordered part type adds to parts inventory at the end of procurement resolution
+- purchase spend reduces cash immediately
+- procurement may spend beyond cash on hand if the plant remains within the debt ceiling
+- if an order would breach the debt ceiling, the order is reduced or rejected until the rule is satisfied
+
+For MVP simplicity, purchased parts arrive in the same round after procurement resolution and are available to production in that round.
+
+### Phase 5: Production resolution
+
+The plant resolves production actions using available parts inventory and finite workstation capacity.
+
+Rules:
+
+- production cannot consume more parts than exist
+- production cannot use more workstation capacity than exists at either workstation
+- if the Production Manager requests more units than can be completed, the plant completes the maximum legal quantity
+- completed units are added to finished goods inventory
+- consumed parts are removed from parts inventory
+- any overtime or operating cost is charged to cash and may create debt within the debt ceiling
+
+The MVP resolves production as completed units within the same round instead of carrying work-in-progress between rounds.
+
+### Phase 6: Sales resolution
+
+The plant converts pricing decisions into market demand, then ships from finished goods inventory.
+
+Rules:
+
+- demand depends on price set by the Sales Manager
+- realized sales cannot exceed offered quantity
+- realized sales cannot exceed demand
+- realized sales cannot exceed finished goods inventory
+- shipped units reduce finished goods inventory and increase cash through revenue
+- unmet demand becomes lost sales in the MVP
+
+### Phase 7: End-of-round finance update
+
+The plant applies round-end financial effects.
+
+Rules:
+
+- short-term debt accrues interest or carrying cost
+- inventory may incur holding cost
+- the event log records key state changes and player commentary
+- finance budgets and targets chosen this round become active for the next round
+
+## Economic And Market Logic
+
+The MVP uses a deliberately compact economic model.
+
+### Cash And Debt
+
+- cash may go below zero
+- negative cash is treated as short-term debt
+- debt may not exceed the active debt ceiling set by finance
+- if a player action would push debt past the allowed ceiling, the plant trims or rejects the action
+
+### Inventory Rules
+
+- parts inventory cannot go negative
+- finished goods inventory cannot go negative
+- no action can sell, consume, or move more units than exist
+
+### Capacity Rules
+
+- every workstation has finite capacity per round
+- each product consumes defined capacity units at each workstation
+- the plant computes the maximum feasible production from capacity and parts availability
+
+### Demand Rules
+
+Each product has:
+
+- a reference price
+- a base demand
+- a price sensitivity
+
+The first implementation should use a simple demand function:
+
+`realized_demand = max(0, base_demand - price_sensitivity * (price - reference_price))`
+
+The plant may round demand to an integer after applying the formula.
+
+### Cost Rules
+
+The first implementation should track:
+
+- part purchase cost
+- optional production operating cost
+- inventory holding cost
+- debt carrying cost
+
+## Action Vocabulary
+
+This section is the canonical answer to "what can a player do in one MVP round?"
+
+### Procurement Manager
+
+- `order_part(part_id, quantity)`
+
+### Production Manager
+
+- `release_product(product_id, quantity)`
+- `allocate_capacity(workstation_id, product_id, capacity_units)`
+
+### Sales Manager
+
+- `set_price(product_id, unit_price)`
+- `set_offer_quantity(product_id, quantity)`
+
+### Finance Controller
+
+- `set_procurement_budget(amount)`
+- `set_production_budget(amount)`
+- `set_sales_target(amount)`
+- `set_debt_ceiling(amount)`
+
+All roles may also submit:
+
+- `comment(text)`
+
+## Metrics Tracked In MVP
+
+The plant should expose shared metrics every round.
+
+- cash
+- short-term debt
+- revenue
+- procurement spend
+- production volume by product
+- units sold by product
+- parts inventory by part
+- finished goods inventory by product
+- workstation utilization by workstation
+- lost sales by product
+- holding cost
+- debt cost
+- round profit
+- cumulative profit
+
+Role dashboards may emphasize subsets of those metrics, but the source data stays shared.
+
+## Win, Loss, And Score Model
+
+The MVP should use a shared plant score rather than separate role-specific victory conditions.
+
+### Shared plant score
+
+At the end of a match:
+
+- primary score: cumulative profit
+- tie-breaker 1: total fulfilled demand
+- tie-breaker 2: lower ending debt
+- tie-breaker 3: lower ending inventory value
+
+### Failure conditions
+
+The plant immediately loses if:
+
+- debt exceeds the active debt ceiling and cannot be corrected by trimming actions
+- a mandatory round cannot be resolved legally
+
+The first playable version should favor a fixed-length match, such as `8` or `12` rounds, instead of open-ended play.
+
+## Rules And Logic By Role
+
+### Procurement Manager Logic
+
+- can buy any part type in any non-negative integer quantity
+- cannot force inventory negative
+- is constrained by current debt ceiling and next-round budget pressure
+
+### Production Manager Logic
+
+- can only produce defined products
+- must respect available part inventory
+- must respect workstation capacity at both workstations
+- cannot create finished products directly without consuming required parts
+
+### Sales Manager Logic
+
+- controls demand indirectly through price
+- cannot sell more than available inventory
+- cannot backdate sales into the current round after seeing production results
+
+### Finance Controller Logic
+
+- does not directly cancel same-round actions
+- shapes the next round through budgets and targets
+- can tighten or loosen debt tolerance and spending guidance
+
+### Plant Logic
+
+- resolves all player actions deterministically
+- applies legality checks in the same order every round
+- allows temporary debt but never negative inventory
+- never allows capacity overuse
+- logs both outcomes and player rationale
+
+## What Is Intentionally Deferred
+
+The MVP does not yet include:
+
+- networked multiplayer
+- long-term era progression
+- multiple scenarios or plants
+- supplier lead times beyond same-round arrival
+- work-in-progress carried between rounds
+- machine failures and stochastic disruptions
+- separate hidden personal victory conditions
+- maintenance, engineering, HR, or distribution roles
+- quality defects, scrap, or rework
+- save/load persistence
+- a fully fleshed out balancing model
+
+## Acceptance Criteria
+
+Issue `#1` is complete when:
+
+- a contributor can describe the exact phases of one round
+- a contributor can list every legal action for each MVP role
+- a contributor can explain how two products, two-part BOMs, and two workstations interact
+- a contributor knows the hard constraints: finite capacity, no negative inventory, debt allowed within limits
+- a future implementation can turn this document into deterministic code without first inventing new rules
+
+## Open Questions
+
+These questions are narrow enough to answer later without blocking implementation, but they are worth confirming before balancing the simulation:
+
+1. Should purchased parts arrive immediately, at end of round, or next round?
+2. Should finance-set budgets be hard caps, soft warnings, or only scoring targets?
+3. Should the first match length be `8`, `10`, or `12` rounds?
+4. Should unmet sales demand be pure lost sales, or should some demand backlog into the next round?


### PR DESCRIPTION
## Summary
- add an MVP game design document for roadmap issue #1
- define the starter scenario with 2 products, 2 parts per product, 2 workstations, multiple customers, and carried WIP
- document round structure, legal actions, metrics, scoring, and hard plant constraints
- capture clarified lead time, finance budget tolerance, weekly cadence, backlog aging, customer sentiment, market pricing, and shop-floor inventory rules
- link the design doc from the README

## Locked In
- purchased parts arrive at the end of the next round
- finance budgets are soft targets with a hard cap at 110%
- matches last 52 rounds, with 1 round = 1 week
- unmet demand becomes backlog, expires after 2 rounds, and damages customer sentiment
- shipments satisfy the oldest backlog first by default
- customer sentiment recovers slowly on its own and at 5% of the reliable-service recovery rate
- customer sentiment recovers faster with reliable service
- Sales sets market-wide product prices, not customer-specific prices or offers
- price changes affect customer purchases in the subsequent round
- work in progress and shop floor inventory carry across rounds

## Status
Issue #1 is fully specified at the MVP rules level. No open MVP rule questions remain in the design doc.