### PR TITLE
[codex] Design canonical plant domain model

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ The initial version of HerbieGo should focus on a small set of roles that create
 
 These hidden objectives are not necessarily "evil" goals. They represent the kinds of local incentives that make real organizations drift away from system-wide optimization.
 
+For the MVP, the canonical playable roles are:
+
+- Procurement Manager
+- Production Manager
+- Sales Manager
+- Finance Controller
+
+The plant itself resolves turns as a system actor. The broader project vision may later add roles such as Plant Manager, but that role is not part of the MVP action roster.
+
 #### Corporate Objectives
 
 All roles operate inside the same plant and contribute to the same corporate objectives:
@@ -49,24 +58,6 @@ All roles operate inside the same plant and contribute to the same corporate obj
 - Protect cash flow and the long-term viability of the business
 
 These are the shared goals the team should be trying to optimize together. The game becomes interesting when role-specific incentives pull players away from these corporate objectives.
-
-#### Plant Manager
-
-Public responsibility:
-
-- Coordinate the whole plant
-- Balance short-term survival with long-term improvement
-- Resolve conflicts between departments
-- Keep the plant profitable overall
-
-Hidden objective:
-
-- Avoid visible plant-wide failure during your tenure
-- Favor decisions that stabilize reported performance quickly, even if they defer deeper structural fixes
-
-Role prompt intent:
-
-The Plant Manager should think like the person ultimately accountable for the whole system. This role values total profitability, cash protection, and coordination, but is under pressure to show visible improvement and prevent major breakdowns.
 
 #### Production Manager
 
@@ -144,9 +135,8 @@ This initial role set creates a strong core tension:
 - Procurement wants cheaper inputs and larger buys
 - Sales wants more orders and stronger promises
 - Finance wants tighter cost control
-- Plant Management wants the whole system to survive and improve
 
-Future expansions may add roles such as maintenance, engineering, distribution, human resources, or scenario-specific executives. The same design pattern should continue: public responsibilities aligned with the plant, and hidden incentives that tempt players toward local optimization.
+Future expansions may add roles such as Plant Manager, maintenance, engineering, distribution, human resources, or scenario-specific executives. The same design pattern should continue: public responsibilities aligned with the plant, and hidden incentives that tempt players toward local optimization.
 
 ### Core Objective
 
@@ -364,3 +354,4 @@ HerbieGo aims to be both a game and a systems-thinking simulation: a place where
 ## Design Docs
 
 - [MVP Game Design](docs/mvp-game-design.md)
+- [Canonical Domain Model](docs/domain-model.md)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ This initial role set creates a strong core tension:
 
 Future expansions may add roles such as Plant Manager, maintenance, engineering, distribution, human resources, or scenario-specific executives. The same design pattern should continue: public responsibilities aligned with the plant, and hidden incentives that tempt players toward local optimization.
 
+Post-MVP expansions should also deepen shop-floor control. Likely additions include workstation scheduling, batch-size decisions, tooling/setup changes that consume production time, maintenance planning, machine failures, repair duration, and explicit bottleneck-management concepts such as Theory of Constraints, drum-buffer-rope, and planner/scheduler/expeditor responsibilities.
+
 ### Core Objective
 
 The primary victory condition is maximizing the plant's long-term profitability. Players are expected to make decisions that affect:

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -1,0 +1,491 @@
+# Canonical Domain Model
+
+This document is the acceptance target for roadmap issue `#2`: design the shared domain types used by simulation, UI, persistence, and AI-facing prompt assembly before implementation spreads across packages.
+
+The goal is not to lock every field forever. The goal is to lock the vocabulary, record shapes, and boundaries that other packages can safely build around.
+
+## Design Intent
+
+The domain model should:
+
+- give `internal/domain` a stable first surface area
+- keep engine, UI, persistence, and prompts talking about the same things with the same names
+- model the MVP cleanly without blocking post-MVP expansion
+- prefer append-only history and explicit events over implicit state changes
+
+## Naming Rules
+
+These terms are canonical and should be reused consistently in code, prompts, logs, and UI labels.
+
+- A `role` is a player-facing responsibility such as Procurement or Sales.
+- An `actor` is either a player role or the plant system.
+- An `action` is an intent submitted during hidden turn collection.
+- An `event` is a resolved outcome emitted by the plant.
+- `inventory` means on-hand stock owned by the plant.
+- `in_transit_supply` means purchased parts that have been ordered but not yet received.
+- `work_in_progress` means units already released into the route but not yet finished.
+- A `backlog` entry is accepted demand that was not yet shipped.
+- `metrics` are computed operational or financial measurements, not player intents.
+
+## MVP Canonical Roles
+
+The MVP canonical role set is:
+
+- `procurement_manager`
+- `production_manager`
+- `sales_manager`
+- `finance_controller`
+
+The plant is modeled separately as a system actor:
+
+- `plant_system`
+
+`Plant Manager` remains a valid future role idea from the broader vision, but it is not part of the MVP role enum and should not appear in MVP action contracts or AI role assignment.
+
+## Core Scalar And Identifier Types
+
+The first implementation should treat these as small, explicit value types even if they initially compile down to `string` or `int`.
+
+```go
+type MatchID string
+type ScenarioID string
+type RoundNumber int
+
+type RoleID string
+type ActorID string
+
+type ProductID string
+type PartID string
+type CustomerID string
+type SupplierID string
+type WorkstationID string
+type MetricID string
+type EventID string
+type CommentaryID string
+type ActionID string
+
+type Units int
+type Money int
+type CapacityUnits int
+type Percentage int
+```
+
+Recommended enum values:
+
+```go
+const (
+    RoleProcurementManager RoleID = "procurement_manager"
+    RoleProductionManager  RoleID = "production_manager"
+    RoleSalesManager       RoleID = "sales_manager"
+    RoleFinanceController  RoleID = "finance_controller"
+)
+
+const (
+    ActorPlantSystem ActorID = "plant_system"
+)
+```
+
+## Shared Aggregate Types
+
+These are the shared records that other packages should expect to consume or produce.
+
+### Match And Round State
+
+```go
+type MatchState struct {
+    MatchID       MatchID
+    ScenarioID    ScenarioID
+    CurrentRound  RoundNumber
+    Roles         []RoleAssignment
+    Plant         PlantState
+    Customers     []CustomerState
+    ActiveTargets BudgetTargets
+    Metrics       PlantMetrics
+    History       RoundHistory
+}
+```
+
+```go
+type RoleAssignment struct {
+    RoleID    RoleID
+    PlayerID  string
+    IsHuman   bool
+    Provider  string
+    ModelName string
+}
+```
+
+### Plant State
+
+`PlantState` is the canonical simulation snapshot. UI projections and prompts should be derived from this shape rather than inventing their own names.
+
+```go
+type PlantState struct {
+    Cash              Money
+    Debt              Money
+    DebtCeiling       Money
+    PartsInventory    []PartInventory
+    WIPInventory      []WIPInventory
+    FinishedInventory []FinishedInventory
+    InTransitSupply   []SupplyLot
+    Workstations      []WorkstationState
+    Backlog           []BacklogEntry
+}
+```
+
+Inventory concepts are intentionally split by state:
+
+- `PartInventory` for purchased parts available for use
+- `WIPInventory` for released but unfinished units by route stage
+- `FinishedInventory` for shippable completed units
+- `SupplyLot` for ordered parts not yet received
+
+```go
+type PartInventory struct {
+    PartID    PartID
+    OnHandQty Units
+}
+
+type WIPInventory struct {
+    ProductID      ProductID
+    WorkstationID  WorkstationID
+    Quantity       Units
+}
+
+type FinishedInventory struct {
+    ProductID ProductID
+    OnHandQty Units
+}
+
+type SupplyLot struct {
+    PurchaseOrderID string
+    SupplierID      SupplierID
+    PartID          PartID
+    Quantity        Units
+    UnitCost        Money
+    OrderedRound    RoundNumber
+    ArrivalRound    RoundNumber
+}
+
+type WorkstationState struct {
+    WorkstationID    WorkstationID
+    DisplayName      string
+    CapacityPerRound CapacityUnits
+    CapacityUsed     CapacityUnits
+}
+```
+
+### Product, Part, And Customer Records
+
+Static scenario data and dynamic state should use the same identifiers.
+
+```go
+type ProductDefinition struct {
+    ProductID      ProductID
+    DisplayName    string
+    BOM            []BOMLine
+    Route          []WorkstationID
+}
+
+type BOMLine struct {
+    PartID    PartID
+    Quantity  Units
+}
+
+type PartDefinition struct {
+    PartID       PartID
+    DisplayName  string
+    DefaultCost  Money
+}
+
+type CustomerState struct {
+    CustomerID      CustomerID
+    DisplayName     string
+    Sentiment       int
+    Backlog         []BacklogEntry
+}
+```
+
+### Budgets, Targets, And Metrics
+
+Budgets are directives. Metrics are observed outcomes.
+
+```go
+type BudgetTargets struct {
+    EffectiveRound          RoundNumber
+    ProcurementBudget       Money
+    ProductionSpendBudget   Money
+    RevenueTarget           Money
+    CashFloorTarget         Money
+    DebtCeilingTarget       Money
+}
+```
+
+```go
+type PlantMetrics struct {
+    ThroughputRevenue     Money
+    OperatingExpense      Money
+    InventoryValue        Money
+    NetCashChange         Money
+    RoundProfit           Money
+    OnTimeShipmentRate    Percentage
+    BacklogUnits          Units
+    LostSalesUnits        Units
+    PartsOnHandUnits      Units
+    FinishedGoodsUnits    Units
+    ProductionOutputUnits Units
+}
+```
+
+If the implementation needs a generic metric feed for UI panes or prompts, it should project from the typed fields above into:
+
+```go
+type MetricValue struct {
+    MetricID    MetricID
+    Value       int
+    DisplayUnit string
+}
+```
+
+## Action Model
+
+Every player turn submission should use a shared envelope plus a role-specific payload.
+
+```go
+type ActionSubmission struct {
+    ActionID     ActionID
+    MatchID      MatchID
+    Round        RoundNumber
+    RoleID       RoleID
+    SubmittedAt  time.Time
+    Action       RoleAction
+    Commentary   CommentaryRecord
+}
+```
+
+```go
+type RoleAction struct {
+    Procurement *ProcurementAction
+    Production  *ProductionAction
+    Sales       *SalesAction
+    Finance     *FinanceAction
+}
+```
+
+Only the payload matching `RoleID` should be populated.
+
+### Procurement
+
+```go
+type ProcurementAction struct {
+    Orders []PurchaseOrderIntent
+}
+
+type PurchaseOrderIntent struct {
+    PartID    PartID
+    SupplierID SupplierID
+    Quantity  Units
+}
+```
+
+### Production
+
+```go
+type ProductionAction struct {
+    Releases          []ProductionRelease
+    CapacityAllocation []CapacityAllocation
+}
+
+type ProductionRelease struct {
+    ProductID ProductID
+    Quantity  Units
+}
+
+type CapacityAllocation struct {
+    WorkstationID WorkstationID
+    ProductID     ProductID
+    Capacity      CapacityUnits
+}
+```
+
+### Sales
+
+```go
+type SalesAction struct {
+    ProductOffers []ProductOffer
+}
+
+type ProductOffer struct {
+    ProductID  ProductID
+    UnitPrice  Money
+}
+```
+
+### Finance
+
+```go
+type FinanceAction struct {
+    NextRoundTargets BudgetTargets
+}
+```
+
+## Demand, Orders, Supply, And Shipment Records
+
+These records are outcomes the engine owns after actions resolve.
+
+```go
+type CustomerOrder struct {
+    OrderID       string
+    CustomerID    CustomerID
+    ProductID     ProductID
+    OrderedQty    Units
+    ShippedQty    Units
+    UnitPrice     Money
+    OrderedRound  RoundNumber
+}
+
+type BacklogEntry struct {
+    CustomerID     CustomerID
+    ProductID      ProductID
+    Quantity       Units
+    OriginRound    RoundNumber
+    AgeInRounds    int
+}
+
+type ShipmentRecord struct {
+    CustomerID   CustomerID
+    ProductID    ProductID
+    Quantity     Units
+    UnitPrice    Money
+    ShipRound    RoundNumber
+}
+```
+
+## Event And Commentary Model
+
+The event stream is append-only. State snapshots may be persisted for convenience, but history should still be reconstructable from events plus scenario data.
+
+```go
+type RoundRecord struct {
+    Round        RoundNumber
+    Actions      []ActionSubmission
+    Events       []RoundEvent
+    Commentary   []CommentaryRecord
+    Metrics      PlantMetrics
+}
+
+type RoundHistory struct {
+    RecentRounds []RoundRecord
+}
+```
+
+```go
+type CommentaryRecord struct {
+    CommentaryID CommentaryID
+    MatchID      MatchID
+    Round        RoundNumber
+    ActorID      ActorID
+    RoleID       RoleID
+    Visibility   CommentaryVisibility
+    Body         string
+}
+```
+
+```go
+type CommentaryVisibility string
+
+const (
+    CommentaryPublic CommentaryVisibility = "public"
+)
+```
+
+```go
+type RoundEvent struct {
+    EventID     EventID
+    MatchID     MatchID
+    Round       RoundNumber
+    Type        RoundEventType
+    ActorID     ActorID
+    Summary     string
+    Payload     map[string]any
+}
+```
+
+Recommended MVP event types:
+
+```go
+type RoundEventType string
+
+const (
+    EventActionAccepted         RoundEventType = "action_accepted"
+    EventBudgetActivated        RoundEventType = "budget_activated"
+    EventPurchaseOrderPlaced    RoundEventType = "purchase_order_placed"
+    EventSupplyArrived          RoundEventType = "supply_arrived"
+    EventProductionReleased     RoundEventType = "production_released"
+    EventWorkAdvanced           RoundEventType = "work_advanced"
+    EventFinishedGoodsProduced  RoundEventType = "finished_goods_produced"
+    EventDemandRealized         RoundEventType = "demand_realized"
+    EventShipmentCompleted      RoundEventType = "shipment_completed"
+    EventBacklogCreated         RoundEventType = "backlog_created"
+    EventBacklogExpired         RoundEventType = "backlog_expired"
+    EventCustomerSentimentMoved RoundEventType = "customer_sentiment_moved"
+    EventCashChanged            RoundEventType = "cash_changed"
+    EventMetricSnapshot         RoundEventType = "metric_snapshot"
+    EventRuleAdjustment         RoundEventType = "rule_adjustment"
+)
+```
+
+`Payload` should carry machine-readable details specific to the event, but `Type` must stay stable so UI filters, persistence, and prompts are not coupled to prose.
+
+## Round View Contract
+
+Prompt assembly, TUI rendering, and human-input screens should all work from the same round-view contract rather than reading simulation internals directly.
+
+```go
+type RoundView struct {
+    MatchID          MatchID
+    Round            RoundNumber
+    ViewerRoleID     RoleID
+    Plant            PlantState
+    Customers        []CustomerState
+    ActiveTargets    BudgetTargets
+    Metrics          PlantMetrics
+    RecentEvents     []RoundEvent
+    RecentCommentary []CommentaryRecord
+}
+```
+
+This keeps AI prompts and UI panes aligned around the same data slices:
+
+- left pane or role header: `ViewerRoleID`
+- center event log: `RecentEvents` and `RecentCommentary`
+- right metrics pane: `Metrics`
+- action form: role-specific subset of `RoundView`
+
+## Explicit Non-Goals For The First Domain Pass
+
+The first domain model should not try to solve everything at once.
+
+- No generic ECS or highly abstract resource graph
+- No multi-plant network model
+- No supplier-specific lead-time rules in the shared types yet
+- No hidden/private commentary visibility classes until the game actually needs them
+- No provider-specific AI fields in domain records beyond stable role assignment metadata
+
+## Stability Rules
+
+Before adding new types elsewhere, contributors should prefer extending this model or projecting from it.
+
+- Engine code should mutate `PlantState`, emit `RoundEvent`, and calculate `PlantMetrics`.
+- UI code should render `RoundView` and avoid inventing parallel inventory or event names.
+- Persistence should store snapshots and/or event history using these identifiers and record names.
+- Prompt builders should serialize `RoundView`, role descriptors, and recent commentary using the same terminology in this document.
+
+## Acceptance Checklist
+
+Issue `#2` should be considered satisfied when:
+
+- core structs and enums are identifiable from this document before package scaffolding starts
+- the MVP role set is explicit and stable
+- plant state, actions, metrics, events, and commentary use one shared vocabulary
+- engine, UI, persistence, and AI prompt work can all point back to this document as the canonical source

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -469,8 +469,12 @@ The first domain model should not try to solve everything at once.
 - No generic ECS or highly abstract resource graph
 - No multi-plant network model
 - No supplier-specific lead-time rules in the shared types yet
+- No workstation scheduling calendar, batch, setup, maintenance, failure, or repair model in the MVP domain contract yet
+- No TOC-specific bottleneck-control entities such as drum-buffer-rope buffers, planner queues, scheduler states, or expeditor workflows yet
 - No hidden/private commentary visibility classes until the game actually needs them
 - No provider-specific AI fields in domain records beyond stable role assignment metadata
+
+Those concepts are expected post-MVP, but they should be added only when the rules are concrete enough to justify stable shared types.
 
 ## Stability Rules
 

--- a/docs/mvp-game-design.md
+++ b/docs/mvp-game-design.md
@@ -19,6 +19,8 @@ The first playable version intentionally focuses on:
 
 The MVP does not yet try to simulate decades of evolution, deep supplier networks, multiple plants, or networked multiplayer.
 
+The MVP also intentionally keeps shop-floor control simple. It uses fixed per-round workstation capacity rather than explicit scheduling, batch setup logic, tooling-change penalties, maintenance planning, stochastic machine failures, or repair-time simulation.
+
 ## Roles In MVP
 
 The MVP includes four player roles plus plant-owned resolution logic.
@@ -137,11 +139,13 @@ Each customer has:
 
 - finite capacity per round
 - converts purchased parts into fabricated subassemblies
+- no explicit queue sequencing or batch setup logic in MVP
 
 #### Workstation 2: `Assembly`
 
 - finite capacity per round
 - converts fabricated subassemblies into finished goods
+- no explicit queue sequencing or tooling-change penalty in MVP
 
 ### Initial Assumptions
 
@@ -151,6 +155,8 @@ The initial implementation should start with visible scenario constants similar 
 - both products require capacity at both workstations
 - `Pump` and `Valve` can consume different amounts of workstation time
 - each part, product, workstation capacity, and cash amount is represented as an integer
+- workstation time is modeled as a simple capacity pool, not a detailed schedule
+- setup times, batch sizes, tooling changes, planned maintenance, machine failures, and repair duration are deferred
 
 Exact numeric values belong in scenario data, not hard-coded into the rules text.
 
@@ -214,6 +220,7 @@ Rules:
 
 - production cannot consume more parts than exist
 - production cannot use more workstation capacity than exists at either workstation
+- production does not sequence jobs within a round; it only allocates aggregate capacity by workstation and product
 - released units first consume required purchased parts and enter shop floor inventory at `Fabrication`
 - units that complete `Fabrication` move into intermediate work-in-progress before `Assembly`
 - units that complete `Assembly` move into finished goods inventory
@@ -273,6 +280,8 @@ The MVP uses a deliberately compact economic model.
 - every workstation has finite capacity per round
 - each product consumes defined capacity units at each workstation
 - the plant computes the maximum feasible production from capacity and parts availability
+- workstation capacity is assumed to be fully available unless reduced by future scenario rules
+- the MVP does not model changeovers, tooling setup loss, maintenance downtime, failure downtime, or repair duration
 
 ### Demand Rules
 
@@ -440,12 +449,54 @@ The MVP does not yet include:
 - long-term era progression
 - multiple scenarios or plants
 - supplier-specific lead times
-- machine failures and stochastic disruptions
+- detailed workstation scheduling or queue sequencing
+- explicit production batch-size rules
+- tooling or setup changes that reduce available production time
+- machine maintenance planning
+- machine failures and repair-time simulation
+- stochastic disruptions beyond the basic deterministic MVP flow
+- explicit bottleneck-management mechanics such as TOC or drum-buffer-rope
+- dedicated planner, scheduler, or expeditor roles
+- formal bottleneck analysis workflows or bottleneck-shift scenarios
 - separate hidden personal victory conditions
 - maintenance, engineering, HR, or distribution roles
 - quality defects, scrap, or rework
 - save/load persistence
 - a fully fleshed out balancing model
+
+## Post-MVP Operations Expansion
+
+These items are intentionally outside the MVP so the first playable version stays small, deterministic, and easy to implement. They are still important future scope and should shape post-MVP design.
+
+### Shop-Floor Control
+
+Post-MVP simulation should consider:
+
+- workstation-level job sequencing within a round
+- production batch-size decisions and the tradeoff between flow and efficiency
+- tooling or setup changes that consume part of a workstation's available time
+- planner or scheduler decisions that change local efficiency but may hurt global throughput
+
+### Reliability And Asset Behavior
+
+Post-MVP simulation should consider:
+
+- preventive and corrective maintenance decisions
+- machine failures that reduce usable capacity
+- repair duration and recovery lag
+- reliability tradeoffs between short-term output pressure and long-term stability
+
+### Constraint Management And TOC
+
+The MVP starter scenario does not yet create a strong explicit bottleneck-management game. Capacity is limited, but the current scope does not yet include the richer Theory of Constraints mechanics that would make bottleneck control a central source of strategy.
+
+Post-MVP scope should consider:
+
+- clearer bottleneck structures in scenario data
+- bottleneck analysis and identification as a first-class gameplay concern
+- Theory of Constraints concepts such as drum-buffer-rope
+- explicit roles or responsibilities for planner, scheduler, and expeditor work
+- scenarios where the active constraint can shift over time
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
## Summary
- add a canonical domain model document for issue #2
- define shared identifiers, state records, action envelopes, metrics, events, and commentary types
- align the README MVP role roster with the canonical four-role design and link the new doc

## Why
Issue #2 asks for a stable shared vocabulary before implementation spreads into engine, UI, persistence, and AI prompt work. This PR creates that contract so package scaffolding can build against one domain language.

## Impact
- future `internal/domain` scaffolding has a clear starting point
- UI, persistence, and prompt builders can project from the same round/state terminology
- MVP role naming is now consistent across the project docs

## Validation
- docs-only change
- reviewed against the existing MVP design doc and roadmap issue wording

Closes #2