### PR TITLE
Scaffold Go module and project package layout

### DIFF
--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jpconstantineau/HerbieGo
+module github.com/jpconstantineau/herbiego
 
 go 1.26
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jpconstantineau/HerbieGo
+
+go 1.26
+
+toolchain go1.26.2

--- a/internal/README.md
+++ b/internal/README.md
@@ -1,0 +1,13 @@
+# Internal Package Layout
+
+The `internal/` tree mirrors the package boundaries defined in [ADR 0001](../docs/adr/0001-initial-architecture.md).
+
+- `app`: application use cases and orchestration
+- `domain`: canonical game vocabulary and state records
+- `scenario`: immutable scenario definitions and catalogs
+- `engine`: deterministic game rules and round resolution
+- `ports`: capability-oriented interfaces consumed by core packages
+- `projection`: read models derived from canonical state
+- `adapters`: concrete infrastructure implementations
+
+These packages start intentionally small so the first implementation work can grow into stable boundaries rather than accidental ones.

--- a/internal/adapters/ai/doc.go
+++ b/internal/adapters/ai/doc.go
@@ -1,0 +1,2 @@
+// Package ai groups provider-specific AI adapters behind application ports.
+package ai

--- a/internal/adapters/ai/ollama/doc.go
+++ b/internal/adapters/ai/ollama/doc.go
@@ -1,0 +1,2 @@
+// Package ollama will implement the Ollama-backed AI adapter.
+package ollama

--- a/internal/adapters/ai/openrouter/doc.go
+++ b/internal/adapters/ai/openrouter/doc.go
@@ -1,0 +1,2 @@
+// Package openrouter will implement the OpenRouter-backed AI adapter.
+package openrouter

--- a/internal/adapters/doc.go
+++ b/internal/adapters/doc.go
@@ -1,0 +1,2 @@
+// Package adapters holds concrete infrastructure implementations for HerbieGo.
+package adapters

--- a/internal/adapters/persistence/doc.go
+++ b/internal/adapters/persistence/doc.go
@@ -1,0 +1,2 @@
+// Package persistence groups storage adapters behind repository ports.
+package persistence

--- a/internal/adapters/persistence/sqlite/doc.go
+++ b/internal/adapters/persistence/sqlite/doc.go
@@ -1,0 +1,2 @@
+// Package sqlite will implement SQLite-backed persistence adapters.
+package sqlite

--- a/internal/adapters/player/doc.go
+++ b/internal/adapters/player/doc.go
@@ -1,0 +1,2 @@
+// Package player groups player-input adapters behind action source ports.
+package player

--- a/internal/adapters/player/human/doc.go
+++ b/internal/adapters/player/human/doc.go
@@ -1,0 +1,2 @@
+// Package human will bridge interactive human input into application ports.
+package human

--- a/internal/adapters/player/llm/doc.go
+++ b/internal/adapters/player/llm/doc.go
@@ -1,0 +1,2 @@
+// Package llm will translate AI decision contracts into submitted role actions.
+package llm

--- a/internal/adapters/random/doc.go
+++ b/internal/adapters/random/doc.go
@@ -1,0 +1,2 @@
+// Package random groups randomness adapters behind deterministic ports.
+package random

--- a/internal/adapters/random/seeded/doc.go
+++ b/internal/adapters/random/seeded/doc.go
@@ -1,0 +1,2 @@
+// Package seeded will implement seeded pseudo-random sources for deterministic play.
+package seeded

--- a/internal/adapters/tui/doc.go
+++ b/internal/adapters/tui/doc.go
@@ -1,0 +1,2 @@
+// Package tui will host the terminal user interface adapter.
+package tui

--- a/internal/app/doc.go
+++ b/internal/app/doc.go
@@ -1,0 +1,2 @@
+// Package app coordinates use cases across the engine, projections, and ports.
+package app

--- a/internal/domain/doc.go
+++ b/internal/domain/doc.go
@@ -1,0 +1,2 @@
+// Package domain defines the canonical game vocabulary and shared record shapes.
+package domain

--- a/internal/engine/doc.go
+++ b/internal/engine/doc.go
@@ -1,0 +1,2 @@
+// Package engine implements deterministic rules, legality checks, and round resolution.
+package engine

--- a/internal/ports/doc.go
+++ b/internal/ports/doc.go
@@ -1,0 +1,2 @@
+// Package ports defines narrow, capability-oriented interfaces for the application core.
+package ports

--- a/internal/projection/doc.go
+++ b/internal/projection/doc.go
@@ -1,0 +1,2 @@
+// Package projection builds read models from canonical domain state.
+package projection

--- a/internal/scenario/doc.go
+++ b/internal/scenario/doc.go
@@ -1,0 +1,2 @@
+// Package scenario contains immutable scenario definitions and catalogs.
+package scenario


### PR DESCRIPTION
Closes #6.

## Summary
- add the initial Go module for `github.com/jpconstantineau/herbiego`
- pin the project to Go `1.26` with `toolchain go1.26.2`
- scaffold `cmd/herbiego` plus the ADR-defined `internal/` package layout with package docs and an `internal/README.md`
- keep the scaffold doc-only at this stage until each package gets its first concrete implementation

## Verification
- `go test ./...`