### PR TITLE
Add app bootstrap and runtime configuration

### DIFF
--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -8,7 +9,24 @@ import (
 )
 
 func main() {
-	runtime, err := app.BootstrapFromEnv()
+	var (
+		configPath   = flag.String("config", "herbiego.yaml", "path to YAML runtime configuration")
+		humanPlayers = flag.Int("human-players", -1, "override the number of human-controlled roles; use 0 for an AI-only test run")
+		seed         = flag.Uint64("seed", 0, "override the deterministic runtime seed")
+	)
+	flag.Parse()
+
+	options := app.BootstrapOptions{
+		ConfigPath: *configPath,
+	}
+	if *humanPlayers >= 0 {
+		options.HumanPlayersOverride = humanPlayers
+	}
+	if *seed != 0 {
+		options.SeedOverride = seed
+	}
+
+	runtime, err := app.Bootstrap(options)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "bootstrap failed:\n%v\n", err)
 		os.Exit(1)
@@ -16,8 +34,9 @@ func main() {
 
 	fmt.Fprintf(
 		os.Stdout,
-		"HerbieGo runtime initialized (env=%s, seed=%d)\nroles: %v\n",
+		"HerbieGo runtime initialized (env=%s, human_players=%d, seed=%d)\nroles: %v\n",
 		runtime.Config.Environment,
+		runtime.Config.HumanPlayers,
 		runtime.Config.Random.Seed,
 		runtime.RoleSummaries(),
 	)

--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -1,3 +1,24 @@
 package main
 
-func main() {}
+import (
+	"fmt"
+	"os"
+
+	"github.com/jpconstantineau/herbiego/internal/app"
+)
+
+func main() {
+	runtime, err := app.BootstrapFromEnv()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bootstrap failed:\n%v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(
+		os.Stdout,
+		"HerbieGo runtime initialized (env=%s, seed=%d)\nroles: %v\n",
+		runtime.Config.Environment,
+		runtime.Config.Random.Seed,
+		runtime.RoleSummaries(),
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/jpconstantineau/herbiego
 go 1.26
 
 toolchain go1.26.2
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/herbiego.yaml
+++ b/herbiego.yaml
@@ -1,0 +1,17 @@
+environment: local
+random:
+  seed: 1
+human_players: 1
+roles:
+  - role_id: procurement_manager
+    provider: ollama
+    model: llama3.2:3b
+  - role_id: production_manager
+    provider: ollama
+    model: llama3.2:3b
+  - role_id: sales_manager
+    provider: openrouter
+    model: openai/gpt-5-mini
+  - role_id: finance_controller
+    provider: ollama
+    model: llama3.2:3b

--- a/internal/adapters/random/seeded/source.go
+++ b/internal/adapters/random/seeded/source.go
@@ -1,0 +1,25 @@
+package seeded
+
+import randv2 "math/rand/v2"
+
+// Source is a deterministic random source backed by PCG.
+type Source struct {
+	random *randv2.Rand
+}
+
+// New constructs a deterministic random source from a single persisted seed.
+func New(seed uint64) *Source {
+	return &Source{
+		random: randv2.New(randv2.NewPCG(seed, seed^0x9e3779b97f4a7c15)),
+	}
+}
+
+// IntN returns, as an int, a non-negative pseudo-random number in [0,n).
+func (s *Source) IntN(n int) int {
+	return s.random.IntN(n)
+}
+
+// Float64 returns, as a float64, a pseudo-random number in [0.0,1.0).
+func (s *Source) Float64() float64 {
+	return s.random.Float64()
+}

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -4,14 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
+	"gopkg.in/yaml.v3"
 )
 
 const (
+	defaultConfigPath  = "herbiego.yaml"
 	defaultEnvironment = "local"
 	defaultRandomSeed  = uint64(1)
 )
@@ -34,14 +34,16 @@ const (
 
 // Config holds process-level runtime configuration.
 type Config struct {
-	Environment string
-	Random      RandomConfig
-	Roles       map[domain.RoleID]RoleConfig
+	Environment  string                       `yaml:"environment"`
+	Random       RandomConfig                 `yaml:"random"`
+	HumanPlayers int                          `yaml:"human_players"`
+	Roles        map[domain.RoleID]RoleConfig `yaml:"-"`
+	RoleConfigs  []RoleConfigFile             `yaml:"roles"`
 }
 
 // RandomConfig controls deterministic randomness for the process.
 type RandomConfig struct {
-	Seed uint64
+	Seed uint64 `yaml:"seed"`
 }
 
 // RoleConfig defines runtime settings for a single role.
@@ -51,64 +53,88 @@ type RoleConfig struct {
 	Model    string
 }
 
-// LoadConfigFromEnv reads runtime configuration from environment variables.
-func LoadConfigFromEnv() (Config, error) {
+// RoleConfigFile is the editable YAML representation for a role's runtime options.
+type RoleConfigFile struct {
+	RoleID   domain.RoleID `yaml:"role_id"`
+	Provider ProviderName  `yaml:"provider"`
+	Model    string        `yaml:"model"`
+}
+
+// BootstrapOptions controls startup loading behavior.
+type BootstrapOptions struct {
+	ConfigPath           string
+	HumanPlayersOverride *int
+	SeedOverride         *uint64
+}
+
+// LoadConfig reads runtime configuration from a YAML file.
+func LoadConfig(path string) (Config, error) {
+	if strings.TrimSpace(path) == "" {
+		path = defaultConfigPath
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("read config file %q: %w", path, err)
+	}
+
 	cfg := Config{
-		Environment: strings.TrimSpace(os.Getenv("HERBIEGO_ENV")),
+		Environment: defaultEnvironment,
 		Random: RandomConfig{
 			Seed: defaultRandomSeed,
 		},
-		Roles: make(map[domain.RoleID]RoleConfig, len(domain.CanonicalRoles())),
+		HumanPlayers: 1,
 	}
 
-	if cfg.Environment == "" {
-		cfg.Environment = defaultEnvironment
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse config file %q: %w", path, err)
 	}
 
-	var errs []error
-
-	if rawSeed := strings.TrimSpace(os.Getenv("HERBIEGO_RANDOM_SEED")); rawSeed != "" {
-		seed, err := strconv.ParseUint(rawSeed, 10, 64)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("HERBIEGO_RANDOM_SEED must be an unsigned integer: %w", err))
-		} else {
-			cfg.Random.Seed = seed
-		}
-	}
-
-	for _, roleID := range domain.CanonicalRoles() {
-		roleCfg := loadRoleConfig(roleID)
-		cfg.Roles[roleID] = roleCfg
-	}
-
+	cfg.normalize()
 	if err := cfg.Validate(); err != nil {
-		errs = append(errs, err)
-	}
-
-	if len(errs) > 0 {
-		return Config{}, errors.Join(errs...)
+		return Config{}, fmt.Errorf("validate config file %q: %w", path, err)
 	}
 
 	return cfg, nil
 }
 
+// ApplyOverrides applies runtime-only startup overrides after config loading.
+func (c Config) ApplyOverrides(options BootstrapOptions) Config {
+	if options.HumanPlayersOverride != nil {
+		c.HumanPlayers = *options.HumanPlayersOverride
+	}
+
+	if options.SeedOverride != nil {
+		c.Random.Seed = *options.SeedOverride
+	}
+
+	c.normalize()
+	return c
+}
+
 // Validate checks that the configuration is internally consistent.
-func (c Config) Validate() error {
+func (c *Config) Validate() error {
+	c.normalize()
+
 	var errs []error
 
 	if strings.TrimSpace(c.Environment) == "" {
-		errs = append(errs, errors.New("HERBIEGO_ENV must not be empty"))
+		errs = append(errs, errors.New("environment must not be empty"))
 	}
 
 	expectedRoles := domain.CanonicalRoles()
 	if len(c.Roles) != len(expectedRoles) {
-		errs = append(errs, fmt.Errorf("runtime roles must include exactly %d canonical roles", len(expectedRoles)))
+		errs = append(errs, fmt.Errorf("roles must include exactly %d canonical roles", len(expectedRoles)))
+	}
+
+	if c.HumanPlayers < 0 || c.HumanPlayers > len(expectedRoles) {
+		errs = append(errs, fmt.Errorf("human_players must be between 0 and %d", len(expectedRoles)))
 	}
 
 	for _, roleID := range expectedRoles {
 		roleCfg, ok := c.Roles[roleID]
 		if !ok {
-			errs = append(errs, fmt.Errorf("runtime role configuration missing for %s", roleID))
+			errs = append(errs, fmt.Errorf("role configuration missing for %s", roleID))
 			continue
 		}
 
@@ -124,47 +150,67 @@ func (c Config) Validate() error {
 	return errors.Join(errs...)
 }
 
-func loadRoleConfig(roleID domain.RoleID) RoleConfig {
-	prefix := envRolePrefix(roleID)
-
-	rawKind := strings.TrimSpace(os.Getenv(prefix + "_KIND"))
-	if rawKind == "" {
-		rawKind = string(PlayerKindHuman)
+func (c *Config) normalize() {
+	if strings.TrimSpace(c.Environment) == "" {
+		c.Environment = defaultEnvironment
 	}
 
-	roleCfg := RoleConfig{
-		Kind:  PlayerKind(strings.ToLower(rawKind)),
-		Model: strings.TrimSpace(os.Getenv(prefix + "_MODEL")),
+	if c.Random.Seed == 0 {
+		c.Random.Seed = defaultRandomSeed
 	}
 
-	if provider := strings.TrimSpace(os.Getenv(prefix + "_PROVIDER")); provider != "" {
-		roleCfg.Provider = ProviderName(strings.ToLower(provider))
+	if c.HumanPlayers == 0 && len(c.RoleConfigs) == 0 && len(c.Roles) == 0 {
+		c.HumanPlayers = 1
 	}
 
-	return roleCfg
+	if c.Roles == nil {
+		c.Roles = make(map[domain.RoleID]RoleConfig, len(c.RoleConfigs))
+	}
+
+	if len(c.RoleConfigs) > 0 {
+		c.Roles = make(map[domain.RoleID]RoleConfig, len(c.RoleConfigs))
+		for index, roleFile := range c.RoleConfigs {
+			roleID := roleFile.RoleID
+			roleCfg := RoleConfig{
+				Kind:     PlayerKindAI,
+				Provider: ProviderName(strings.ToLower(strings.TrimSpace(string(roleFile.Provider)))),
+				Model:    strings.TrimSpace(roleFile.Model),
+			}
+
+			if index < c.HumanPlayers {
+				roleCfg.Kind = PlayerKindHuman
+			}
+
+			c.Roles[roleID] = roleCfg
+		}
+	}
 }
 
 func validateRoleConfig(roleID domain.RoleID, roleCfg RoleConfig) error {
 	var errs []error
-	prefix := envRolePrefix(roleID)
+
+	if roleCfg.Kind == "" {
+		errs = append(errs, fmt.Errorf("%s kind must not be empty", roleID))
+	}
 
 	switch roleCfg.Kind {
 	case PlayerKindHuman:
-		if roleCfg.Provider != "" {
-			errs = append(errs, fmt.Errorf("%s_PROVIDER must be unset when %s_KIND=%q", prefix, prefix, PlayerKindHuman))
-		}
-		if roleCfg.Model != "" {
-			errs = append(errs, fmt.Errorf("%s_MODEL must be unset when %s_KIND=%q", prefix, prefix, PlayerKindHuman))
-		}
-	case PlayerKindAI:
-		if !slices.Contains([]ProviderName{ProviderOllama, ProviderOpenRouter}, roleCfg.Provider) {
-			errs = append(errs, fmt.Errorf("%s_PROVIDER must be one of %q or %q when %s_KIND=%q", prefix, ProviderOllama, ProviderOpenRouter, prefix, PlayerKindAI))
+		// Human-controlled roles still carry minimal AI mapping so a CLI override can enable AI-only tests.
+		if roleCfg.Provider == "" {
+			errs = append(errs, fmt.Errorf("%s provider must not be empty", roleID))
 		}
 		if roleCfg.Model == "" {
-			errs = append(errs, fmt.Errorf("%s_MODEL is required when %s_KIND=%q", prefix, prefix, PlayerKindAI))
+			errs = append(errs, fmt.Errorf("%s model must not be empty", roleID))
+		}
+	case PlayerKindAI:
+		if roleCfg.Provider == "" {
+			errs = append(errs, fmt.Errorf("%s provider must not be empty", roleID))
+		}
+		if roleCfg.Model == "" {
+			errs = append(errs, fmt.Errorf("%s model must not be empty", roleID))
 		}
 	default:
-		errs = append(errs, fmt.Errorf("%s_KIND must be %q or %q", prefix, PlayerKindHuman, PlayerKindAI))
+		errs = append(errs, fmt.Errorf("%s kind must be %q or %q", roleID, PlayerKindHuman, PlayerKindAI))
 	}
 
 	if len(errs) == 0 {
@@ -172,8 +218,4 @@ func validateRoleConfig(roleID domain.RoleID, roleCfg RoleConfig) error {
 	}
 
 	return errors.Join(errs...)
-}
-
-func envRolePrefix(roleID domain.RoleID) string {
-	return "HERBIEGO_ROLE_" + strings.ToUpper(string(roleID))
 }

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -1,0 +1,179 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+const (
+	defaultEnvironment = "local"
+	defaultRandomSeed  = uint64(1)
+)
+
+// PlayerKind determines how a role is controlled at runtime.
+type PlayerKind string
+
+const (
+	PlayerKindHuman PlayerKind = "human"
+	PlayerKindAI    PlayerKind = "ai"
+)
+
+// ProviderName identifies the model backend used for an AI-controlled role.
+type ProviderName string
+
+const (
+	ProviderOllama     ProviderName = "ollama"
+	ProviderOpenRouter ProviderName = "openrouter"
+)
+
+// Config holds process-level runtime configuration.
+type Config struct {
+	Environment string
+	Random      RandomConfig
+	Roles       map[domain.RoleID]RoleConfig
+}
+
+// RandomConfig controls deterministic randomness for the process.
+type RandomConfig struct {
+	Seed uint64
+}
+
+// RoleConfig defines runtime settings for a single role.
+type RoleConfig struct {
+	Kind     PlayerKind
+	Provider ProviderName
+	Model    string
+}
+
+// LoadConfigFromEnv reads runtime configuration from environment variables.
+func LoadConfigFromEnv() (Config, error) {
+	cfg := Config{
+		Environment: strings.TrimSpace(os.Getenv("HERBIEGO_ENV")),
+		Random: RandomConfig{
+			Seed: defaultRandomSeed,
+		},
+		Roles: make(map[domain.RoleID]RoleConfig, len(domain.CanonicalRoles())),
+	}
+
+	if cfg.Environment == "" {
+		cfg.Environment = defaultEnvironment
+	}
+
+	var errs []error
+
+	if rawSeed := strings.TrimSpace(os.Getenv("HERBIEGO_RANDOM_SEED")); rawSeed != "" {
+		seed, err := strconv.ParseUint(rawSeed, 10, 64)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("HERBIEGO_RANDOM_SEED must be an unsigned integer: %w", err))
+		} else {
+			cfg.Random.Seed = seed
+		}
+	}
+
+	for _, roleID := range domain.CanonicalRoles() {
+		roleCfg := loadRoleConfig(roleID)
+		cfg.Roles[roleID] = roleCfg
+	}
+
+	if err := cfg.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return Config{}, errors.Join(errs...)
+	}
+
+	return cfg, nil
+}
+
+// Validate checks that the configuration is internally consistent.
+func (c Config) Validate() error {
+	var errs []error
+
+	if strings.TrimSpace(c.Environment) == "" {
+		errs = append(errs, errors.New("HERBIEGO_ENV must not be empty"))
+	}
+
+	expectedRoles := domain.CanonicalRoles()
+	if len(c.Roles) != len(expectedRoles) {
+		errs = append(errs, fmt.Errorf("runtime roles must include exactly %d canonical roles", len(expectedRoles)))
+	}
+
+	for _, roleID := range expectedRoles {
+		roleCfg, ok := c.Roles[roleID]
+		if !ok {
+			errs = append(errs, fmt.Errorf("runtime role configuration missing for %s", roleID))
+			continue
+		}
+
+		if err := validateRoleConfig(roleID, roleCfg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errors.Join(errs...)
+}
+
+func loadRoleConfig(roleID domain.RoleID) RoleConfig {
+	prefix := envRolePrefix(roleID)
+
+	rawKind := strings.TrimSpace(os.Getenv(prefix + "_KIND"))
+	if rawKind == "" {
+		rawKind = string(PlayerKindHuman)
+	}
+
+	roleCfg := RoleConfig{
+		Kind:  PlayerKind(strings.ToLower(rawKind)),
+		Model: strings.TrimSpace(os.Getenv(prefix + "_MODEL")),
+	}
+
+	if provider := strings.TrimSpace(os.Getenv(prefix + "_PROVIDER")); provider != "" {
+		roleCfg.Provider = ProviderName(strings.ToLower(provider))
+	}
+
+	return roleCfg
+}
+
+func validateRoleConfig(roleID domain.RoleID, roleCfg RoleConfig) error {
+	var errs []error
+	prefix := envRolePrefix(roleID)
+
+	switch roleCfg.Kind {
+	case PlayerKindHuman:
+		if roleCfg.Provider != "" {
+			errs = append(errs, fmt.Errorf("%s_PROVIDER must be unset when %s_KIND=%q", prefix, prefix, PlayerKindHuman))
+		}
+		if roleCfg.Model != "" {
+			errs = append(errs, fmt.Errorf("%s_MODEL must be unset when %s_KIND=%q", prefix, prefix, PlayerKindHuman))
+		}
+	case PlayerKindAI:
+		if !slices.Contains([]ProviderName{ProviderOllama, ProviderOpenRouter}, roleCfg.Provider) {
+			errs = append(errs, fmt.Errorf("%s_PROVIDER must be one of %q or %q when %s_KIND=%q", prefix, ProviderOllama, ProviderOpenRouter, prefix, PlayerKindAI))
+		}
+		if roleCfg.Model == "" {
+			errs = append(errs, fmt.Errorf("%s_MODEL is required when %s_KIND=%q", prefix, prefix, PlayerKindAI))
+		}
+	default:
+		errs = append(errs, fmt.Errorf("%s_KIND must be %q or %q", prefix, PlayerKindHuman, PlayerKindAI))
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errors.Join(errs...)
+}
+
+func envRolePrefix(roleID domain.RoleID) string {
+	return "HERBIEGO_ROLE_" + strings.ToUpper(string(roleID))
+}

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -16,6 +16,13 @@ const (
 	defaultRandomSeed  = uint64(1)
 )
 
+var preferredHumanRoleOrder = []domain.RoleID{
+	domain.RoleProductionManager,
+	domain.RoleProcurementManager,
+	domain.RoleSalesManager,
+	domain.RoleFinanceController,
+}
+
 // PlayerKind determines how a role is controlled at runtime.
 type PlayerKind string
 
@@ -169,21 +176,37 @@ func (c *Config) normalize() {
 
 	if len(c.RoleConfigs) > 0 {
 		c.Roles = make(map[domain.RoleID]RoleConfig, len(c.RoleConfigs))
-		for index, roleFile := range c.RoleConfigs {
+		for _, roleFile := range c.RoleConfigs {
 			roleID := roleFile.RoleID
-			roleCfg := RoleConfig{
+			c.Roles[roleID] = RoleConfig{
 				Kind:     PlayerKindAI,
 				Provider: ProviderName(strings.ToLower(strings.TrimSpace(string(roleFile.Provider)))),
 				Model:    strings.TrimSpace(roleFile.Model),
 			}
+		}
 
-			if index < c.HumanPlayers {
-				roleCfg.Kind = PlayerKindHuman
+		for _, roleID := range selectedHumanRoles(c.HumanPlayers) {
+			roleCfg, ok := c.Roles[roleID]
+			if !ok {
+				continue
 			}
 
+			roleCfg.Kind = PlayerKindHuman
 			c.Roles[roleID] = roleCfg
 		}
 	}
+}
+
+func selectedHumanRoles(humanPlayers int) []domain.RoleID {
+	if humanPlayers <= 0 {
+		return nil
+	}
+
+	if humanPlayers > len(preferredHumanRoleOrder) {
+		humanPlayers = len(preferredHumanRoleOrder)
+	}
+
+	return preferredHumanRoleOrder[:humanPlayers]
 }
 
 func validateRoleConfig(roleID domain.RoleID, roleCfg RoleConfig) error {

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -47,12 +47,12 @@ roles:
 		t.Fatalf("HumanPlayers = %d, want 1", cfg.HumanPlayers)
 	}
 
-	if cfg.Roles[domain.RoleProcurementManager].Kind != PlayerKindHuman {
-		t.Fatalf("procurement kind = %q, want %q", cfg.Roles[domain.RoleProcurementManager].Kind, PlayerKindHuman)
+	if cfg.Roles[domain.RoleProductionManager].Kind != PlayerKindHuman {
+		t.Fatalf("production kind = %q, want %q", cfg.Roles[domain.RoleProductionManager].Kind, PlayerKindHuman)
 	}
 
-	if cfg.Roles[domain.RoleProductionManager].Kind != PlayerKindAI {
-		t.Fatalf("production kind = %q, want %q", cfg.Roles[domain.RoleProductionManager].Kind, PlayerKindAI)
+	if cfg.Roles[domain.RoleProcurementManager].Kind != PlayerKindAI {
+		t.Fatalf("procurement kind = %q, want %q", cfg.Roles[domain.RoleProcurementManager].Kind, PlayerKindAI)
 	}
 }
 

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+func TestLoadConfigFromEnvDefaults(t *testing.T) {
+	clearConfigEnv(t)
+
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv() error = %v", err)
+	}
+
+	if cfg.Environment != defaultEnvironment {
+		t.Fatalf("Environment = %q, want %q", cfg.Environment, defaultEnvironment)
+	}
+
+	if cfg.Random.Seed != defaultRandomSeed {
+		t.Fatalf("Random.Seed = %d, want %d", cfg.Random.Seed, defaultRandomSeed)
+	}
+
+	for _, roleID := range domain.CanonicalRoles() {
+		roleCfg, ok := cfg.Roles[roleID]
+		if !ok {
+			t.Fatalf("missing role config for %s", roleID)
+		}
+
+		if roleCfg.Kind != PlayerKindHuman {
+			t.Fatalf("role %s kind = %q, want %q", roleID, roleCfg.Kind, PlayerKindHuman)
+		}
+	}
+}
+
+func TestLoadConfigFromEnvAIRoleMapping(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HERBIEGO_ENV", "test")
+	t.Setenv("HERBIEGO_RANDOM_SEED", "42")
+	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_KIND", "ai")
+	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_PROVIDER", "ollama")
+	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_MODEL", "llama3.2:3b")
+
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv() error = %v", err)
+	}
+
+	finance := cfg.Roles[domain.RoleFinanceController]
+	if finance.Kind != PlayerKindAI {
+		t.Fatalf("finance kind = %q, want %q", finance.Kind, PlayerKindAI)
+	}
+
+	if finance.Provider != ProviderOllama {
+		t.Fatalf("finance provider = %q, want %q", finance.Provider, ProviderOllama)
+	}
+
+	if finance.Model != "llama3.2:3b" {
+		t.Fatalf("finance model = %q, want %q", finance.Model, "llama3.2:3b")
+	}
+}
+
+func TestLoadConfigFromEnvReportsValidationErrors(t *testing.T) {
+	clearConfigEnv(t)
+	t.Setenv("HERBIEGO_RANDOM_SEED", "nope")
+	t.Setenv("HERBIEGO_ROLE_SALES_MANAGER_KIND", "bot")
+	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_KIND", "ai")
+	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_PROVIDER", "invalid")
+
+	_, err := LoadConfigFromEnv()
+	if err == nil {
+		t.Fatal("LoadConfigFromEnv() error = nil, want validation error")
+	}
+
+	message := err.Error()
+	for _, want := range []string{
+		"HERBIEGO_RANDOM_SEED must be an unsigned integer",
+		"HERBIEGO_ROLE_SALES_MANAGER_KIND must be \"human\" or \"ai\"",
+		"HERBIEGO_ROLE_FINANCE_CONTROLLER_PROVIDER must be one of",
+		"HERBIEGO_ROLE_FINANCE_CONTROLLER_MODEL is required",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("error %q does not contain %q", message, want)
+		}
+	}
+}
+
+func clearConfigEnv(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("HERBIEGO_ENV", "")
+	t.Setenv("HERBIEGO_RANDOM_SEED", "")
+
+	for _, roleID := range domain.CanonicalRoles() {
+		prefix := envRolePrefix(roleID)
+		t.Setenv(prefix+"_KIND", "")
+		t.Setenv(prefix+"_PROVIDER", "")
+		t.Setenv(prefix+"_MODEL", "")
+	}
+}

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,85 +1,125 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
 )
 
-func TestLoadConfigFromEnvDefaults(t *testing.T) {
-	clearConfigEnv(t)
+func TestLoadConfigDefaultsFromYAML(t *testing.T) {
+	configPath := writeConfigFile(t, `
+environment: local
+random:
+  seed: 7
+human_players: 1
+roles:
+  - role_id: procurement_manager
+    provider: ollama
+    model: llama3.2:3b
+  - role_id: production_manager
+    provider: ollama
+    model: llama3.2:3b
+  - role_id: sales_manager
+    provider: openrouter
+    model: openai/gpt-5-mini
+  - role_id: finance_controller
+    provider: ollama
+    model: llama3.2:3b
+`)
 
-	cfg, err := LoadConfigFromEnv()
+	cfg, err := LoadConfig(configPath)
 	if err != nil {
-		t.Fatalf("LoadConfigFromEnv() error = %v", err)
+		t.Fatalf("LoadConfig() error = %v", err)
 	}
 
-	if cfg.Environment != defaultEnvironment {
-		t.Fatalf("Environment = %q, want %q", cfg.Environment, defaultEnvironment)
+	if cfg.Environment != "local" {
+		t.Fatalf("Environment = %q, want %q", cfg.Environment, "local")
 	}
 
-	if cfg.Random.Seed != defaultRandomSeed {
-		t.Fatalf("Random.Seed = %d, want %d", cfg.Random.Seed, defaultRandomSeed)
+	if cfg.Random.Seed != 7 {
+		t.Fatalf("Random.Seed = %d, want 7", cfg.Random.Seed)
+	}
+
+	if cfg.HumanPlayers != 1 {
+		t.Fatalf("HumanPlayers = %d, want 1", cfg.HumanPlayers)
+	}
+
+	if cfg.Roles[domain.RoleProcurementManager].Kind != PlayerKindHuman {
+		t.Fatalf("procurement kind = %q, want %q", cfg.Roles[domain.RoleProcurementManager].Kind, PlayerKindHuman)
+	}
+
+	if cfg.Roles[domain.RoleProductionManager].Kind != PlayerKindAI {
+		t.Fatalf("production kind = %q, want %q", cfg.Roles[domain.RoleProductionManager].Kind, PlayerKindAI)
+	}
+}
+
+func TestConfigApplyOverridesSupportsAITestMode(t *testing.T) {
+	configPath := writeConfigFile(t, `
+roles:
+  - role_id: procurement_manager
+    provider: ollama
+    model: llama3.2:3b
+  - role_id: production_manager
+    provider: ollama
+    model: llama3.2:3b
+  - role_id: sales_manager
+    provider: openrouter
+    model: openai/gpt-5-mini
+  - role_id: finance_controller
+    provider: ollama
+    model: llama3.2:3b
+`)
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	humanPlayers := 0
+	seed := uint64(42)
+	cfg = cfg.ApplyOverrides(BootstrapOptions{
+		HumanPlayersOverride: &humanPlayers,
+		SeedOverride:         &seed,
+	})
+
+	if cfg.HumanPlayers != 0 {
+		t.Fatalf("HumanPlayers = %d, want 0", cfg.HumanPlayers)
+	}
+
+	if cfg.Random.Seed != 42 {
+		t.Fatalf("Random.Seed = %d, want 42", cfg.Random.Seed)
 	}
 
 	for _, roleID := range domain.CanonicalRoles() {
-		roleCfg, ok := cfg.Roles[roleID]
-		if !ok {
-			t.Fatalf("missing role config for %s", roleID)
-		}
-
-		if roleCfg.Kind != PlayerKindHuman {
-			t.Fatalf("role %s kind = %q, want %q", roleID, roleCfg.Kind, PlayerKindHuman)
+		if cfg.Roles[roleID].Kind != PlayerKindAI {
+			t.Fatalf("role %s kind = %q, want %q", roleID, cfg.Roles[roleID].Kind, PlayerKindAI)
 		}
 	}
 }
 
-func TestLoadConfigFromEnvAIRoleMapping(t *testing.T) {
-	clearConfigEnv(t)
-	t.Setenv("HERBIEGO_ENV", "test")
-	t.Setenv("HERBIEGO_RANDOM_SEED", "42")
-	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_KIND", "ai")
-	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_PROVIDER", "ollama")
-	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_MODEL", "llama3.2:3b")
+func TestLoadConfigReportsValidationErrors(t *testing.T) {
+	configPath := writeConfigFile(t, `
+human_players: 5
+roles:
+  - role_id: procurement_manager
+    provider: ""
+    model: ""
+`)
 
-	cfg, err := LoadConfigFromEnv()
-	if err != nil {
-		t.Fatalf("LoadConfigFromEnv() error = %v", err)
-	}
-
-	finance := cfg.Roles[domain.RoleFinanceController]
-	if finance.Kind != PlayerKindAI {
-		t.Fatalf("finance kind = %q, want %q", finance.Kind, PlayerKindAI)
-	}
-
-	if finance.Provider != ProviderOllama {
-		t.Fatalf("finance provider = %q, want %q", finance.Provider, ProviderOllama)
-	}
-
-	if finance.Model != "llama3.2:3b" {
-		t.Fatalf("finance model = %q, want %q", finance.Model, "llama3.2:3b")
-	}
-}
-
-func TestLoadConfigFromEnvReportsValidationErrors(t *testing.T) {
-	clearConfigEnv(t)
-	t.Setenv("HERBIEGO_RANDOM_SEED", "nope")
-	t.Setenv("HERBIEGO_ROLE_SALES_MANAGER_KIND", "bot")
-	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_KIND", "ai")
-	t.Setenv("HERBIEGO_ROLE_FINANCE_CONTROLLER_PROVIDER", "invalid")
-
-	_, err := LoadConfigFromEnv()
+	_, err := LoadConfig(configPath)
 	if err == nil {
-		t.Fatal("LoadConfigFromEnv() error = nil, want validation error")
+		t.Fatal("LoadConfig() error = nil, want validation error")
 	}
 
 	message := err.Error()
 	for _, want := range []string{
-		"HERBIEGO_RANDOM_SEED must be an unsigned integer",
-		"HERBIEGO_ROLE_SALES_MANAGER_KIND must be \"human\" or \"ai\"",
-		"HERBIEGO_ROLE_FINANCE_CONTROLLER_PROVIDER must be one of",
-		"HERBIEGO_ROLE_FINANCE_CONTROLLER_MODEL is required",
+		"human_players must be between 0 and 4",
+		"roles must include exactly 4 canonical roles",
+		"procurement_manager provider must not be empty",
+		"procurement_manager model must not be empty",
 	} {
 		if !strings.Contains(message, want) {
 			t.Fatalf("error %q does not contain %q", message, want)
@@ -87,16 +127,14 @@ func TestLoadConfigFromEnvReportsValidationErrors(t *testing.T) {
 	}
 }
 
-func clearConfigEnv(t *testing.T) {
+func writeConfigFile(t *testing.T, contents string) string {
 	t.Helper()
 
-	t.Setenv("HERBIEGO_ENV", "")
-	t.Setenv("HERBIEGO_RANDOM_SEED", "")
-
-	for _, roleID := range domain.CanonicalRoles() {
-		prefix := envRolePrefix(roleID)
-		t.Setenv(prefix+"_KIND", "")
-		t.Setenv(prefix+"_PROVIDER", "")
-		t.Setenv(prefix+"_MODEL", "")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "herbiego.yaml")
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(contents)), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
 	}
+
+	return path
 }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -15,13 +15,14 @@ type Runtime struct {
 	Random ports.RandomSource
 }
 
-// BootstrapFromEnv loads runtime configuration and constructs process dependencies.
-func BootstrapFromEnv() (Runtime, error) {
-	cfg, err := LoadConfigFromEnv()
+// Bootstrap loads startup configuration and constructs process dependencies.
+func Bootstrap(options BootstrapOptions) (Runtime, error) {
+	cfg, err := LoadConfig(options.ConfigPath)
 	if err != nil {
 		return Runtime{}, fmt.Errorf("load runtime config: %w", err)
 	}
 
+	cfg = cfg.ApplyOverrides(options)
 	return NewRuntime(cfg)
 }
 
@@ -47,7 +48,7 @@ func (r Runtime) RoleSummaries() []string {
 		}
 
 		summary := fmt.Sprintf("%s=%s", roleID, roleCfg.Kind)
-		if roleCfg.Kind == PlayerKindAI {
+		if roleCfg.Provider != "" || roleCfg.Model != "" {
 			summary = fmt.Sprintf("%s[%s:%s]", summary, roleCfg.Provider, roleCfg.Model)
 		}
 

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+// Runtime contains the process dependencies created during startup.
+type Runtime struct {
+	Config Config
+	Random ports.RandomSource
+}
+
+// BootstrapFromEnv loads runtime configuration and constructs process dependencies.
+func BootstrapFromEnv() (Runtime, error) {
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		return Runtime{}, fmt.Errorf("load runtime config: %w", err)
+	}
+
+	return NewRuntime(cfg)
+}
+
+// NewRuntime validates runtime config and constructs startup dependencies.
+func NewRuntime(cfg Config) (Runtime, error) {
+	if err := cfg.Validate(); err != nil {
+		return Runtime{}, fmt.Errorf("validate runtime config: %w", err)
+	}
+
+	return Runtime{
+		Config: cfg,
+		Random: seeded.New(cfg.Random.Seed),
+	}, nil
+}
+
+// RoleSummaries returns a stable summary of role runtime assignments.
+func (r Runtime) RoleSummaries() []string {
+	summaries := make([]string, 0, len(r.Config.Roles))
+	for _, roleID := range domain.CanonicalRoles() {
+		roleCfg, ok := r.Config.Roles[roleID]
+		if !ok {
+			continue
+		}
+
+		summary := fmt.Sprintf("%s=%s", roleID, roleCfg.Kind)
+		if roleCfg.Kind == PlayerKindAI {
+			summary = fmt.Sprintf("%s[%s:%s]", summary, roleCfg.Provider, roleCfg.Model)
+		}
+
+		summaries = append(summaries, summary)
+	}
+
+	slices.Sort(summaries)
+	return summaries
+}

--- a/internal/domain/roles.go
+++ b/internal/domain/roles.go
@@ -1,0 +1,25 @@
+package domain
+
+import "slices"
+
+// RoleID identifies a playable role in a match.
+type RoleID string
+
+const (
+	RoleProcurementManager RoleID = "procurement_manager"
+	RoleProductionManager  RoleID = "production_manager"
+	RoleSalesManager       RoleID = "sales_manager"
+	RoleFinanceController  RoleID = "finance_controller"
+)
+
+var canonicalRoles = []RoleID{
+	RoleProcurementManager,
+	RoleProductionManager,
+	RoleSalesManager,
+	RoleFinanceController,
+}
+
+// CanonicalRoles returns the MVP role identifiers in stable order.
+func CanonicalRoles() []RoleID {
+	return slices.Clone(canonicalRoles)
+}

--- a/internal/ports/random.go
+++ b/internal/ports/random.go
@@ -1,0 +1,7 @@
+package ports
+
+// RandomSource provides deterministic randomness to the application and engine.
+type RandomSource interface {
+	IntN(n int) int
+	Float64() float64
+}


### PR DESCRIPTION
## Summary
- add runtime bootstrap plumbing in `internal/app` and wire `cmd/herbiego` through it
- load environment-based role runtime config with per-role kind/provider/model validation
- add a seeded `math/rand/v2` adapter plus tests for defaults and config failures

## Verification
- `go test ./...`
- `go run ./cmd/herbiego`

## Clarification Questions
- Should the long-term default local profile stay `human` for every role, or do you want a minimal AI-first local profile once the provider adapters are implemented?
- Do you want provider-level settings like API base URLs and credentials to live in this runtime config layer next, or should that wait until the concrete OpenRouter/Ollama adapters are added?
- For seeded randomness, should the process-level seed here eventually become a per-match persisted seed owned by app/persistence wiring?

Refs #7