### PR TITLE
[codex] Add CI workflow for build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+
+      - name: Verify module downloads
+        run: go mod download
+
+      - name: Check formatting
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "The following files need gofmt:"
+            printf '%s\n' "$unformatted"
+            exit 1
+          fi
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Run staticcheck
+        run: staticcheck ./...
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build packages
+        run: go build ./...


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow that runs on pull requests and pushes to `main`
- validate formatting, module download, vet, staticcheck, tests, and build in separate steps for easier diagnosis
- use the Go toolchain declared in `go.mod` so CI matches the repository's Go 1.26 baseline

## Why
This repository did not yet have automated validation for incoming changes. Adding CI now gives fast feedback on formatting, correctness, and build health without introducing a second source of truth for the Go version.

## Validation
- `gofmt -l .`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./...`
- `go build ./...`

## Clarification Questions
- Should we eventually expand CI to an OS matrix as well, or is `ubuntu-latest` the intended scope for now?
- Once tooling setup lands more broadly, would you prefer `staticcheck` to be pinned in repo-managed tool dependencies instead of installed at `@latest` in CI?

Closes #9