### PR TITLE
[codex] Document local development workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to HerbieGo
+
+This guide covers the current local development workflow for HerbieGo.
+
+## Prerequisites
+
+- Go `1.26.2` or newer
+- Git
+
+The repository tracks its preferred toolchain in [go.mod](go.mod), so a recent Go install can automatically select the pinned toolchain version.
+
+## First-time setup
+
+1. Clone the repository.
+2. Download module dependencies:
+
+   ```bash
+   go mod download
+   ```
+
+3. Review the checked-in runtime config in [herbiego.yaml](herbiego.yaml).
+
+## Run the app
+
+Start the current bootstrap executable with:
+
+```bash
+go run ./cmd/herbiego
+```
+
+Useful flags:
+
+- `-config` selects a YAML config file. The default is `herbiego.yaml`.
+- `-human-players` overrides how many canonical roles are human-controlled. Use `0` to force an AI-only test run.
+- `-seed` overrides the deterministic random seed for a run.
+
+Example:
+
+```bash
+go run ./cmd/herbiego -config herbiego.yaml -human-players 0 -seed 42
+```
+
+The current executable validates runtime configuration and prints the initialized role summary. The full TUI gameplay loop has not landed yet, so a successful local run is currently a bootstrap check rather than an interactive match.
+
+## Test and validate changes
+
+Run the contributor quality suite with:
+
+```bash
+go run ./cmd/quality
+```
+
+That command runs:
+
+- `gofmt -w` on repository Go files
+- `go test ./...`
+- `go tool staticcheck ./...`
+
+When you only want verification without rewriting files, run:
+
+```bash
+go run ./cmd/quality verify
+```
+
+You can also run one task at a time while iterating:
+
+```bash
+go run ./cmd/quality fmt
+go run ./cmd/quality test
+go run ./cmd/quality lint
+```
+
+CI also runs `go vet ./...` and `go build ./...`, so those are useful extra checks before opening a PR.
+
+## Environment variables
+
+HerbieGo does not currently require any environment variables for local bootstrap, tests, or the quality workflow.
+
+Today, runtime provider selection is driven by YAML configuration, not by environment-variable switches inside the application. If future provider adapters add credential requirements, document those alongside the adapter implementation before relying on them in contributor workflows.
+
+## How AI providers are configured
+
+AI role configuration lives in [herbiego.yaml](herbiego.yaml).
+
+Each entry under `roles` configures one canonical role with:
+
+- `role_id`: the role being configured
+- `provider`: the AI backend name, currently `ollama` or `openrouter`
+- `model`: the model identifier to use for that role
+
+Example:
+
+```yaml
+roles:
+  - role_id: sales_manager
+    provider: openrouter
+    model: openai/gpt-5-mini
+```
+
+`human_players` determines which roles stay human-controlled during startup. The application assigns human control in a fixed order and keeps provider/model values on every role so contributors can switch to AI-only runs with a CLI override instead of rewriting config.
+
+At the moment, the provider adapter packages are still placeholders, so the YAML file mainly captures intended runtime wiring and validation rules rather than a fully implemented remote-provider session.

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ HerbieGo aims to be both a game and a systems-thinking simulation: a place where
 - [MVP Game Design](docs/mvp-game-design.md)
 - [Canonical Domain Model](docs/domain-model.md)
 - [Architecture Decision Records](docs/adr/README.md)
+- [Contributor Guide](CONTRIBUTING.md)
 
 ## Contributor Quality Checks
 


### PR DESCRIPTION
## Summary
- add a root `CONTRIBUTING.md` with the current local development workflow
- document how to run the bootstrap app, how to run checks, and where runtime provider configuration lives
- link the contributor guide from `README.md`

## Why
Issue #10 asks for contributor-facing documentation that makes it possible to run and work on the project without reading source first. The repo already had design docs and quality-check notes, but it did not yet have one concise setup guide covering run/test/configuration expectations.

## Notes
- the current app does not require any environment variables for bootstrap, tests, or `cmd/quality`
- provider selection is currently configured in `herbiego.yaml`
- the Ollama/OpenRouter adapter packages are still placeholders, so the guide documents the current state rather than future credential wiring

## Validation
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go run ./cmd/quality verify` currently fails on the existing `main` baseline because many pre-existing Go files are already reported by `gofmt -l`; this PR does not change those files

## Clarification Questions
1. Once the provider adapters are implemented, do you want provider-specific credential environment variables documented in `CONTRIBUTING.md`, or should that live in a separate runtime configuration guide?
2. Do you want the contributor workflow to stay in `CONTRIBUTING.md`, or should a condensed version also move higher into `README.md` after the gameplay loop becomes interactive?

Fixes #10