### PR TITLE
Implement canonical game state store

### DIFF
--- a/internal/adapters/persistence/memory/doc.go
+++ b/internal/adapters/persistence/memory/doc.go
@@ -1,0 +1,2 @@
+// Package memory provides an in-memory canonical match state store.
+package memory

--- a/internal/adapters/persistence/memory/store.go
+++ b/internal/adapters/persistence/memory/store.go
@@ -12,6 +12,7 @@ import (
 var ErrMatchNotFound = errors.New("memory store: match not found")
 
 type Options struct {
+	// RecentHistoryLimit bounds MatchState.History without trimming the full event or commentary timeline.
 	RecentHistoryLimit int
 }
 
@@ -144,6 +145,7 @@ func (s *Store) EventTimeline(matchID domain.MatchID) ([]domain.RoundEvent, erro
 	return cloneEvents(match.events), nil
 }
 
+// Commentary returns the full append-only public commentary timeline for the match.
 func (s *Store) Commentary(matchID domain.MatchID) ([]domain.CommentaryRecord, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/adapters/persistence/memory/store.go
+++ b/internal/adapters/persistence/memory/store.go
@@ -1,0 +1,217 @@
+package memory
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+var ErrMatchNotFound = errors.New("memory store: match not found")
+
+type Options struct {
+	RecentHistoryLimit int
+}
+
+type Store struct {
+	mu           sync.RWMutex
+	historyLimit int
+	matches      map[domain.MatchID]storedMatch
+}
+
+type storedMatch struct {
+	state      domain.MatchState
+	rounds     []domain.RoundRecord
+	events     []domain.RoundEvent
+	commentary []domain.CommentaryRecord
+}
+
+func NewStore(options Options) *Store {
+	return &Store{
+		historyLimit: normalizedHistoryLimit(options.RecentHistoryLimit),
+		matches:      make(map[domain.MatchID]storedMatch),
+	}
+}
+
+func (s *Store) CreateMatch(initial domain.MatchState) error {
+	if initial.MatchID == "" {
+		return errors.New("memory store: match id must not be empty")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.matches[initial.MatchID]; exists {
+		return fmt.Errorf("memory store: match %q already exists", initial.MatchID)
+	}
+
+	state := initial.Clone()
+	history := state.History.Recent(s.historyLimit)
+	rounds := history.RecentRounds
+	state.History = history
+
+	s.matches[initial.MatchID] = storedMatch{
+		state:      state,
+		rounds:     cloneRoundRecords(rounds),
+		events:     flattenEvents(rounds),
+		commentary: flattenCommentary(rounds),
+	}
+
+	return nil
+}
+
+func (s *Store) CurrentState(matchID domain.MatchID) (domain.MatchState, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	match, ok := s.matches[matchID]
+	if !ok {
+		return domain.MatchState{}, ErrMatchNotFound
+	}
+
+	return match.state.Clone(), nil
+}
+
+func (s *Store) CommitRound(matchID domain.MatchID, nextState domain.MatchState, round domain.RoundRecord) (domain.MatchState, error) {
+	if matchID == "" {
+		return domain.MatchState{}, errors.New("memory store: match id must not be empty")
+	}
+	if nextState.MatchID != matchID {
+		return domain.MatchState{}, fmt.Errorf("memory store: next state match id %q does not match %q", nextState.MatchID, matchID)
+	}
+	if round.Round <= 0 {
+		return domain.MatchState{}, fmt.Errorf("memory store: round %d must be positive", round.Round)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	match, ok := s.matches[matchID]
+	if !ok {
+		return domain.MatchState{}, ErrMatchNotFound
+	}
+
+	if len(match.rounds) > 0 {
+		last := match.rounds[len(match.rounds)-1].Round
+		if round.Round <= last {
+			return domain.MatchState{}, fmt.Errorf("memory store: round %d must be greater than last committed round %d", round.Round, last)
+		}
+	}
+
+	committedRound := round.Clone()
+	match.rounds = append(match.rounds, committedRound)
+	match.events = append(match.events, flattenEvents([]domain.RoundRecord{committedRound})...)
+	match.commentary = append(match.commentary, flattenCommentary([]domain.RoundRecord{committedRound})...)
+
+	match.state = nextState.Clone()
+	match.state.History = domain.RoundHistory{
+		RecentRounds: cloneRoundRecords(tail(match.rounds, s.historyLimit)),
+	}
+
+	s.matches[matchID] = match
+	return match.state.Clone(), nil
+}
+
+func (s *Store) Round(matchID domain.MatchID, roundNumber domain.RoundNumber) (domain.RoundRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	match, ok := s.matches[matchID]
+	if !ok {
+		return domain.RoundRecord{}, ErrMatchNotFound
+	}
+
+	for _, round := range match.rounds {
+		if round.Round == roundNumber {
+			return round.Clone(), nil
+		}
+	}
+
+	return domain.RoundRecord{}, fmt.Errorf("memory store: round %d not found", roundNumber)
+}
+
+func (s *Store) EventTimeline(matchID domain.MatchID) ([]domain.RoundEvent, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	match, ok := s.matches[matchID]
+	if !ok {
+		return nil, ErrMatchNotFound
+	}
+
+	return cloneEvents(match.events), nil
+}
+
+func (s *Store) Commentary(matchID domain.MatchID) ([]domain.CommentaryRecord, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	match, ok := s.matches[matchID]
+	if !ok {
+		return nil, ErrMatchNotFound
+	}
+
+	return slices.Clone(match.commentary), nil
+}
+
+func normalizedHistoryLimit(limit int) int {
+	if limit <= 0 {
+		return 10
+	}
+
+	return limit
+}
+
+func cloneRoundRecords(rounds []domain.RoundRecord) []domain.RoundRecord {
+	if rounds == nil {
+		return nil
+	}
+
+	cloned := make([]domain.RoundRecord, len(rounds))
+	for i := range rounds {
+		cloned[i] = rounds[i].Clone()
+	}
+
+	return cloned
+}
+
+func cloneEvents(events []domain.RoundEvent) []domain.RoundEvent {
+	if events == nil {
+		return nil
+	}
+
+	cloned := make([]domain.RoundEvent, len(events))
+	for i := range events {
+		cloned[i] = events[i].Clone()
+	}
+
+	return cloned
+}
+
+func flattenEvents(rounds []domain.RoundRecord) []domain.RoundEvent {
+	var events []domain.RoundEvent
+	for _, round := range rounds {
+		events = append(events, cloneEvents(round.Events)...)
+	}
+
+	return events
+}
+
+func flattenCommentary(rounds []domain.RoundRecord) []domain.CommentaryRecord {
+	var commentary []domain.CommentaryRecord
+	for _, round := range rounds {
+		commentary = append(commentary, slices.Clone(round.Commentary)...)
+	}
+
+	return commentary
+}
+
+func tail[T any](items []T, limit int) []T {
+	if limit <= 0 || len(items) <= limit {
+		return items
+	}
+
+	return items[len(items)-limit:]
+}

--- a/internal/adapters/persistence/memory/store_test.go
+++ b/internal/adapters/persistence/memory/store_test.go
@@ -1,0 +1,156 @@
+package memory_test
+
+import (
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/adapters/persistence/memory"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+func TestStoreCommitRoundExposesCurrentStateAndTimelines(t *testing.T) {
+	store := memory.NewStore(memory.Options{RecentHistoryLimit: 2})
+	initial := domain.MatchState{
+		MatchID:      "match-1",
+		ScenarioID:   "starter",
+		CurrentRound: 1,
+	}
+
+	if err := store.CreateMatch(initial); err != nil {
+		t.Fatalf("CreateMatch() error = %v", err)
+	}
+
+	round := domain.RoundRecord{
+		Round: 1,
+		Events: []domain.RoundEvent{
+			{
+				EventID: "event-1",
+				MatchID: "match-1",
+				Round:   1,
+				Type:    domain.EventBudgetActivated,
+				ActorID: domain.ActorPlantSystem,
+				Summary: "Activated round targets",
+				Payload: map[string]any{"budget": 10},
+			},
+		},
+		Commentary: []domain.CommentaryRecord{
+			{
+				CommentaryID: "comment-1",
+				MatchID:      "match-1",
+				Round:        1,
+				ActorID:      domain.ActorPlantSystem,
+				RoleID:       domain.RoleFinanceController,
+				Visibility:   domain.CommentaryPublic,
+				Body:         "Finance targets are now active.",
+			},
+		},
+	}
+	nextState := domain.MatchState{
+		MatchID:      "match-1",
+		ScenarioID:   "starter",
+		CurrentRound: 2,
+		Plant: domain.PlantState{
+			Cash: 25,
+		},
+	}
+
+	state, err := store.CommitRound(initial.MatchID, nextState, round)
+	if err != nil {
+		t.Fatalf("CommitRound() error = %v", err)
+	}
+
+	if state.CurrentRound != 2 {
+		t.Fatalf("CurrentRound = %d, want 2", state.CurrentRound)
+	}
+	if len(state.History.RecentRounds) != 1 {
+		t.Fatalf("History len = %d, want 1", len(state.History.RecentRounds))
+	}
+	if state.History.RecentRounds[0].Round != 1 {
+		t.Fatalf("History round = %d, want 1", state.History.RecentRounds[0].Round)
+	}
+
+	storedRound, err := store.Round(initial.MatchID, 1)
+	if err != nil {
+		t.Fatalf("Round() error = %v", err)
+	}
+	if len(storedRound.Events) != 1 {
+		t.Fatalf("stored events len = %d, want 1", len(storedRound.Events))
+	}
+
+	timeline, err := store.EventTimeline(initial.MatchID)
+	if err != nil {
+		t.Fatalf("EventTimeline() error = %v", err)
+	}
+	if len(timeline) != 1 {
+		t.Fatalf("timeline len = %d, want 1", len(timeline))
+	}
+	if got := timeline[0].Payload["budget"]; got != 10 {
+		t.Fatalf("timeline payload budget = %v, want 10", got)
+	}
+
+	commentary, err := store.Commentary(initial.MatchID)
+	if err != nil {
+		t.Fatalf("Commentary() error = %v", err)
+	}
+	if len(commentary) != 1 {
+		t.Fatalf("commentary len = %d, want 1", len(commentary))
+	}
+}
+
+func TestStoreTrimsCurrentHistoryWindowButKeepsAppendOnlyTimeline(t *testing.T) {
+	store := memory.NewStore(memory.Options{RecentHistoryLimit: 2})
+	initial := domain.MatchState{
+		MatchID:      "match-1",
+		ScenarioID:   "starter",
+		CurrentRound: 1,
+	}
+
+	if err := store.CreateMatch(initial); err != nil {
+		t.Fatalf("CreateMatch() error = %v", err)
+	}
+
+	for round := range 3 {
+		roundNumber := domain.RoundNumber(round + 1)
+		_, err := store.CommitRound(initial.MatchID, domain.MatchState{
+			MatchID:      initial.MatchID,
+			ScenarioID:   initial.ScenarioID,
+			CurrentRound: roundNumber + 1,
+		}, domain.RoundRecord{
+			Round: roundNumber,
+			Events: []domain.RoundEvent{
+				{
+					EventID: domain.EventID("event-" + string(rune('1'+round))),
+					MatchID: initial.MatchID,
+					Round:   roundNumber,
+					Type:    domain.EventMetricSnapshot,
+					ActorID: domain.ActorPlantSystem,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CommitRound(%d) error = %v", roundNumber, err)
+		}
+	}
+
+	state, err := store.CurrentState(initial.MatchID)
+	if err != nil {
+		t.Fatalf("CurrentState() error = %v", err)
+	}
+
+	if len(state.History.RecentRounds) != 2 {
+		t.Fatalf("History len = %d, want 2", len(state.History.RecentRounds))
+	}
+	if state.History.RecentRounds[0].Round != 2 || state.History.RecentRounds[1].Round != 3 {
+		t.Fatalf("History rounds = %#v, want [2 3]", []domain.RoundNumber{
+			state.History.RecentRounds[0].Round,
+			state.History.RecentRounds[1].Round,
+		})
+	}
+
+	timeline, err := store.EventTimeline(initial.MatchID)
+	if err != nil {
+		t.Fatalf("EventTimeline() error = %v", err)
+	}
+	if len(timeline) != 3 {
+		t.Fatalf("timeline len = %d, want 3", len(timeline))
+	}
+}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -29,6 +29,7 @@ type Percentage int
 
 const ActorPlantSystem ActorID = "plant_system"
 
+// MatchState is the canonical in-memory snapshot for the round currently being collected.
 type MatchState struct {
 	MatchID       MatchID
 	ScenarioID    ScenarioID
@@ -254,6 +255,7 @@ type CommentaryRecord struct {
 
 type CommentaryVisibility string
 
+// CommentaryPublic is the only MVP visibility class; all stored commentary is public after reveal.
 const CommentaryPublic CommentaryVisibility = "public"
 
 type RoundEvent struct {

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -1,0 +1,482 @@
+package domain
+
+import (
+	"maps"
+	"slices"
+	"time"
+)
+
+type MatchID string
+type ScenarioID string
+type RoundNumber int
+
+type ActorID string
+
+type ProductID string
+type PartID string
+type CustomerID string
+type SupplierID string
+type WorkstationID string
+type MetricID string
+type EventID string
+type CommentaryID string
+type ActionID string
+
+type Units int
+type Money int
+type CapacityUnits int
+type Percentage int
+
+const ActorPlantSystem ActorID = "plant_system"
+
+type MatchState struct {
+	MatchID       MatchID
+	ScenarioID    ScenarioID
+	CurrentRound  RoundNumber
+	Roles         []RoleAssignment
+	Plant         PlantState
+	Customers     []CustomerState
+	ActiveTargets BudgetTargets
+	Metrics       PlantMetrics
+	History       RoundHistory
+}
+
+type RoleAssignment struct {
+	RoleID    RoleID
+	PlayerID  string
+	IsHuman   bool
+	Provider  string
+	ModelName string
+}
+
+type PlantState struct {
+	Cash              Money
+	Debt              Money
+	DebtCeiling       Money
+	PartsInventory    []PartInventory
+	WIPInventory      []WIPInventory
+	FinishedInventory []FinishedInventory
+	InTransitSupply   []SupplyLot
+	Workstations      []WorkstationState
+	Backlog           []BacklogEntry
+}
+
+type PartInventory struct {
+	PartID    PartID
+	OnHandQty Units
+}
+
+type WIPInventory struct {
+	ProductID     ProductID
+	WorkstationID WorkstationID
+	Quantity      Units
+}
+
+type FinishedInventory struct {
+	ProductID ProductID
+	OnHandQty Units
+}
+
+type SupplyLot struct {
+	PurchaseOrderID string
+	SupplierID      SupplierID
+	PartID          PartID
+	Quantity        Units
+	UnitCost        Money
+	OrderedRound    RoundNumber
+	ArrivalRound    RoundNumber
+}
+
+type WorkstationState struct {
+	WorkstationID    WorkstationID
+	DisplayName      string
+	CapacityPerRound CapacityUnits
+	CapacityUsed     CapacityUnits
+}
+
+type ProductDefinition struct {
+	ProductID   ProductID
+	DisplayName string
+	BOM         []BOMLine
+	Route       []WorkstationID
+}
+
+type BOMLine struct {
+	PartID   PartID
+	Quantity Units
+}
+
+type PartDefinition struct {
+	PartID      PartID
+	DisplayName string
+	DefaultCost Money
+}
+
+type CustomerState struct {
+	CustomerID  CustomerID
+	DisplayName string
+	Sentiment   int
+	Backlog     []BacklogEntry
+}
+
+type BudgetTargets struct {
+	EffectiveRound        RoundNumber
+	ProcurementBudget     Money
+	ProductionSpendBudget Money
+	RevenueTarget         Money
+	CashFloorTarget       Money
+	DebtCeilingTarget     Money
+}
+
+type PlantMetrics struct {
+	ThroughputRevenue     Money
+	OperatingExpense      Money
+	InventoryValue        Money
+	NetCashChange         Money
+	RoundProfit           Money
+	OnTimeShipmentRate    Percentage
+	BacklogUnits          Units
+	LostSalesUnits        Units
+	PartsOnHandUnits      Units
+	FinishedGoodsUnits    Units
+	ProductionOutputUnits Units
+}
+
+type MetricValue struct {
+	MetricID    MetricID
+	Value       int
+	DisplayUnit string
+}
+
+type ActionSubmission struct {
+	ActionID    ActionID
+	MatchID     MatchID
+	Round       RoundNumber
+	RoleID      RoleID
+	SubmittedAt time.Time
+	Action      RoleAction
+	Commentary  CommentaryRecord
+}
+
+type RoleAction struct {
+	Procurement *ProcurementAction
+	Production  *ProductionAction
+	Sales       *SalesAction
+	Finance     *FinanceAction
+}
+
+type ProcurementAction struct {
+	Orders []PurchaseOrderIntent
+}
+
+type PurchaseOrderIntent struct {
+	PartID     PartID
+	SupplierID SupplierID
+	Quantity   Units
+}
+
+type ProductionAction struct {
+	Releases           []ProductionRelease
+	CapacityAllocation []CapacityAllocation
+}
+
+type ProductionRelease struct {
+	ProductID ProductID
+	Quantity  Units
+}
+
+type CapacityAllocation struct {
+	WorkstationID WorkstationID
+	ProductID     ProductID
+	Capacity      CapacityUnits
+}
+
+type SalesAction struct {
+	ProductOffers []ProductOffer
+}
+
+type ProductOffer struct {
+	ProductID ProductID
+	UnitPrice Money
+}
+
+type FinanceAction struct {
+	NextRoundTargets BudgetTargets
+}
+
+type CustomerOrder struct {
+	OrderID      string
+	CustomerID   CustomerID
+	ProductID    ProductID
+	OrderedQty   Units
+	ShippedQty   Units
+	UnitPrice    Money
+	OrderedRound RoundNumber
+}
+
+type BacklogEntry struct {
+	CustomerID  CustomerID
+	ProductID   ProductID
+	Quantity    Units
+	OriginRound RoundNumber
+	AgeInRounds int
+}
+
+type ShipmentRecord struct {
+	CustomerID CustomerID
+	ProductID  ProductID
+	Quantity   Units
+	UnitPrice  Money
+	ShipRound  RoundNumber
+}
+
+type RoundRecord struct {
+	Round      RoundNumber
+	Actions    []ActionSubmission
+	Events     []RoundEvent
+	Commentary []CommentaryRecord
+	Metrics    PlantMetrics
+}
+
+type RoundHistory struct {
+	RecentRounds []RoundRecord
+}
+
+type CommentaryRecord struct {
+	CommentaryID CommentaryID
+	MatchID      MatchID
+	Round        RoundNumber
+	ActorID      ActorID
+	RoleID       RoleID
+	Visibility   CommentaryVisibility
+	Body         string
+}
+
+type CommentaryVisibility string
+
+const CommentaryPublic CommentaryVisibility = "public"
+
+type RoundEvent struct {
+	EventID EventID
+	MatchID MatchID
+	Round   RoundNumber
+	Type    RoundEventType
+	ActorID ActorID
+	Summary string
+	Payload map[string]any
+}
+
+type RoundEventType string
+
+const (
+	EventBudgetActivated        RoundEventType = "budget_activated"
+	EventPurchaseOrderPlaced    RoundEventType = "purchase_order_placed"
+	EventSupplyArrived          RoundEventType = "supply_arrived"
+	EventProductionReleased     RoundEventType = "production_released"
+	EventWorkAdvanced           RoundEventType = "work_advanced"
+	EventFinishedGoodsProduced  RoundEventType = "finished_goods_produced"
+	EventDemandRealized         RoundEventType = "demand_realized"
+	EventShipmentCompleted      RoundEventType = "shipment_completed"
+	EventBacklogCreated         RoundEventType = "backlog_created"
+	EventBacklogExpired         RoundEventType = "backlog_expired"
+	EventCustomerSentimentMoved RoundEventType = "customer_sentiment_moved"
+	EventCashChanged            RoundEventType = "cash_changed"
+	EventMetricSnapshot         RoundEventType = "metric_snapshot"
+	EventRuleAdjustment         RoundEventType = "rule_adjustment"
+)
+
+type RoundView struct {
+	MatchID          MatchID
+	Round            RoundNumber
+	ViewerRoleID     RoleID
+	Plant            PlantState
+	Customers        []CustomerState
+	ActiveTargets    BudgetTargets
+	Metrics          PlantMetrics
+	RecentEvents     []RoundEvent
+	RecentCommentary []CommentaryRecord
+}
+
+func (s MatchState) Clone() MatchState {
+	return MatchState{
+		MatchID:       s.MatchID,
+		ScenarioID:    s.ScenarioID,
+		CurrentRound:  s.CurrentRound,
+		Roles:         slices.Clone(s.Roles),
+		Plant:         s.Plant.Clone(),
+		Customers:     cloneSlice(s.Customers, CustomerState.Clone),
+		ActiveTargets: s.ActiveTargets,
+		Metrics:       s.Metrics,
+		History:       s.History.Clone(),
+	}
+}
+
+func (s PlantState) Clone() PlantState {
+	return PlantState{
+		Cash:              s.Cash,
+		Debt:              s.Debt,
+		DebtCeiling:       s.DebtCeiling,
+		PartsInventory:    slices.Clone(s.PartsInventory),
+		WIPInventory:      slices.Clone(s.WIPInventory),
+		FinishedInventory: slices.Clone(s.FinishedInventory),
+		InTransitSupply:   slices.Clone(s.InTransitSupply),
+		Workstations:      slices.Clone(s.Workstations),
+		Backlog:           slices.Clone(s.Backlog),
+	}
+}
+
+func (s CustomerState) Clone() CustomerState {
+	return CustomerState{
+		CustomerID:  s.CustomerID,
+		DisplayName: s.DisplayName,
+		Sentiment:   s.Sentiment,
+		Backlog:     slices.Clone(s.Backlog),
+	}
+}
+
+func (h RoundHistory) Clone() RoundHistory {
+	return RoundHistory{
+		RecentRounds: cloneSlice(h.RecentRounds, RoundRecord.Clone),
+	}
+}
+
+func (h RoundHistory) Recent(limit int) RoundHistory {
+	if limit <= 0 || len(h.RecentRounds) <= limit {
+		return h.Clone()
+	}
+
+	start := len(h.RecentRounds) - limit
+	return RoundHistory{
+		RecentRounds: cloneSlice(h.RecentRounds[start:], RoundRecord.Clone),
+	}
+}
+
+func (r RoundRecord) Clone() RoundRecord {
+	return RoundRecord{
+		Round:      r.Round,
+		Actions:    cloneSlice(r.Actions, ActionSubmission.Clone),
+		Events:     cloneSlice(r.Events, RoundEvent.Clone),
+		Commentary: cloneSlice(r.Commentary, CommentaryRecord.Clone),
+		Metrics:    r.Metrics,
+	}
+}
+
+func (s ActionSubmission) Clone() ActionSubmission {
+	return ActionSubmission{
+		ActionID:    s.ActionID,
+		MatchID:     s.MatchID,
+		Round:       s.Round,
+		RoleID:      s.RoleID,
+		SubmittedAt: s.SubmittedAt,
+		Action:      s.Action.Clone(),
+		Commentary:  s.Commentary.Clone(),
+	}
+}
+
+func (a RoleAction) Clone() RoleAction {
+	return RoleAction{
+		Procurement: clonePtr(a.Procurement, ProcurementAction.Clone),
+		Production:  clonePtr(a.Production, ProductionAction.Clone),
+		Sales:       clonePtr(a.Sales, SalesAction.Clone),
+		Finance:     clonePtr(a.Finance, FinanceAction.Clone),
+	}
+}
+
+func (a ProcurementAction) Clone() ProcurementAction {
+	return ProcurementAction{Orders: slices.Clone(a.Orders)}
+}
+
+func (a ProductionAction) Clone() ProductionAction {
+	return ProductionAction{
+		Releases:           slices.Clone(a.Releases),
+		CapacityAllocation: slices.Clone(a.CapacityAllocation),
+	}
+}
+
+func (a SalesAction) Clone() SalesAction {
+	return SalesAction{ProductOffers: slices.Clone(a.ProductOffers)}
+}
+
+func (a FinanceAction) Clone() FinanceAction {
+	return FinanceAction{NextRoundTargets: a.NextRoundTargets}
+}
+
+func (r CommentaryRecord) Clone() CommentaryRecord {
+	return r
+}
+
+func (e RoundEvent) Clone() RoundEvent {
+	return RoundEvent{
+		EventID: e.EventID,
+		MatchID: e.MatchID,
+		Round:   e.Round,
+		Type:    e.Type,
+		ActorID: e.ActorID,
+		Summary: e.Summary,
+		Payload: clonePayload(e.Payload),
+	}
+}
+
+func (v RoundView) Clone() RoundView {
+	return RoundView{
+		MatchID:          v.MatchID,
+		Round:            v.Round,
+		ViewerRoleID:     v.ViewerRoleID,
+		Plant:            v.Plant.Clone(),
+		Customers:        cloneSlice(v.Customers, CustomerState.Clone),
+		ActiveTargets:    v.ActiveTargets,
+		Metrics:          v.Metrics,
+		RecentEvents:     cloneSlice(v.RecentEvents, RoundEvent.Clone),
+		RecentCommentary: cloneSlice(v.RecentCommentary, CommentaryRecord.Clone),
+	}
+}
+
+func clonePayload(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+
+	cloned := maps.Clone(payload)
+	for key, value := range cloned {
+		cloned[key] = cloneAny(value)
+	}
+
+	return cloned
+}
+
+func cloneAny(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return clonePayload(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i := range typed {
+			cloned[i] = cloneAny(typed[i])
+		}
+		return cloned
+	default:
+		return typed
+	}
+}
+
+func cloneSlice[T any](items []T, clone func(T) T) []T {
+	if items == nil {
+		return nil
+	}
+
+	cloned := make([]T, len(items))
+	for i := range items {
+		cloned[i] = clone(items[i])
+	}
+
+	return cloned
+}
+
+func clonePtr[T any](item *T, clone func(T) T) *T {
+	if item == nil {
+		return nil
+	}
+
+	cloned := clone(*item)
+	return &cloned
+}

--- a/internal/ports/state_store.go
+++ b/internal/ports/state_store.go
@@ -1,0 +1,13 @@
+package ports
+
+import "github.com/jpconstantineau/herbiego/internal/domain"
+
+// MatchStateStore persists and serves canonical match state plus append-only history.
+type MatchStateStore interface {
+	CreateMatch(initial domain.MatchState) error
+	CurrentState(matchID domain.MatchID) (domain.MatchState, error)
+	CommitRound(matchID domain.MatchID, nextState domain.MatchState, round domain.RoundRecord) (domain.MatchState, error)
+	Round(matchID domain.MatchID, round domain.RoundNumber) (domain.RoundRecord, error)
+	EventTimeline(matchID domain.MatchID) ([]domain.RoundEvent, error)
+	Commentary(matchID domain.MatchID) ([]domain.CommentaryRecord, error)
+}

--- a/internal/ports/state_store.go
+++ b/internal/ports/state_store.go
@@ -2,7 +2,8 @@ package ports
 
 import "github.com/jpconstantineau/herbiego/internal/domain"
 
-// MatchStateStore persists and serves canonical match state plus append-only history.
+// MatchStateStore persists and serves canonical match state for the round being collected,
+// plus append-only event and commentary timelines.
 type MatchStateStore interface {
 	CreateMatch(initial domain.MatchState) error
 	CurrentState(matchID domain.MatchID) (domain.MatchState, error)

--- a/internal/projection/round_view.go
+++ b/internal/projection/round_view.go
@@ -1,0 +1,63 @@
+package projection
+
+import (
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+// BuildRoundView projects the canonical state and recent append-only history into a player-facing view.
+func BuildRoundView(state domain.MatchState, viewerRoleID domain.RoleID) domain.RoundView {
+	recentEvents := make([]domain.RoundEvent, 0)
+	recentCommentary := make([]domain.CommentaryRecord, 0)
+	for _, round := range state.History.RecentRounds {
+		recentEvents = append(recentEvents, cloneEvents(round.Events)...)
+		recentCommentary = append(recentCommentary, cloneCommentary(round.Commentary)...)
+	}
+
+	return domain.RoundView{
+		MatchID:          state.MatchID,
+		Round:            state.CurrentRound,
+		ViewerRoleID:     viewerRoleID,
+		Plant:            state.Plant.Clone(),
+		Customers:        cloneCustomers(state.Customers),
+		ActiveTargets:    state.ActiveTargets,
+		Metrics:          state.Metrics,
+		RecentEvents:     recentEvents,
+		RecentCommentary: recentCommentary,
+	}
+}
+
+func cloneEvents(events []domain.RoundEvent) []domain.RoundEvent {
+	if events == nil {
+		return nil
+	}
+
+	cloned := make([]domain.RoundEvent, len(events))
+	for i := range events {
+		cloned[i] = events[i].Clone()
+	}
+
+	return cloned
+}
+
+func cloneCommentary(commentary []domain.CommentaryRecord) []domain.CommentaryRecord {
+	if commentary == nil {
+		return nil
+	}
+
+	cloned := make([]domain.CommentaryRecord, len(commentary))
+	copy(cloned, commentary)
+	return cloned
+}
+
+func cloneCustomers(customers []domain.CustomerState) []domain.CustomerState {
+	if customers == nil {
+		return nil
+	}
+
+	cloned := make([]domain.CustomerState, len(customers))
+	for i := range customers {
+		cloned[i] = customers[i].Clone()
+	}
+
+	return cloned
+}

--- a/internal/projection/round_view_test.go
+++ b/internal/projection/round_view_test.go
@@ -1,0 +1,83 @@
+package projection_test
+
+import (
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/projection"
+)
+
+func TestBuildRoundViewIncludesRecentHistoryWindow(t *testing.T) {
+	state := domain.MatchState{
+		MatchID:      "match-1",
+		CurrentRound: 4,
+		Plant: domain.PlantState{
+			Cash: 100,
+		},
+		Customers: []domain.CustomerState{
+			{CustomerID: "cust-1", DisplayName: "Acme"},
+		},
+		ActiveTargets: domain.BudgetTargets{
+			EffectiveRound:        4,
+			ProcurementBudget:     20,
+			ProductionSpendBudget: 30,
+		},
+		Metrics: domain.PlantMetrics{
+			ThroughputRevenue: 55,
+		},
+		History: domain.RoundHistory{
+			RecentRounds: []domain.RoundRecord{
+				{
+					Round: 2,
+					Events: []domain.RoundEvent{
+						{
+							EventID: "event-2",
+							MatchID: "match-1",
+							Round:   2,
+							Type:    domain.EventSupplyArrived,
+						},
+					},
+				},
+				{
+					Round: 3,
+					Commentary: []domain.CommentaryRecord{
+						{
+							CommentaryID: "comment-3",
+							MatchID:      "match-1",
+							Round:        3,
+							RoleID:       domain.RoleSalesManager,
+							Visibility:   domain.CommentaryPublic,
+							Body:         "Demand stayed strong.",
+						},
+					},
+					Events: []domain.RoundEvent{
+						{
+							EventID: "event-3",
+							MatchID: "match-1",
+							Round:   3,
+							Type:    domain.EventShipmentCompleted,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	view := projection.BuildRoundView(state, domain.RoleSalesManager)
+
+	if view.Round != 4 {
+		t.Fatalf("Round = %d, want 4", view.Round)
+	}
+	if view.ViewerRoleID != domain.RoleSalesManager {
+		t.Fatalf("ViewerRoleID = %q, want %q", view.ViewerRoleID, domain.RoleSalesManager)
+	}
+	if len(view.RecentEvents) != 2 {
+		t.Fatalf("RecentEvents len = %d, want 2", len(view.RecentEvents))
+	}
+	if len(view.RecentCommentary) != 1 {
+		t.Fatalf("RecentCommentary len = %d, want 1", len(view.RecentCommentary))
+	}
+	if view.Plant.Cash != 100 {
+		t.Fatalf("Plant.Cash = %d, want 100", view.Plant.Cash)
+	}
+}


### PR DESCRIPTION
## Summary
- add the canonical domain records needed for match state, actions, events, commentary, metrics, and round views
- add a `MatchStateStore` port plus a mutex-protected in-memory implementation with append-only round commits
- add `RoundView` projection support and tests covering current-state queries, history windows, commentary, and event timelines
- codify the review decisions that `CurrentRound` is the round being collected, the in-memory event/commentary timelines remain unbounded, and commentary stays public in MVP

Closes #11.

## Verification
- `go test ./...`
- `go run ./cmd/quality verify`

## Decisions Captured
- `MatchState.CurrentRound` is the round currently being collected.
- The in-memory store keeps an unbounded append-only event/commentary timeline.
- Commentary remains public for MVP.