### PR TITLE
Validate role actions in the round resolver

### DIFF
--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -15,6 +15,7 @@ import (
 type Options struct {
 	HistoryLimit     int
 	ProcurementTerms ProcurementTermsHook
+	ProductionBOM    ProductionBOMHook
 	ProductionRoute  ProductionRouteHook
 	WorldUpdate      WorldUpdateHook
 }
@@ -32,6 +33,21 @@ type ProcurementTermsContext struct {
 type ProcurementTerms struct {
 	UnitCost             domain.Money
 	MinimumOrderQuantity domain.Units
+}
+
+// ProductionBOMHook lets scenario data define the parts consumed when a product is released.
+// The default implementation assumes products consume no explicit parts until scenario data is provided.
+type ProductionBOMHook func(ProductionBOMContext) ProductionBOM
+
+type ProductionBOMContext struct {
+	State        domain.MatchState
+	CurrentRound domain.RoundNumber
+	ProductID    domain.ProductID
+}
+
+type ProductionBOM struct {
+	KnownProduct bool
+	Parts        []domain.BOMLine
 }
 
 // ProductionRouteHook lets scenario data define product-specific routing semantics.
@@ -69,6 +85,7 @@ type Result struct {
 type Resolver struct {
 	historyLimit     int
 	procurementTerms ProcurementTermsHook
+	productionBOM    ProductionBOMHook
 	productionRoute  ProductionRouteHook
 	worldUpdate      WorldUpdateHook
 }
@@ -77,6 +94,7 @@ func NewResolver(options Options) *Resolver {
 	return &Resolver{
 		historyLimit:     normalizedHistoryLimit(options.HistoryLimit),
 		procurementTerms: defaultProcurementTerms(options.ProcurementTerms),
+		productionBOM:    defaultProductionBOM(options.ProductionBOM),
 		productionRoute:  defaultProductionRoute(options.ProductionRoute),
 		worldUpdate:      options.WorldUpdate,
 	}
@@ -110,6 +128,7 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 		currentRound:     state.CurrentRound,
 		stats:            &resolutionStats{},
 		procurementTerms: r.procurementTerms,
+		productionBOM:    r.productionBOM,
 		productionRoute:  r.productionRoute,
 	}
 
@@ -160,6 +179,7 @@ type roundPhase struct {
 	currentRound     domain.RoundNumber
 	stats            *resolutionStats
 	procurementTerms ProcurementTermsHook
+	productionBOM    ProductionBOMHook
 	productionRoute  ProductionRouteHook
 	eventSeq         int
 }
@@ -310,10 +330,46 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 			continue
 		}
 
-		addWIPInventory(&p.state.Plant.WIPInventory, release.ProductID, firstStation, release.Quantity)
-		p.appendEvent(domain.EventProductionReleased, domain.ActorPlantSystem, fmt.Sprintf("Released %d %s into production", release.Quantity, release.ProductID), map[string]any{
+		bom := p.productionBOM(ProductionBOMContext{
+			State:        p.state.Clone(),
+			CurrentRound: p.currentRound,
+			ProductID:    release.ProductID,
+		})
+		if !bom.KnownProduct {
+			p.appendEvent(domain.EventRuleAdjustment, domain.ActorPlantSystem, "Rejected production release for unknown product", map[string]any{
+				"product_id":          string(release.ProductID),
+				"requested_quantity":  int(release.Quantity),
+				"accepted_quantity":   0,
+				"blocked_requirement": "unknown_product",
+			})
+			continue
+		}
+
+		allowed := release.Quantity
+		if len(bom.Parts) > 0 {
+			allowed = minUnits(allowed, maxBuildableQuantity(p.state.Plant.PartsInventory, bom.Parts))
+			if allowed != release.Quantity {
+				p.appendEvent(domain.EventRuleAdjustment, domain.ActorPlantSystem, "Trimmed production release to available part inventory", map[string]any{
+					"product_id":         string(release.ProductID),
+					"requested_quantity": int(release.Quantity),
+					"accepted_quantity":  int(allowed),
+				})
+			}
+		}
+		if allowed <= 0 {
+			p.appendEvent(domain.EventRuleAdjustment, domain.ActorPlantSystem, "Rejected production release because required parts were unavailable", map[string]any{
+				"product_id":         string(release.ProductID),
+				"requested_quantity": int(release.Quantity),
+				"accepted_quantity":  0,
+			})
+			continue
+		}
+
+		consumePartInventory(&p.state.Plant.PartsInventory, bom.Parts, allowed)
+		addWIPInventory(&p.state.Plant.WIPInventory, release.ProductID, firstStation, allowed)
+		p.appendEvent(domain.EventProductionReleased, domain.ActorPlantSystem, fmt.Sprintf("Released %d %s into production", allowed, release.ProductID), map[string]any{
 			"product_id":     string(release.ProductID),
-			"quantity":       int(release.Quantity),
+			"quantity":       int(allowed),
 			"workstation_id": string(firstStation),
 		})
 	}
@@ -619,7 +675,7 @@ func normalizeActions(state domain.MatchState, actions []domain.ActionSubmission
 		if len(assignedRoles) > 0 && !assignedRoles[action.RoleID] {
 			return nil, fmt.Errorf("engine: action %q role %q is not assigned in the current match", action.ActionID, action.RoleID)
 		}
-		if err := validateActionSubmission(action); err != nil {
+		if err := validateActionSubmission(state, action); err != nil {
 			return nil, err
 		}
 		if _, exists := byRole[action.RoleID]; exists {
@@ -657,8 +713,11 @@ func assignedRoles(state domain.MatchState) map[domain.RoleID]bool {
 	return assigned
 }
 
-func validateActionSubmission(action domain.ActionSubmission) error {
+func validateActionSubmission(state domain.MatchState, action domain.ActionSubmission) error {
 	payloads := populatedPayloadNames(action.Action)
+	if len(payloads) == 0 {
+		return fmt.Errorf("engine: action %q role %q must include payload %q", action.ActionID, action.RoleID, action.RoleID)
+	}
 	if len(payloads) > 1 {
 		return fmt.Errorf("engine: action %q role %q includes multiple payloads: %s", action.ActionID, action.RoleID, strings.Join(payloads, ", "))
 	}
@@ -670,7 +729,7 @@ func validateActionSubmission(action domain.ActionSubmission) error {
 	case domain.RoleProcurementManager:
 		return validateProcurementAction(action)
 	case domain.RoleProductionManager:
-		return validateProductionAction(action)
+		return validateProductionAction(state, action)
 	case domain.RoleSalesManager:
 		return validateSalesAction(action)
 	case domain.RoleFinanceController:
@@ -699,7 +758,7 @@ func populatedPayloadNames(action domain.RoleAction) []string {
 
 func validateProcurementAction(action domain.ActionSubmission) error {
 	if action.Action.Procurement == nil {
-		return nil
+		return fmt.Errorf("engine: action %q role %q must include payload %q", action.ActionID, action.RoleID, action.RoleID)
 	}
 
 	for index, order := range action.Action.Procurement.Orders {
@@ -710,9 +769,9 @@ func validateProcurementAction(action domain.ActionSubmission) error {
 	return nil
 }
 
-func validateProductionAction(action domain.ActionSubmission) error {
+func validateProductionAction(state domain.MatchState, action domain.ActionSubmission) error {
 	if action.Action.Production == nil {
-		return nil
+		return fmt.Errorf("engine: action %q role %q must include payload %q", action.ActionID, action.RoleID, action.RoleID)
 	}
 
 	for index, release := range action.Action.Production.Releases {
@@ -724,13 +783,16 @@ func validateProductionAction(action domain.ActionSubmission) error {
 		if allocation.Capacity < 0 {
 			return fmt.Errorf("engine: action %q capacity allocation %d capacity must be non-negative", action.ActionID, index)
 		}
+		if workstationIndex(state.Plant.Workstations, allocation.WorkstationID) < 0 {
+			return fmt.Errorf("engine: action %q capacity allocation %d references unknown workstation %q", action.ActionID, index, allocation.WorkstationID)
+		}
 	}
 	return nil
 }
 
 func validateSalesAction(action domain.ActionSubmission) error {
 	if action.Action.Sales == nil {
-		return nil
+		return fmt.Errorf("engine: action %q role %q must include payload %q", action.ActionID, action.RoleID, action.RoleID)
 	}
 
 	for index, offer := range action.Action.Sales.ProductOffers {
@@ -743,7 +805,7 @@ func validateSalesAction(action domain.ActionSubmission) error {
 
 func validateFinanceAction(action domain.ActionSubmission) error {
 	if action.Action.Finance == nil {
-		return nil
+		return fmt.Errorf("engine: action %q role %q must include payload %q", action.ActionID, action.RoleID, action.RoleID)
 	}
 
 	targets := action.Action.Finance.NextRoundTargets
@@ -867,6 +929,55 @@ func addPartInventory(items *[]domain.PartInventory, partID domain.PartID, quant
 		}
 	}
 	*items = append(*items, domain.PartInventory{PartID: partID, OnHandQty: quantity})
+}
+
+func partQuantity(items []domain.PartInventory, partID domain.PartID) domain.Units {
+	for _, item := range items {
+		if item.PartID == partID {
+			return item.OnHandQty
+		}
+	}
+	return 0
+}
+
+func consumePartInventory(items *[]domain.PartInventory, bom []domain.BOMLine, quantity domain.Units) {
+	for _, line := range bom {
+		takePartInventory(items, line.PartID, line.Quantity*quantity)
+	}
+}
+
+func takePartInventory(items *[]domain.PartInventory, partID domain.PartID, quantity domain.Units) {
+	filtered := (*items)[:0]
+	for _, item := range *items {
+		if item.PartID == partID {
+			item.OnHandQty -= quantity
+		}
+		if item.OnHandQty > 0 {
+			filtered = append(filtered, item)
+		}
+	}
+	*items = filtered
+}
+
+func maxBuildableQuantity(items []domain.PartInventory, bom []domain.BOMLine) domain.Units {
+	if len(bom) == 0 {
+		return 0
+	}
+
+	allowed := domain.Units(-1)
+	for _, line := range bom {
+		if line.Quantity <= 0 {
+			continue
+		}
+		buildable := partQuantity(items, line.PartID) / line.Quantity
+		if allowed < 0 || buildable < allowed {
+			allowed = buildable
+		}
+	}
+	if allowed < 0 {
+		return 0
+	}
+	return allowed
 }
 
 func addWIPInventory(items *[]domain.WIPInventory, productID domain.ProductID, workstationID domain.WorkstationID, quantity domain.Units) {
@@ -1011,6 +1122,16 @@ func defaultProcurementTerms(hook ProcurementTermsHook) ProcurementTermsHook {
 
 	return func(_ ProcurementTermsContext) ProcurementTerms {
 		return ProcurementTerms{UnitCost: 1}
+	}
+}
+
+func defaultProductionBOM(hook ProductionBOMHook) ProductionBOMHook {
+	if hook != nil {
+		return hook
+	}
+
+	return func(_ ProductionBOMContext) ProductionBOM {
+		return ProductionBOM{KnownProduct: true}
 	}
 }
 

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -226,6 +226,13 @@ func (p *roundPhase) resolveProcurement(action *domain.ActionSubmission) {
 		}
 
 		if allowed <= 0 {
+			p.appendEvent(domain.EventRuleAdjustment, domain.ActorPlantSystem, "Rejected procurement order because no legal quantity remained", map[string]any{
+				"part_id":                string(order.PartID),
+				"requested_quantity":     int(order.Quantity),
+				"accepted_quantity":      0,
+				"minimum_order_quantity": int(terms.MinimumOrderQuantity),
+				"effective_unit_cost":    int(terms.UnitCost),
+			})
 			continue
 		}
 
@@ -598,12 +605,22 @@ func (p *roundPhase) appendEvent(eventType domain.RoundEventType, actorID domain
 
 func normalizeActions(state domain.MatchState, actions []domain.ActionSubmission) ([]domain.ActionSubmission, error) {
 	byRole := map[domain.RoleID]domain.ActionSubmission{}
+	assignedRoles := assignedRoles(state)
 	for _, action := range actions {
 		if action.MatchID != state.MatchID {
 			return nil, fmt.Errorf("engine: action %q match id %q does not match state %q", action.ActionID, action.MatchID, state.MatchID)
 		}
 		if action.Round != state.CurrentRound {
 			return nil, fmt.Errorf("engine: action %q round %d does not match state round %d", action.ActionID, action.Round, state.CurrentRound)
+		}
+		if !slices.Contains(domain.CanonicalRoles(), action.RoleID) {
+			return nil, fmt.Errorf("engine: action %q uses unsupported role %q", action.ActionID, action.RoleID)
+		}
+		if len(assignedRoles) > 0 && !assignedRoles[action.RoleID] {
+			return nil, fmt.Errorf("engine: action %q role %q is not assigned in the current match", action.ActionID, action.RoleID)
+		}
+		if err := validateActionSubmission(action); err != nil {
+			return nil, err
 		}
 		if _, exists := byRole[action.RoleID]; exists {
 			return nil, fmt.Errorf("engine: duplicate action for role %q", action.RoleID)
@@ -626,6 +643,126 @@ func normalizeActions(state domain.MatchState, actions []domain.ActionSubmission
 	}
 
 	return ordered, nil
+}
+
+func assignedRoles(state domain.MatchState) map[domain.RoleID]bool {
+	if len(state.Roles) == 0 {
+		return nil
+	}
+
+	assigned := make(map[domain.RoleID]bool, len(state.Roles))
+	for _, role := range state.Roles {
+		assigned[role.RoleID] = true
+	}
+	return assigned
+}
+
+func validateActionSubmission(action domain.ActionSubmission) error {
+	payloads := populatedPayloadNames(action.Action)
+	if len(payloads) > 1 {
+		return fmt.Errorf("engine: action %q role %q includes multiple payloads: %s", action.ActionID, action.RoleID, strings.Join(payloads, ", "))
+	}
+	if len(payloads) == 1 && payloads[0] != string(action.RoleID) {
+		return fmt.Errorf("engine: action %q role %q includes mismatched payload %q", action.ActionID, action.RoleID, payloads[0])
+	}
+
+	switch action.RoleID {
+	case domain.RoleProcurementManager:
+		return validateProcurementAction(action)
+	case domain.RoleProductionManager:
+		return validateProductionAction(action)
+	case domain.RoleSalesManager:
+		return validateSalesAction(action)
+	case domain.RoleFinanceController:
+		return validateFinanceAction(action)
+	default:
+		return fmt.Errorf("engine: action %q uses unsupported role %q", action.ActionID, action.RoleID)
+	}
+}
+
+func populatedPayloadNames(action domain.RoleAction) []string {
+	var names []string
+	if action.Procurement != nil {
+		names = append(names, string(domain.RoleProcurementManager))
+	}
+	if action.Production != nil {
+		names = append(names, string(domain.RoleProductionManager))
+	}
+	if action.Sales != nil {
+		names = append(names, string(domain.RoleSalesManager))
+	}
+	if action.Finance != nil {
+		names = append(names, string(domain.RoleFinanceController))
+	}
+	return names
+}
+
+func validateProcurementAction(action domain.ActionSubmission) error {
+	if action.Action.Procurement == nil {
+		return nil
+	}
+
+	for index, order := range action.Action.Procurement.Orders {
+		if order.Quantity < 0 {
+			return fmt.Errorf("engine: action %q procurement order %d quantity must be non-negative", action.ActionID, index)
+		}
+	}
+	return nil
+}
+
+func validateProductionAction(action domain.ActionSubmission) error {
+	if action.Action.Production == nil {
+		return nil
+	}
+
+	for index, release := range action.Action.Production.Releases {
+		if release.Quantity < 0 {
+			return fmt.Errorf("engine: action %q production release %d quantity must be non-negative", action.ActionID, index)
+		}
+	}
+	for index, allocation := range action.Action.Production.CapacityAllocation {
+		if allocation.Capacity < 0 {
+			return fmt.Errorf("engine: action %q capacity allocation %d capacity must be non-negative", action.ActionID, index)
+		}
+	}
+	return nil
+}
+
+func validateSalesAction(action domain.ActionSubmission) error {
+	if action.Action.Sales == nil {
+		return nil
+	}
+
+	for index, offer := range action.Action.Sales.ProductOffers {
+		if offer.UnitPrice < 0 {
+			return fmt.Errorf("engine: action %q sales offer %d unit price must be non-negative", action.ActionID, index)
+		}
+	}
+	return nil
+}
+
+func validateFinanceAction(action domain.ActionSubmission) error {
+	if action.Action.Finance == nil {
+		return nil
+	}
+
+	targets := action.Action.Finance.NextRoundTargets
+	if targets.ProcurementBudget < 0 {
+		return fmt.Errorf("engine: action %q procurement budget must be non-negative", action.ActionID)
+	}
+	if targets.ProductionSpendBudget < 0 {
+		return fmt.Errorf("engine: action %q production budget must be non-negative", action.ActionID)
+	}
+	if targets.RevenueTarget < 0 {
+		return fmt.Errorf("engine: action %q revenue target must be non-negative", action.ActionID)
+	}
+	if targets.CashFloorTarget < 0 {
+		return fmt.Errorf("engine: action %q cash floor target must be non-negative", action.ActionID)
+	}
+	if targets.DebtCeilingTarget < 0 {
+		return fmt.Errorf("engine: action %q debt ceiling target must be non-negative", action.ActionID)
+	}
+	return nil
 }
 
 func collectCommentary(state domain.MatchState, actions []domain.ActionSubmission) []domain.CommentaryRecord {

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -51,7 +51,9 @@ func TestResolverProducesDeterministicRoundResults(t *testing.T) {
 }
 
 func TestResolverExecutesRoundPhasesAndSchedulesNextTargets(t *testing.T) {
-	resolver := engine.NewResolver(engine.Options{})
+	resolver := engine.NewResolver(engine.Options{
+		ProductionBOM: widgetBOM,
+	})
 
 	result, err := resolver.ResolveRound(fixtureState(), fixtureActions(), seeded.New(7))
 	if err != nil {
@@ -73,8 +75,8 @@ func TestResolverExecutesRoundPhasesAndSchedulesNextTargets(t *testing.T) {
 	if got := finishedQty(result.NextState.Plant.FinishedInventory, "widget"); got != 1 {
 		t.Fatalf("FinishedInventory(widget) = %d, want 1", got)
 	}
-	if got := partQty(result.NextState.Plant.PartsInventory, "housing"); got != 4 {
-		t.Fatalf("PartsInventory(housing) = %d, want 4", got)
+	if got := partQty(result.NextState.Plant.PartsInventory, "housing"); got != 2 {
+		t.Fatalf("PartsInventory(housing) = %d, want 2", got)
 	}
 	if len(result.NextState.Plant.InTransitSupply) != 1 {
 		t.Fatalf("InTransitSupply len = %d, want 1", len(result.NextState.Plant.InTransitSupply))
@@ -117,6 +119,7 @@ func TestResolverExecutesRoundPhasesAndSchedulesNextTargets(t *testing.T) {
 
 func TestResolverUsesWorldUpdateHookAfterSales(t *testing.T) {
 	resolver := engine.NewResolver(engine.Options{
+		ProductionBOM: widgetBOM,
 		WorldUpdate: func(ctx *engine.WorldUpdateContext) error {
 			ctx.State.Customers[0].Sentiment += 2
 			ctx.AppendEvent(domain.EventRuleAdjustment, domain.ActorPlantSystem, "World update adjusted sentiment", map[string]any{
@@ -151,6 +154,7 @@ func TestResolverUsesScenarioProcurementTermsAndRoutingHooks(t *testing.T) {
 				MinimumOrderQuantity: 5,
 			}
 		},
+		ProductionBOM: widgetBOM,
 		ProductionRoute: func(ctx engine.ProductionRouteContext) engine.ProductionRouteStep {
 			switch ctx.CurrentStationID {
 			case "fabrication":
@@ -192,6 +196,20 @@ func TestResolverUsesScenarioProcurementTermsAndRoutingHooks(t *testing.T) {
 	}
 }
 
+func TestResolverRequiresExplicitRolePayload(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+	actions := fixtureActions()
+	actions[2].Action = domain.RoleAction{}
+
+	_, err := resolver.ResolveRound(fixtureState(), actions, seeded.New(1))
+	if err == nil {
+		t.Fatal("ResolveRound() error = nil, want missing payload error")
+	}
+	if got := err.Error(); got != `engine: action "sales-1" role "sales_manager" must include payload "sales_manager"` {
+		t.Fatalf("ResolveRound() error = %q", got)
+	}
+}
+
 func TestResolverRejectsMismatchedRolePayloads(t *testing.T) {
 	resolver := engine.NewResolver(engine.Options{})
 	actions := fixtureActions()
@@ -226,6 +244,20 @@ func TestResolverRejectsMultiplePayloads(t *testing.T) {
 		t.Fatal("ResolveRound() error = nil, want multiple payload error")
 	}
 	if got := err.Error(); got != `engine: action "prod-1" role "production_manager" includes multiple payloads: production_manager, sales_manager` {
+		t.Fatalf("ResolveRound() error = %q", got)
+	}
+}
+
+func TestResolverRejectsUnknownWorkstationsDuringValidation(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+	actions := fixtureActions()
+	actions[1].Action.Production.CapacityAllocation[0].WorkstationID = "unknown"
+
+	_, err := resolver.ResolveRound(fixtureState(), actions, seeded.New(1))
+	if err == nil {
+		t.Fatal("ResolveRound() error = nil, want unknown workstation error")
+	}
+	if got := err.Error(); got != `engine: action "prod-1" capacity allocation 0 references unknown workstation "unknown"` {
 		t.Fatalf("ResolveRound() error = %q", got)
 	}
 }
@@ -292,6 +324,79 @@ func TestResolverEmitsRuleAdjustmentWhenProcurementOrderIsFullyRejected(t *testi
 	}
 	if !rejected {
 		t.Fatalf("Round.Events missing procurement rejection rule adjustment: %#v", result.Round.Events)
+	}
+}
+
+func TestResolverConsumesPartsAndTrimsReleaseToAvailableBOM(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		ProductionBOM: widgetBOM,
+	})
+	state := fixtureState()
+	state.Plant.PartsInventory = []domain.PartInventory{
+		{PartID: "housing", OnHandQty: 1},
+	}
+	state.Plant.InTransitSupply = nil
+	actions := fixtureActions()
+	actions[1].Action.Production.Releases = []domain.ProductionRelease{
+		{ProductID: "widget", Quantity: 3},
+	}
+	actions[1].Action.Production.CapacityAllocation = nil
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := partQty(result.NextState.Plant.PartsInventory, "housing"); got != 0 {
+		t.Fatalf("PartsInventory(housing) = %d, want 0", got)
+	}
+	if got := wipQty(result.NextState.Plant.WIPInventory, "widget", "fabrication"); got != 1 {
+		t.Fatalf("WIP(fabrication/widget) = %d, want 1", got)
+	}
+
+	trimmed := false
+	for _, event := range result.Round.Events {
+		if event.Type == domain.EventRuleAdjustment && event.Summary == "Trimmed production release to available part inventory" {
+			trimmed = true
+			if got := event.Payload["accepted_quantity"]; got != 1 {
+				t.Fatalf("accepted_quantity = %#v, want 1", got)
+			}
+		}
+	}
+	if !trimmed {
+		t.Fatalf("Round.Events missing production trim event: %#v", result.Round.Events)
+	}
+}
+
+func TestResolverRejectsUnknownProductsWhenProductionBOMMarksThemUnknown(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		ProductionBOM: func(ctx engine.ProductionBOMContext) engine.ProductionBOM {
+			if ctx.ProductID == "widget" {
+				return widgetBOM(ctx)
+			}
+			return engine.ProductionBOM{}
+		},
+	})
+	state := fixtureState()
+	actions := fixtureActions()
+	actions[1].Action.Production.Releases = []domain.ProductionRelease{
+		{ProductID: "mystery", Quantity: 1},
+	}
+	actions[1].Action.Production.CapacityAllocation = nil
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	rejected := false
+	for _, event := range result.Round.Events {
+		if event.Type == domain.EventRuleAdjustment && event.Summary == "Rejected production release for unknown product" {
+			rejected = true
+		}
+	}
+	if !rejected {
+		t.Fatalf("Round.Events missing unknown-product rejection: %#v", result.Round.Events)
 	}
 }
 
@@ -449,4 +554,17 @@ func wipQty(items []domain.WIPInventory, productID domain.ProductID, workstation
 		}
 	}
 	return 0
+}
+
+func widgetBOM(ctx engine.ProductionBOMContext) engine.ProductionBOM {
+	if ctx.ProductID != "widget" {
+		return engine.ProductionBOM{KnownProduct: true}
+	}
+
+	return engine.ProductionBOM{
+		KnownProduct: true,
+		Parts: []domain.BOMLine{
+			{PartID: "housing", Quantity: 1},
+		},
+	}
 }

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -192,6 +192,109 @@ func TestResolverUsesScenarioProcurementTermsAndRoutingHooks(t *testing.T) {
 	}
 }
 
+func TestResolverRejectsMismatchedRolePayloads(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+	actions := fixtureActions()
+	actions[0].Action = domain.RoleAction{
+		Sales: &domain.SalesAction{
+			ProductOffers: []domain.ProductOffer{
+				{ProductID: "widget", UnitPrice: 9},
+			},
+		},
+	}
+
+	_, err := resolver.ResolveRound(fixtureState(), actions, seeded.New(1))
+	if err == nil {
+		t.Fatal("ResolveRound() error = nil, want mismatched payload error")
+	}
+	if got := err.Error(); got != `engine: action "proc-1" role "procurement_manager" includes mismatched payload "sales_manager"` {
+		t.Fatalf("ResolveRound() error = %q", got)
+	}
+}
+
+func TestResolverRejectsMultiplePayloads(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+	actions := fixtureActions()
+	actions[1].Action.Sales = &domain.SalesAction{
+		ProductOffers: []domain.ProductOffer{
+			{ProductID: "widget", UnitPrice: 7},
+		},
+	}
+
+	_, err := resolver.ResolveRound(fixtureState(), actions, seeded.New(1))
+	if err == nil {
+		t.Fatal("ResolveRound() error = nil, want multiple payload error")
+	}
+	if got := err.Error(); got != `engine: action "prod-1" role "production_manager" includes multiple payloads: production_manager, sales_manager` {
+		t.Fatalf("ResolveRound() error = %q", got)
+	}
+}
+
+func TestResolverRejectsNegativeValues(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+	actions := fixtureActions()
+	actions[2].Action.Sales.ProductOffers[0].UnitPrice = -1
+
+	_, err := resolver.ResolveRound(fixtureState(), actions, seeded.New(1))
+	if err == nil {
+		t.Fatal("ResolveRound() error = nil, want negative price error")
+	}
+	if got := err.Error(); got != `engine: action "sales-1" sales offer 0 unit price must be non-negative` {
+		t.Fatalf("ResolveRound() error = %q", got)
+	}
+}
+
+func TestResolverRejectsActionsForUnassignedRoles(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+	state := fixtureState()
+	state.Roles = []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "proc"},
+		{RoleID: domain.RoleProductionManager, PlayerID: "prod"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales"},
+	}
+
+	_, err := resolver.ResolveRound(state, fixtureActions(), seeded.New(1))
+	if err == nil {
+		t.Fatal("ResolveRound() error = nil, want unassigned role error")
+	}
+	if got := err.Error(); got != `engine: action "fin-1" role "finance_controller" is not assigned in the current match` {
+		t.Fatalf("ResolveRound() error = %q", got)
+	}
+}
+
+func TestResolverEmitsRuleAdjustmentWhenProcurementOrderIsFullyRejected(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+	state := fixtureState()
+	state.ActiveTargets.ProcurementBudget = 1
+	state.Plant.Cash = 0
+	state.Plant.DebtCeiling = 0
+
+	result, err := resolver.ResolveRound(state, fixtureActions(), seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := len(result.NextState.Plant.InTransitSupply); got != 0 {
+		t.Fatalf("InTransitSupply len = %d, want 0", got)
+	}
+
+	rejected := false
+	for _, event := range result.Round.Events {
+		if event.Type != domain.EventRuleAdjustment {
+			continue
+		}
+		if event.Summary == "Rejected procurement order because no legal quantity remained" {
+			rejected = true
+			if got := event.Payload["accepted_quantity"]; got != 0 {
+				t.Fatalf("accepted_quantity = %#v, want 0", got)
+			}
+		}
+	}
+	if !rejected {
+		t.Fatalf("Round.Events missing procurement rejection rule adjustment: %#v", result.Round.Events)
+	}
+}
+
 func fixtureState() domain.MatchState {
 	return domain.MatchState{
 		MatchID:      "match-1",


### PR DESCRIPTION
Fixes #13.

## Summary
- validate frozen round submissions against canonical roles and assigned match roles
- reject mismatched or multi-payload role actions before resolution
- reject negative quantities, prices, and finance targets with deterministic engine errors
- emit an explicit `rule_adjustment` event when a procurement line is fully rejected during resolution
- add resolver tests covering invalid action envelopes and rejection visibility

## Verification
- `go test ./...`
- `go tool staticcheck ./...`

## Note
- `go run ./cmd/quality verify` currently fails on existing repo-wide formatting drift already present on `main`; this branch keeps the diff scoped to issue `#13`

## Clarification Questions
1. Should a frozen round submission with no populated role payload be treated as a legal no-op, or should collection always require the role-specific payload field to be present even when empty?
2. Once scenario catalogs land, should unknown `product_id`, `part_id`, `customer_id`, and `workstation_id` values be rejected during pre-freeze validation, or converted into resolver-time `rule_adjustment` no-ops?
3. Do we want issue `#13` to grow into BOM-aware production validation and part-consumption rules, or should that be handled in a follow-up issue once `internal/scenario` exposes the starter product definitions?