### PR TITLE
Implement MVP plant economics model

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -65,17 +65,20 @@ type PlantState struct {
 type PartInventory struct {
 	PartID    PartID
 	OnHandQty Units
+	UnitCost  Money
 }
 
 type WIPInventory struct {
 	ProductID     ProductID
 	WorkstationID WorkstationID
 	Quantity      Units
+	UnitCost      Money
 }
 
 type FinishedInventory struct {
 	ProductID ProductID
 	OnHandQty Units
+	UnitCost  Money
 }
 
 type SupplyLot struct {
@@ -132,6 +135,10 @@ type BudgetTargets struct {
 type PlantMetrics struct {
 	ThroughputRevenue     Money
 	OperatingExpense      Money
+	ProcurementSpend      Money
+	ProductionSpend       Money
+	HoldingCost           Money
+	DebtServiceCost       Money
 	InventoryValue        Money
 	NetCashChange         Money
 	RoundProfit           Money

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -17,6 +17,8 @@ type Options struct {
 	ProcurementTerms ProcurementTermsHook
 	ProductionBOM    ProductionBOMHook
 	ProductionRoute  ProductionRouteHook
+	ProductionCost   ProductionCostHook
+	InventoryCost    InventoryCarryingCostHook
 	WorldUpdate      WorldUpdateHook
 }
 
@@ -66,6 +68,41 @@ type ProductionRouteStep struct {
 	Finished          bool
 }
 
+// ProductionCostHook lets scenario data define operating expense per unit of advanced capacity.
+// The default implementation charges 1 money unit per unit of advanced work.
+type ProductionCostHook func(ProductionCostContext) ProductionCost
+
+type ProductionCostContext struct {
+	State         domain.MatchState
+	CurrentRound  domain.RoundNumber
+	ProductID     domain.ProductID
+	WorkstationID domain.WorkstationID
+	Quantity      domain.CapacityUnits
+}
+
+type ProductionCost struct {
+	CostPerCapacityUnit domain.Money
+}
+
+// InventoryCarryingCostHook lets scenario data define carrying cost by inventory class.
+// The default implementation charges a flat 10% round-end carrying cost with a minimum of 1.
+type InventoryCarryingCostHook func(InventoryCarryingCostContext) domain.Money
+
+type InventoryCarryingCostContext struct {
+	State          domain.MatchState
+	CurrentRound   domain.RoundNumber
+	InventoryClass InventoryClass
+	InventoryValue domain.Money
+}
+
+type InventoryClass string
+
+const (
+	InventoryClassParts    InventoryClass = "parts"
+	InventoryClassWIP      InventoryClass = "wip"
+	InventoryClassFinished InventoryClass = "finished"
+)
+
 // WorldUpdateHook is the extension point for scenario-owned demand generation, market behavior,
 // and other seeded world events that should stay outside the deterministic core resolver.
 type WorldUpdateHook func(*WorldUpdateContext) error
@@ -87,6 +124,8 @@ type Resolver struct {
 	procurementTerms ProcurementTermsHook
 	productionBOM    ProductionBOMHook
 	productionRoute  ProductionRouteHook
+	productionCost   ProductionCostHook
+	inventoryCost    InventoryCarryingCostHook
 	worldUpdate      WorldUpdateHook
 }
 
@@ -96,6 +135,8 @@ func NewResolver(options Options) *Resolver {
 		procurementTerms: defaultProcurementTerms(options.ProcurementTerms),
 		productionBOM:    defaultProductionBOM(options.ProductionBOM),
 		productionRoute:  defaultProductionRoute(options.ProductionRoute),
+		productionCost:   defaultProductionCost(options.ProductionCost),
+		inventoryCost:    options.InventoryCost,
 		worldUpdate:      options.WorldUpdate,
 	}
 }
@@ -130,6 +171,8 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 		procurementTerms: r.procurementTerms,
 		productionBOM:    r.productionBOM,
 		productionRoute:  r.productionRoute,
+		productionCost:   r.productionCost,
+		inventoryCost:    r.inventoryCost,
 	}
 
 	if nextState.ActiveTargets.EffectiveRound == state.CurrentRound {
@@ -181,6 +224,8 @@ type roundPhase struct {
 	procurementTerms ProcurementTermsHook
 	productionBOM    ProductionBOMHook
 	productionRoute  ProductionRouteHook
+	productionCost   ProductionCostHook
+	inventoryCost    InventoryCarryingCostHook
 	eventSeq         int
 }
 
@@ -398,16 +443,26 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 		remainingCapacity := p.state.Plant.Workstations[wsIndex].CapacityPerRound - p.state.Plant.Workstations[wsIndex].CapacityUsed
 		availableWIP := wipQuantity(p.state.Plant.WIPInventory, allocation.ProductID, allocation.WorkstationID)
 		advance := minCapacity(allocation.Capacity, remainingCapacity, domain.CapacityUnits(availableWIP))
+		costing := p.productionCost(ProductionCostContext{
+			State:         p.state.Clone(),
+			CurrentRound:  p.currentRound,
+			ProductID:     allocation.ProductID,
+			WorkstationID: allocation.WorkstationID,
+			Quantity:      advance,
+		})
+		if costing.CostPerCapacityUnit <= 0 {
+			costing.CostPerCapacityUnit = 1
+		}
 		if hardCap > 0 {
 			remainingBudget := hardCap - spendUsed
 			if remainingBudget <= 0 {
 				advance = 0
 			} else {
-				advance = minCapacity(advance, domain.CapacityUnits(remainingBudget))
+				advance = minCapacity(advance, domain.CapacityUnits(affordableQuantity(remainingBudget, costing.CostPerCapacityUnit)))
 			}
 		}
 		affordable := availableSpendCapacity(p.state.Plant)
-		advance = minCapacity(advance, domain.CapacityUnits(affordable))
+		advance = minCapacity(advance, domain.CapacityUnits(affordableQuantity(affordable, costing.CostPerCapacityUnit)))
 		if advance < allocation.Capacity {
 			p.appendEvent(domain.EventRuleAdjustment, domain.ActorPlantSystem, "Trimmed production advance to available work or capacity", map[string]any{
 				"workstation_id":     string(allocation.WorkstationID),
@@ -422,7 +477,7 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 
 		advancedCost := takeWIPInventory(&p.state.Plant.WIPInventory, allocation.ProductID, allocation.WorkstationID, domain.Units(advance))
 		p.state.Plant.Workstations[wsIndex].CapacityUsed += advance
-		lineSpend := domain.Money(advance)
+		lineSpend := spendForQuantity(domain.Units(advance), costing.CostPerCapacityUnit)
 		spendUsed += lineSpend
 		p.stats.productionSpend += lineSpend
 
@@ -662,18 +717,40 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 }
 
 func (p *roundPhase) applyRoundOperatingCosts() (domain.Money, domain.Money) {
-	inventoryValue := domain.Money(0)
+	partsValue := domain.Money(0)
 	for _, part := range p.state.Plant.PartsInventory {
-		inventoryValue += inventoryCost(part.OnHandQty, part.UnitCost)
+		partsValue += inventoryCost(part.OnHandQty, part.UnitCost)
 	}
+	wipValue := domain.Money(0)
 	for _, item := range p.state.Plant.WIPInventory {
-		inventoryValue += inventoryCost(item.Quantity, item.UnitCost)
+		wipValue += inventoryCost(item.Quantity, item.UnitCost)
 	}
+	finishedValue := domain.Money(0)
 	for _, item := range p.state.Plant.FinishedInventory {
-		inventoryValue += inventoryCost(item.OnHandQty, item.UnitCost)
+		finishedValue += inventoryCost(item.OnHandQty, item.UnitCost)
 	}
 
-	holdingCost := carryingCost(inventoryValue)
+	holdingCost := carryingCost(partsValue + wipValue + finishedValue)
+	if p.inventoryCost != nil {
+		holdingCost = p.inventoryCost(InventoryCarryingCostContext{
+			State:          p.state.Clone(),
+			CurrentRound:   p.currentRound,
+			InventoryClass: InventoryClassParts,
+			InventoryValue: partsValue,
+		})
+		holdingCost += p.inventoryCost(InventoryCarryingCostContext{
+			State:          p.state.Clone(),
+			CurrentRound:   p.currentRound,
+			InventoryClass: InventoryClassWIP,
+			InventoryValue: wipValue,
+		})
+		holdingCost += p.inventoryCost(InventoryCarryingCostContext{
+			State:          p.state.Clone(),
+			CurrentRound:   p.currentRound,
+			InventoryClass: InventoryClassFinished,
+			InventoryValue: finishedValue,
+		})
+	}
 	debtCost := carryingCost(p.state.Plant.Debt)
 	total := holdingCost + debtCost
 	if total > 0 {
@@ -1277,6 +1354,16 @@ func defaultProductionRoute(hook ProductionRouteHook) ProductionRouteHook {
 			return ProductionRouteStep{Finished: true}
 		}
 		return ProductionRouteStep{NextWorkstationID: ctx.State.Plant.Workstations[index+1].WorkstationID}
+	}
+}
+
+func defaultProductionCost(hook ProductionCostHook) ProductionCostHook {
+	if hook != nil {
+		return hook
+	}
+
+	return func(_ ProductionCostContext) ProductionCost {
+		return ProductionCost{CostPerCapacityUnit: 1}
 	}
 }
 

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -188,8 +188,11 @@ type resolutionStats struct {
 	revenue          domain.Money
 	procurementSpend domain.Money
 	productionSpend  domain.Money
+	holdingCost      domain.Money
+	debtServiceCost  domain.Money
 	shippedUnits     domain.Units
 	producedUnits    domain.Units
+	lostSalesUnits   domain.Units
 }
 
 func (p *roundPhase) resolveProcurement(action *domain.ActionSubmission) {
@@ -307,11 +310,12 @@ func (p *roundPhase) receiveSupply() {
 
 	p.state.Plant.InTransitSupply = remaining
 	for _, lot := range arrivals {
-		addPartInventory(&p.state.Plant.PartsInventory, lot.PartID, lot.Quantity)
+		addPartInventory(&p.state.Plant.PartsInventory, lot.PartID, lot.Quantity, lot.UnitCost)
 		p.appendEvent(domain.EventSupplyArrived, domain.ActorPlantSystem, fmt.Sprintf("Received %d %s", lot.Quantity, lot.PartID), map[string]any{
 			"purchase_order_id": lot.PurchaseOrderID,
 			"part_id":           string(lot.PartID),
 			"quantity":          int(lot.Quantity),
+			"unit_cost":         int(lot.UnitCost),
 		})
 	}
 }
@@ -365,15 +369,18 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 			continue
 		}
 
-		consumePartInventory(&p.state.Plant.PartsInventory, bom.Parts, allowed)
-		addWIPInventory(&p.state.Plant.WIPInventory, release.ProductID, firstStation, allowed)
+		materialCost := consumePartInventory(&p.state.Plant.PartsInventory, bom.Parts, allowed)
+		addWIPInventory(&p.state.Plant.WIPInventory, release.ProductID, firstStation, allowed, perUnitCost(materialCost, allowed))
 		p.appendEvent(domain.EventProductionReleased, domain.ActorPlantSystem, fmt.Sprintf("Released %d %s into production", allowed, release.ProductID), map[string]any{
 			"product_id":     string(release.ProductID),
 			"quantity":       int(allowed),
 			"workstation_id": string(firstStation),
+			"material_cost":  int(materialCost),
 		})
 	}
 
+	hardCap := cappedBudget(p.state.ActiveTargets.ProductionSpendBudget)
+	spendUsed := domain.Money(0)
 	for _, allocation := range action.Action.Production.CapacityAllocation {
 		if allocation.Capacity <= 0 {
 			continue
@@ -391,6 +398,16 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 		remainingCapacity := p.state.Plant.Workstations[wsIndex].CapacityPerRound - p.state.Plant.Workstations[wsIndex].CapacityUsed
 		availableWIP := wipQuantity(p.state.Plant.WIPInventory, allocation.ProductID, allocation.WorkstationID)
 		advance := minCapacity(allocation.Capacity, remainingCapacity, domain.CapacityUnits(availableWIP))
+		if hardCap > 0 {
+			remainingBudget := hardCap - spendUsed
+			if remainingBudget <= 0 {
+				advance = 0
+			} else {
+				advance = minCapacity(advance, domain.CapacityUnits(remainingBudget))
+			}
+		}
+		affordable := availableSpendCapacity(p.state.Plant)
+		advance = minCapacity(advance, domain.CapacityUnits(affordable))
 		if advance < allocation.Capacity {
 			p.appendEvent(domain.EventRuleAdjustment, domain.ActorPlantSystem, "Trimmed production advance to available work or capacity", map[string]any{
 				"workstation_id":     string(allocation.WorkstationID),
@@ -403,8 +420,11 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 			continue
 		}
 
-		takeWIPInventory(&p.state.Plant.WIPInventory, allocation.ProductID, allocation.WorkstationID, domain.Units(advance))
+		advancedCost := takeWIPInventory(&p.state.Plant.WIPInventory, allocation.ProductID, allocation.WorkstationID, domain.Units(advance))
 		p.state.Plant.Workstations[wsIndex].CapacityUsed += advance
+		lineSpend := domain.Money(advance)
+		spendUsed += lineSpend
+		p.stats.productionSpend += lineSpend
 
 		if wsIndex == len(p.state.Plant.Workstations)-1 {
 			route := p.productionRoute(ProductionRouteContext{
@@ -414,12 +434,13 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 				CurrentStationID: allocation.WorkstationID,
 			})
 			if route.Finished {
-				addFinishedInventory(&p.state.Plant.FinishedInventory, allocation.ProductID, domain.Units(advance))
+				addFinishedInventory(&p.state.Plant.FinishedInventory, allocation.ProductID, domain.Units(advance), perUnitCost(advancedCost, domain.Units(advance)))
 				p.stats.producedUnits += domain.Units(advance)
 				p.appendEvent(domain.EventFinishedGoodsProduced, domain.ActorPlantSystem, fmt.Sprintf("Finished %d %s", advance, allocation.ProductID), map[string]any{
 					"product_id":     string(allocation.ProductID),
 					"quantity":       int(advance),
 					"workstation_id": string(allocation.WorkstationID),
+					"inventory_cost": int(advancedCost),
 				})
 				continue
 			}
@@ -432,12 +453,13 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 			CurrentStationID: allocation.WorkstationID,
 		})
 		if route.Finished {
-			addFinishedInventory(&p.state.Plant.FinishedInventory, allocation.ProductID, domain.Units(advance))
+			addFinishedInventory(&p.state.Plant.FinishedInventory, allocation.ProductID, domain.Units(advance), perUnitCost(advancedCost, domain.Units(advance)))
 			p.stats.producedUnits += domain.Units(advance)
 			p.appendEvent(domain.EventFinishedGoodsProduced, domain.ActorPlantSystem, fmt.Sprintf("Finished %d %s", advance, allocation.ProductID), map[string]any{
 				"product_id":     string(allocation.ProductID),
 				"quantity":       int(advance),
 				"workstation_id": string(allocation.WorkstationID),
+				"inventory_cost": int(advancedCost),
 			})
 			continue
 		}
@@ -449,15 +471,24 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 				"workstation_id": string(allocation.WorkstationID),
 				"quantity":       int(advance),
 			})
-			addWIPInventory(&p.state.Plant.WIPInventory, allocation.ProductID, allocation.WorkstationID, domain.Units(advance))
+			addWIPInventory(&p.state.Plant.WIPInventory, allocation.ProductID, allocation.WorkstationID, domain.Units(advance), perUnitCost(advancedCost, domain.Units(advance)))
 			continue
 		}
-		addWIPInventory(&p.state.Plant.WIPInventory, allocation.ProductID, nextStation, domain.Units(advance))
+		addWIPInventory(&p.state.Plant.WIPInventory, allocation.ProductID, nextStation, domain.Units(advance), perUnitCost(advancedCost, domain.Units(advance)))
 		p.appendEvent(domain.EventWorkAdvanced, domain.ActorPlantSystem, fmt.Sprintf("Advanced %d %s to %s", advance, allocation.ProductID, nextStation), map[string]any{
 			"product_id":          string(allocation.ProductID),
 			"quantity":            int(advance),
 			"from_workstation_id": string(allocation.WorkstationID),
 			"to_workstation_id":   string(nextStation),
+		})
+	}
+
+	if spendUsed > 0 {
+		p.applyCashDelta(-spendUsed)
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Production spending applied", map[string]any{
+			"delta": -int(spendUsed),
+			"cash":  int(p.state.Plant.Cash),
+			"debt":  int(p.state.Plant.Debt),
 		})
 	}
 }
@@ -536,6 +567,7 @@ func (p *roundPhase) finalizeRound(action *domain.ActionSubmission) {
 	for _, entry := range backlog {
 		entry.AgeInRounds++
 		if entry.AgeInRounds > 2 {
+			p.stats.lostSalesUnits += entry.Quantity
 			p.appendEvent(domain.EventBacklogExpired, domain.ActorPlantSystem, fmt.Sprintf("Expired backlog for %s/%s", entry.CustomerID, entry.ProductID), map[string]any{
 				"customer_id": string(entry.CustomerID),
 				"product_id":  string(entry.ProductID),
@@ -562,9 +594,14 @@ func (p *roundPhase) finalizeRound(action *domain.ActionSubmission) {
 		p.state.ActiveTargets = targets
 	}
 
+	holdingCost, debtCost := p.applyRoundOperatingCosts()
+	p.stats.holdingCost = holdingCost
+	p.stats.debtServiceCost = debtCost
+
 	metrics := p.computeMetrics()
 	p.round.Metrics = metrics
 	p.appendEvent(domain.EventMetricSnapshot, domain.ActorPlantSystem, "Recorded round metrics", map[string]any{
+		"operating_expense":       int(metrics.OperatingExpense),
 		"round_profit":            int(metrics.RoundProfit),
 		"throughput_revenue":      int(metrics.ThroughputRevenue),
 		"backlog_units":           int(metrics.BacklogUnits),
@@ -582,17 +619,24 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 	inventoryValue := domain.Money(0)
 	for _, part := range p.state.Plant.PartsInventory {
 		partsUnits += part.OnHandQty
-		inventoryValue += domain.Money(part.OnHandQty)
+		inventoryValue += inventoryCost(part.OnHandQty, part.UnitCost)
+	}
+
+	wipUnits := domain.Units(0)
+	for _, item := range p.state.Plant.WIPInventory {
+		wipUnits += item.Quantity
+		inventoryValue += inventoryCost(item.Quantity, item.UnitCost)
 	}
 
 	finishedUnits := domain.Units(0)
 	for _, item := range p.state.Plant.FinishedInventory {
 		finishedUnits += item.OnHandQty
-		inventoryValue += domain.Money(item.OnHandQty)
+		inventoryValue += inventoryCost(item.OnHandQty, item.UnitCost)
 	}
 
-	netCashChange := p.stats.revenue - p.stats.procurementSpend - p.stats.productionSpend
-	demandUnits := p.stats.shippedUnits + backlogUnits
+	operatingExpense := p.stats.procurementSpend + p.stats.productionSpend + p.stats.holdingCost + p.stats.debtServiceCost
+	netCashChange := p.stats.revenue - operatingExpense
+	demandUnits := p.stats.shippedUnits + backlogUnits + p.stats.lostSalesUnits
 	onTime := domain.Percentage(100)
 	if demandUnits > 0 {
 		onTime = domain.Percentage(int(p.stats.shippedUnits) * 100 / int(demandUnits))
@@ -600,16 +644,50 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 
 	return domain.PlantMetrics{
 		ThroughputRevenue:     p.stats.revenue,
-		OperatingExpense:      p.stats.procurementSpend + p.stats.productionSpend,
+		OperatingExpense:      operatingExpense,
+		ProcurementSpend:      p.stats.procurementSpend,
+		ProductionSpend:       p.stats.productionSpend,
+		HoldingCost:           p.stats.holdingCost,
+		DebtServiceCost:       p.stats.debtServiceCost,
 		InventoryValue:        inventoryValue,
 		NetCashChange:         netCashChange,
-		RoundProfit:           p.stats.revenue - p.stats.procurementSpend - p.stats.productionSpend,
+		RoundProfit:           p.stats.revenue - operatingExpense,
 		OnTimeShipmentRate:    onTime,
 		BacklogUnits:          backlogUnits,
+		LostSalesUnits:        p.stats.lostSalesUnits,
 		PartsOnHandUnits:      partsUnits,
 		FinishedGoodsUnits:    finishedUnits,
 		ProductionOutputUnits: p.stats.producedUnits,
 	}
+}
+
+func (p *roundPhase) applyRoundOperatingCosts() (domain.Money, domain.Money) {
+	inventoryValue := domain.Money(0)
+	for _, part := range p.state.Plant.PartsInventory {
+		inventoryValue += inventoryCost(part.OnHandQty, part.UnitCost)
+	}
+	for _, item := range p.state.Plant.WIPInventory {
+		inventoryValue += inventoryCost(item.Quantity, item.UnitCost)
+	}
+	for _, item := range p.state.Plant.FinishedInventory {
+		inventoryValue += inventoryCost(item.OnHandQty, item.UnitCost)
+	}
+
+	holdingCost := carryingCost(inventoryValue)
+	debtCost := carryingCost(p.state.Plant.Debt)
+	total := holdingCost + debtCost
+	if total > 0 {
+		p.applyCashDelta(-total)
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Round-end carrying costs applied", map[string]any{
+			"delta":             -int(total),
+			"cash":              int(p.state.Plant.Cash),
+			"debt":              int(p.state.Plant.Debt),
+			"holding_cost":      int(holdingCost),
+			"debt_service_cost": int(debtCost),
+		})
+	}
+
+	return holdingCost, debtCost
 }
 
 func (p *roundPhase) syncCustomerBacklog(backlog []domain.BacklogEntry) {
@@ -921,14 +999,29 @@ func cappedBudget(target domain.Money) domain.Money {
 	return target + target/10
 }
 
-func addPartInventory(items *[]domain.PartInventory, partID domain.PartID, quantity domain.Units) {
+func addPartInventory(items *[]domain.PartInventory, partID domain.PartID, quantity domain.Units, unitCost domain.Money) {
+	if quantity <= 0 {
+		return
+	}
+
 	for index := range *items {
 		if (*items)[index].PartID == partID {
+			if (*items)[index].UnitCost <= 0 {
+				(*items)[index].OnHandQty += quantity
+				(*items)[index].UnitCost = unitCost
+				return
+			}
+			if unitCost <= 0 {
+				(*items)[index].OnHandQty += quantity
+				return
+			}
+			totalValue := inventoryCost((*items)[index].OnHandQty, (*items)[index].UnitCost) + inventoryCost(quantity, unitCost)
 			(*items)[index].OnHandQty += quantity
+			(*items)[index].UnitCost = perUnitCost(totalValue, (*items)[index].OnHandQty)
 			return
 		}
 	}
-	*items = append(*items, domain.PartInventory{PartID: partID, OnHandQty: quantity})
+	*items = append(*items, domain.PartInventory{PartID: partID, OnHandQty: quantity, UnitCost: unitCost})
 }
 
 func partQuantity(items []domain.PartInventory, partID domain.PartID) domain.Units {
@@ -940,16 +1033,20 @@ func partQuantity(items []domain.PartInventory, partID domain.PartID) domain.Uni
 	return 0
 }
 
-func consumePartInventory(items *[]domain.PartInventory, bom []domain.BOMLine, quantity domain.Units) {
+func consumePartInventory(items *[]domain.PartInventory, bom []domain.BOMLine, quantity domain.Units) domain.Money {
+	totalCost := domain.Money(0)
 	for _, line := range bom {
-		takePartInventory(items, line.PartID, line.Quantity*quantity)
+		totalCost += takePartInventory(items, line.PartID, line.Quantity*quantity)
 	}
+	return totalCost
 }
 
-func takePartInventory(items *[]domain.PartInventory, partID domain.PartID, quantity domain.Units) {
+func takePartInventory(items *[]domain.PartInventory, partID domain.PartID, quantity domain.Units) domain.Money {
+	totalCost := domain.Money(0)
 	filtered := (*items)[:0]
 	for _, item := range *items {
 		if item.PartID == partID {
+			totalCost = inventoryCost(quantity, item.UnitCost)
 			item.OnHandQty -= quantity
 		}
 		if item.OnHandQty > 0 {
@@ -957,6 +1054,7 @@ func takePartInventory(items *[]domain.PartInventory, partID domain.PartID, quan
 		}
 	}
 	*items = filtered
+	return totalCost
 }
 
 func maxBuildableQuantity(items []domain.PartInventory, bom []domain.BOMLine) domain.Units {
@@ -980,14 +1078,29 @@ func maxBuildableQuantity(items []domain.PartInventory, bom []domain.BOMLine) do
 	return allowed
 }
 
-func addWIPInventory(items *[]domain.WIPInventory, productID domain.ProductID, workstationID domain.WorkstationID, quantity domain.Units) {
+func addWIPInventory(items *[]domain.WIPInventory, productID domain.ProductID, workstationID domain.WorkstationID, quantity domain.Units, unitCost domain.Money) {
+	if quantity <= 0 {
+		return
+	}
+
 	for index := range *items {
 		if (*items)[index].ProductID == productID && (*items)[index].WorkstationID == workstationID {
+			if (*items)[index].UnitCost <= 0 {
+				(*items)[index].Quantity += quantity
+				(*items)[index].UnitCost = unitCost
+				return
+			}
+			if unitCost <= 0 {
+				(*items)[index].Quantity += quantity
+				return
+			}
+			totalValue := inventoryCost((*items)[index].Quantity, (*items)[index].UnitCost) + inventoryCost(quantity, unitCost)
 			(*items)[index].Quantity += quantity
+			(*items)[index].UnitCost = perUnitCost(totalValue, (*items)[index].Quantity)
 			return
 		}
 	}
-	*items = append(*items, domain.WIPInventory{ProductID: productID, WorkstationID: workstationID, Quantity: quantity})
+	*items = append(*items, domain.WIPInventory{ProductID: productID, WorkstationID: workstationID, Quantity: quantity, UnitCost: unitCost})
 }
 
 func wipQuantity(items []domain.WIPInventory, productID domain.ProductID, workstationID domain.WorkstationID) domain.Units {
@@ -999,10 +1112,12 @@ func wipQuantity(items []domain.WIPInventory, productID domain.ProductID, workst
 	return 0
 }
 
-func takeWIPInventory(items *[]domain.WIPInventory, productID domain.ProductID, workstationID domain.WorkstationID, quantity domain.Units) {
+func takeWIPInventory(items *[]domain.WIPInventory, productID domain.ProductID, workstationID domain.WorkstationID, quantity domain.Units) domain.Money {
+	totalCost := domain.Money(0)
 	filtered := (*items)[:0]
 	for _, item := range *items {
 		if item.ProductID == productID && item.WorkstationID == workstationID {
+			totalCost = inventoryCost(quantity, item.UnitCost)
 			item.Quantity -= quantity
 		}
 		if item.Quantity > 0 {
@@ -1010,16 +1125,32 @@ func takeWIPInventory(items *[]domain.WIPInventory, productID domain.ProductID, 
 		}
 	}
 	*items = filtered
+	return totalCost
 }
 
-func addFinishedInventory(items *[]domain.FinishedInventory, productID domain.ProductID, quantity domain.Units) {
+func addFinishedInventory(items *[]domain.FinishedInventory, productID domain.ProductID, quantity domain.Units, unitCost domain.Money) {
+	if quantity <= 0 {
+		return
+	}
+
 	for index := range *items {
 		if (*items)[index].ProductID == productID {
+			if (*items)[index].UnitCost <= 0 {
+				(*items)[index].OnHandQty += quantity
+				(*items)[index].UnitCost = unitCost
+				return
+			}
+			if unitCost <= 0 {
+				(*items)[index].OnHandQty += quantity
+				return
+			}
+			totalValue := inventoryCost((*items)[index].OnHandQty, (*items)[index].UnitCost) + inventoryCost(quantity, unitCost)
 			(*items)[index].OnHandQty += quantity
+			(*items)[index].UnitCost = perUnitCost(totalValue, (*items)[index].OnHandQty)
 			return
 		}
 	}
-	*items = append(*items, domain.FinishedInventory{ProductID: productID, OnHandQty: quantity})
+	*items = append(*items, domain.FinishedInventory{ProductID: productID, OnHandQty: quantity, UnitCost: unitCost})
 }
 
 func finishedQuantity(items []domain.FinishedInventory, productID domain.ProductID) domain.Units {
@@ -1153,11 +1284,29 @@ func spendForQuantity(quantity domain.Units, unitCost domain.Money) domain.Money
 	return domain.Money(quantity) * unitCost
 }
 
+func inventoryCost(quantity domain.Units, unitCost domain.Money) domain.Money {
+	return domain.Money(quantity) * unitCost
+}
+
+func perUnitCost(totalCost domain.Money, quantity domain.Units) domain.Money {
+	if quantity <= 0 {
+		return 0
+	}
+	return totalCost / domain.Money(quantity)
+}
+
 func affordableQuantity(available domain.Money, unitCost domain.Money) domain.Units {
 	if available <= 0 || unitCost <= 0 {
 		return 0
 	}
 	return domain.Units(available / unitCost)
+}
+
+func carryingCost(amount domain.Money) domain.Money {
+	if amount <= 0 {
+		return 0
+	}
+	return max(1, (amount+9)/10)
 }
 
 func minCapacity(values ...domain.CapacityUnits) domain.CapacityUnits {

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -217,6 +217,52 @@ func TestResolverUsesScenarioProcurementTermsAndRoutingHooks(t *testing.T) {
 	}
 }
 
+func TestResolverUsesScenarioProductionAndInventoryCostHooks(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		ProductionBOM: widgetBOM,
+		ProductionCost: func(ctx engine.ProductionCostContext) engine.ProductionCost {
+			switch ctx.WorkstationID {
+			case "fabrication":
+				return engine.ProductionCost{CostPerCapacityUnit: 2}
+			case "assembly":
+				return engine.ProductionCost{CostPerCapacityUnit: 3}
+			default:
+				return engine.ProductionCost{CostPerCapacityUnit: 1}
+			}
+		},
+		InventoryCost: func(ctx engine.InventoryCarryingCostContext) domain.Money {
+			if ctx.InventoryValue <= 0 {
+				return 0
+			}
+			switch ctx.InventoryClass {
+			case engine.InventoryClassParts:
+				return 1
+			case engine.InventoryClassWIP:
+				return 2
+			case engine.InventoryClassFinished:
+				return 3
+			default:
+				return 0
+			}
+		},
+	})
+
+	result, err := resolver.ResolveRound(fixtureState(), fixtureActions(), seeded.New(7))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.Round.Metrics.ProductionSpend; got != 10 {
+		t.Fatalf("ProductionSpend = %d, want 10", got)
+	}
+	if got := result.Round.Metrics.HoldingCost; got != 6 {
+		t.Fatalf("HoldingCost = %d, want 6", got)
+	}
+	if got := result.Round.Metrics.OperatingExpense; got != 20 {
+		t.Fatalf("OperatingExpense = %d, want 20", got)
+	}
+}
+
 func TestResolverRequiresExplicitRolePayload(t *testing.T) {
 	resolver := engine.NewResolver(engine.Options{})
 	actions := fixtureActions()

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -66,8 +66,8 @@ func TestResolverExecutesRoundPhasesAndSchedulesNextTargets(t *testing.T) {
 	if result.NextState.ActiveTargets.EffectiveRound != 3 {
 		t.Fatalf("ActiveTargets.EffectiveRound = %d, want 3", result.NextState.ActiveTargets.EffectiveRound)
 	}
-	if result.NextState.Plant.Cash != 24 {
-		t.Fatalf("Plant.Cash = %d, want 24", result.NextState.Plant.Cash)
+	if result.NextState.Plant.Cash != 19 {
+		t.Fatalf("Plant.Cash = %d, want 19", result.NextState.Plant.Cash)
 	}
 	if result.NextState.Plant.Debt != 0 {
 		t.Fatalf("Plant.Debt = %d, want 0", result.NextState.Plant.Debt)
@@ -89,6 +89,24 @@ func TestResolverExecutesRoundPhasesAndSchedulesNextTargets(t *testing.T) {
 	}
 	if result.Round.Metrics.ThroughputRevenue != 18 {
 		t.Fatalf("ThroughputRevenue = %d, want 18", result.Round.Metrics.ThroughputRevenue)
+	}
+	if result.Round.Metrics.ProcurementSpend != 4 {
+		t.Fatalf("ProcurementSpend = %d, want 4", result.Round.Metrics.ProcurementSpend)
+	}
+	if result.Round.Metrics.ProductionSpend != 4 {
+		t.Fatalf("ProductionSpend = %d, want 4", result.Round.Metrics.ProductionSpend)
+	}
+	if result.Round.Metrics.HoldingCost != 1 {
+		t.Fatalf("HoldingCost = %d, want 1", result.Round.Metrics.HoldingCost)
+	}
+	if result.Round.Metrics.OperatingExpense != 9 {
+		t.Fatalf("OperatingExpense = %d, want 9", result.Round.Metrics.OperatingExpense)
+	}
+	if result.Round.Metrics.InventoryValue != 4 {
+		t.Fatalf("InventoryValue = %d, want 4", result.Round.Metrics.InventoryValue)
+	}
+	if result.Round.Metrics.RoundProfit != 9 {
+		t.Fatalf("RoundProfit = %d, want 9", result.Round.Metrics.RoundProfit)
 	}
 	if result.Round.Metrics.BacklogUnits != 0 {
 		t.Fatalf("BacklogUnits = %d, want 0", result.Round.Metrics.BacklogUnits)
@@ -138,8 +156,11 @@ func TestResolverUsesWorldUpdateHookAfterSales(t *testing.T) {
 	if result.NextState.Customers[0].Sentiment != 7 {
 		t.Fatalf("Customer sentiment = %d, want 7", result.NextState.Customers[0].Sentiment)
 	}
-	if result.Round.Events[len(result.Round.Events)-2].Type != domain.EventRuleAdjustment {
-		t.Fatalf("World update event order = %#v, want rule adjustment before metric snapshot", result.Round.Events[len(result.Round.Events)-2].Type)
+	if result.Round.Events[len(result.Round.Events)-1].Type != domain.EventMetricSnapshot {
+		t.Fatalf("last event type = %#v, want metric snapshot", result.Round.Events[len(result.Round.Events)-1].Type)
+	}
+	if result.Round.Events[len(result.Round.Events)-3].Type != domain.EventRuleAdjustment {
+		t.Fatalf("World update event order = %#v, want rule adjustment before round-end cash update and metric snapshot", result.Round.Events[len(result.Round.Events)-3].Type)
 	}
 }
 
@@ -400,6 +421,73 @@ func TestResolverRejectsUnknownProductsWhenProductionBOMMarksThemUnknown(t *test
 	}
 }
 
+func TestResolverTrimsProductionToBudgetAndAvailableCash(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		ProductionBOM: widgetBOM,
+	})
+	state := fixtureState()
+	state.ActiveTargets.ProductionSpendBudget = 1
+	actions := fixtureActions()
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.Round.Metrics.ProductionSpend; got != 1 {
+		t.Fatalf("ProductionSpend = %d, want 1", got)
+	}
+	if got := result.NextState.Plant.Workstations[0].CapacityUsed; got != 1 {
+		t.Fatalf("fabrication capacity used = %d, want 1", got)
+	}
+
+	trimmed := false
+	for _, event := range result.Round.Events {
+		if event.Type == domain.EventRuleAdjustment && event.Summary == "Trimmed production advance to available work or capacity" {
+			if got := event.Payload["accepted_capacity"]; got == 1 {
+				trimmed = true
+			}
+		}
+	}
+	if !trimmed {
+		t.Fatalf("Round.Events missing production budget trim: %#v", result.Round.Events)
+	}
+}
+
+func TestResolverTracksLostSalesAndDebtServiceInMetrics(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+	state := fixtureState()
+	state.Plant.Cash = 0
+	state.Plant.Debt = 10
+	state.Plant.DebtCeiling = 20
+	state.Plant.Backlog = []domain.BacklogEntry{
+		{CustomerID: "cust-1", ProductID: "widget", Quantity: 3, OriginRound: 1, AgeInRounds: 2},
+	}
+	state.Plant.FinishedInventory = nil
+	state.Plant.InTransitSupply = nil
+
+	actions := fixtureActions()
+	actions[0].Action.Procurement.Orders = nil
+	actions[1].Action.Production.Releases = nil
+	actions[1].Action.Production.CapacityAllocation = nil
+	actions[2].Action.Sales.ProductOffers = nil
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.Round.Metrics.LostSalesUnits; got != 3 {
+		t.Fatalf("LostSalesUnits = %d, want 3", got)
+	}
+	if got := result.Round.Metrics.DebtServiceCost; got != 1 {
+		t.Fatalf("DebtServiceCost = %d, want 1", got)
+	}
+	if got := result.NextState.Customers[0].Sentiment; got != 4 {
+		t.Fatalf("Customer sentiment = %d, want 4", got)
+	}
+}
+
 func fixtureState() domain.MatchState {
 	return domain.MatchState{
 		MatchID:      "match-1",
@@ -418,13 +506,13 @@ func fixtureState() domain.MatchState {
 			Debt:        0,
 			DebtCeiling: 5,
 			PartsInventory: []domain.PartInventory{
-				{PartID: "housing", OnHandQty: 1},
+				{PartID: "housing", OnHandQty: 1, UnitCost: 1},
 			},
 			WIPInventory: []domain.WIPInventory{
-				{ProductID: "widget", WorkstationID: "assembly", Quantity: 1},
+				{ProductID: "widget", WorkstationID: "assembly", Quantity: 1, UnitCost: 1},
 			},
 			FinishedInventory: []domain.FinishedInventory{
-				{ProductID: "widget", OnHandQty: 1},
+				{ProductID: "widget", OnHandQty: 1, UnitCost: 1},
 			},
 			InTransitSupply: []domain.SupplyLot{
 				{


### PR DESCRIPTION
## Summary
- implement carried-cost inventory accounting across parts, WIP, and finished goods
- enforce production spending against finance targets and available cash/debt capacity
- apply round-end holding and debt-service costs so overbuying or overproducing can reduce plant profit
- extend resolver coverage for profitability, production trimming, and lost-sales/debt-service behavior

## Validation
- `go run ./cmd/quality verify`

Closes #14.

## Clarification Questions
- Should production operating expense stay as a simple `1` cost per capacity unit for the MVP, or do you want it moved behind a scenario hook next?
- Should inventory carrying cost remain a flat `10%` round-end heuristic, or would you prefer per-scenario rates by inventory class later?
- Is average carried cost on inventory the right MVP behavior, or do you want standard costs defined in scenario seed data before more scenarios land?