### PR TITLE
Implement structured round event log history

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -302,8 +302,23 @@ type RoundView struct {
 	Customers        []CustomerState
 	ActiveTargets    BudgetTargets
 	Metrics          PlantMetrics
+	RecentRounds     []RoundHistoryEntry
 	RecentEvents     []RoundEvent
 	RecentCommentary []CommentaryRecord
+}
+
+type RoundHistoryEntry struct {
+	Round      RoundNumber
+	Events     []RoundEvent
+	Commentary []CommentaryRecord
+	Summary    RoundSummary
+}
+
+type RoundSummary struct {
+	Metrics         PlantMetrics
+	EventCount      int
+	CommentaryCount int
+	ActionCount     int
 }
 
 func (s MatchState) Clone() MatchState {
@@ -435,8 +450,27 @@ func (v RoundView) Clone() RoundView {
 		Customers:        cloneSlice(v.Customers, CustomerState.Clone),
 		ActiveTargets:    v.ActiveTargets,
 		Metrics:          v.Metrics,
+		RecentRounds:     cloneSlice(v.RecentRounds, RoundHistoryEntry.Clone),
 		RecentEvents:     cloneSlice(v.RecentEvents, RoundEvent.Clone),
 		RecentCommentary: cloneSlice(v.RecentCommentary, CommentaryRecord.Clone),
+	}
+}
+
+func (e RoundHistoryEntry) Clone() RoundHistoryEntry {
+	return RoundHistoryEntry{
+		Round:      e.Round,
+		Events:     cloneSlice(e.Events, RoundEvent.Clone),
+		Commentary: cloneSlice(e.Commentary, CommentaryRecord.Clone),
+		Summary:    e.Summary.Clone(),
+	}
+}
+
+func (s RoundSummary) Clone() RoundSummary {
+	return RoundSummary{
+		Metrics:         s.Metrics,
+		EventCount:      s.EventCount,
+		CommentaryCount: s.CommentaryCount,
+		ActionCount:     s.ActionCount,
 	}
 }
 

--- a/internal/projection/round_view.go
+++ b/internal/projection/round_view.go
@@ -6,9 +6,10 @@ import (
 
 // BuildRoundView projects the canonical state and recent append-only history into a player-facing view.
 func BuildRoundView(state domain.MatchState, viewerRoleID domain.RoleID) domain.RoundView {
+	recentRounds := buildRecentRounds(state.History.Recent(10))
 	recentEvents := make([]domain.RoundEvent, 0)
 	recentCommentary := make([]domain.CommentaryRecord, 0)
-	for _, round := range state.History.RecentRounds {
+	for _, round := range recentRounds {
 		recentEvents = append(recentEvents, cloneEvents(round.Events)...)
 		recentCommentary = append(recentCommentary, cloneCommentary(round.Commentary)...)
 	}
@@ -21,9 +22,33 @@ func BuildRoundView(state domain.MatchState, viewerRoleID domain.RoleID) domain.
 		Customers:        cloneCustomers(state.Customers),
 		ActiveTargets:    state.ActiveTargets,
 		Metrics:          state.Metrics,
+		RecentRounds:     recentRounds,
 		RecentEvents:     recentEvents,
 		RecentCommentary: recentCommentary,
 	}
+}
+
+func buildRecentRounds(history domain.RoundHistory) []domain.RoundHistoryEntry {
+	if len(history.RecentRounds) == 0 {
+		return nil
+	}
+
+	entries := make([]domain.RoundHistoryEntry, len(history.RecentRounds))
+	for i, round := range history.RecentRounds {
+		entries[i] = domain.RoundHistoryEntry{
+			Round:      round.Round,
+			Events:     cloneEvents(round.Events),
+			Commentary: cloneCommentary(round.Commentary),
+			Summary: domain.RoundSummary{
+				Metrics:         round.Metrics,
+				EventCount:      len(round.Events),
+				CommentaryCount: len(round.Commentary),
+				ActionCount:     len(round.Actions),
+			},
+		}
+	}
+
+	return entries
 }
 
 func cloneEvents(events []domain.RoundEvent) []domain.RoundEvent {

--- a/internal/projection/round_view_test.go
+++ b/internal/projection/round_view_test.go
@@ -40,6 +40,13 @@ func TestBuildRoundViewIncludesRecentHistoryWindow(t *testing.T) {
 				},
 				{
 					Round: 3,
+					Actions: []domain.ActionSubmission{
+						{ActionID: "sales-3", RoleID: domain.RoleSalesManager},
+					},
+					Metrics: domain.PlantMetrics{
+						RoundProfit:       12,
+						ThroughputRevenue: 21,
+					},
 					Commentary: []domain.CommentaryRecord{
 						{
 							CommentaryID: "comment-3",
@@ -71,13 +78,106 @@ func TestBuildRoundViewIncludesRecentHistoryWindow(t *testing.T) {
 	if view.ViewerRoleID != domain.RoleSalesManager {
 		t.Fatalf("ViewerRoleID = %q, want %q", view.ViewerRoleID, domain.RoleSalesManager)
 	}
+	if len(view.RecentRounds) != 2 {
+		t.Fatalf("RecentRounds len = %d, want 2", len(view.RecentRounds))
+	}
 	if len(view.RecentEvents) != 2 {
 		t.Fatalf("RecentEvents len = %d, want 2", len(view.RecentEvents))
 	}
 	if len(view.RecentCommentary) != 1 {
 		t.Fatalf("RecentCommentary len = %d, want 1", len(view.RecentCommentary))
 	}
+	if got := view.RecentRounds[1].Round; got != 3 {
+		t.Fatalf("RecentRounds[1].Round = %d, want 3", got)
+	}
+	if got := view.RecentRounds[1].Commentary[0].Body; got != "Demand stayed strong." {
+		t.Fatalf("RecentRounds[1].Commentary[0].Body = %q, want %q", got, "Demand stayed strong.")
+	}
+	if got := view.RecentRounds[1].Summary.CommentaryCount; got != 1 {
+		t.Fatalf("RecentRounds[1].Summary.CommentaryCount = %d, want 1", got)
+	}
+	if got := view.RecentRounds[1].Summary.ActionCount; got != 1 {
+		t.Fatalf("RecentRounds[1].Summary.ActionCount = %d, want 1", got)
+	}
+	if got := view.RecentRounds[1].Summary.Metrics.RoundProfit; got != 12 {
+		t.Fatalf("RecentRounds[1].Summary.Metrics.RoundProfit = %d, want 12", got)
+	}
 	if view.Plant.Cash != 100 {
 		t.Fatalf("Plant.Cash = %d, want 100", view.Plant.Cash)
+	}
+}
+
+func TestBuildRoundViewLimitsStructuredHistoryToLastTenRounds(t *testing.T) {
+	rounds := make([]domain.RoundRecord, 0, 12)
+	for round := range 12 {
+		rounds = append(rounds, domain.RoundRecord{
+			Round: domain.RoundNumber(round + 1),
+			Events: []domain.RoundEvent{
+				{
+					EventID: domain.EventID("event"),
+					MatchID: "match-1",
+					Round:   domain.RoundNumber(round + 1),
+					Type:    domain.EventMetricSnapshot,
+				},
+			},
+		})
+	}
+
+	view := projection.BuildRoundView(domain.MatchState{
+		MatchID:      "match-1",
+		CurrentRound: 13,
+		History: domain.RoundHistory{
+			RecentRounds: rounds,
+		},
+	}, domain.RoleFinanceController)
+
+	if len(view.RecentRounds) != 10 {
+		t.Fatalf("RecentRounds len = %d, want 10", len(view.RecentRounds))
+	}
+	if got := view.RecentRounds[0].Round; got != 3 {
+		t.Fatalf("RecentRounds[0].Round = %d, want 3", got)
+	}
+	if got := view.RecentRounds[9].Round; got != 12 {
+		t.Fatalf("RecentRounds[9].Round = %d, want 12", got)
+	}
+}
+
+func TestBuildRoundViewClonesStructuredHistory(t *testing.T) {
+	state := domain.MatchState{
+		MatchID:      "match-1",
+		CurrentRound: 2,
+		History: domain.RoundHistory{
+			RecentRounds: []domain.RoundRecord{
+				{
+					Round: 1,
+					Events: []domain.RoundEvent{
+						{
+							EventID: "event-1",
+							MatchID: "match-1",
+							Round:   1,
+							Type:    domain.EventDemandRealized,
+							Payload: map[string]any{"quantity": 2},
+						},
+					},
+					Commentary: []domain.CommentaryRecord{
+						{
+							CommentaryID: "comment-1",
+							Body:         "Original",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	view := projection.BuildRoundView(state, domain.RoleProcurementManager)
+	view.RecentRounds[0].Events[0].Payload["quantity"] = 99
+	view.RecentRounds[0].Commentary[0].Body = "Changed"
+
+	if got := state.History.RecentRounds[0].Events[0].Payload["quantity"]; got != 2 {
+		t.Fatalf("state payload quantity = %#v, want 2", got)
+	}
+	if got := state.History.RecentRounds[0].Commentary[0].Body; got != "Original" {
+		t.Fatalf("state commentary body = %q, want %q", got, "Original")
 	}
 }


### PR DESCRIPTION
## Summary
- add structured per-round history entries to `RoundView` so events, commentary, and round summaries stay attached to the originating round
- cap projected history windows to the latest 10 rounds while preserving the existing flattened recent event/commentary feeds
- add projection tests for round-context attachment, 10-round trimming, and clone safety

## Testing
- go test ./...

Closes #15.

## Confirmed Decisions
1. Round summaries remain metrics-only for the MVP.
2. Commentary remains fully public in this projection layer; any future visibility filtering should happen in another layer.