### PR TITLE
Create starter scenario and seeded initial match

### DIFF
--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -34,10 +34,17 @@ func main() {
 
 	fmt.Fprintf(
 		os.Stdout,
-		"HerbieGo runtime initialized (env=%s, human_players=%d, seed=%d)\nroles: %v\n",
+		"HerbieGo runtime initialized (env=%s, human_players=%d, seed=%d)\nscenario: %s (%s)\nmatch: %s round=%d cash=%d debt=%d backlog=%d\nroles: %v\n",
 		runtime.Config.Environment,
 		runtime.Config.HumanPlayers,
 		runtime.Config.Random.Seed,
+		runtime.Scenario.ID,
+		runtime.Scenario.DisplayName,
+		runtime.InitialMatch.MatchID,
+		runtime.InitialMatch.CurrentRound,
+		runtime.InitialMatch.Plant.Cash,
+		runtime.InitialMatch.Plant.Debt,
+		len(runtime.InitialMatch.Plant.Backlog),
 		runtime.RoleSummaries(),
 	)
 }

--- a/cmd/quality/main.go
+++ b/cmd/quality/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -133,16 +135,14 @@ func runGoFmt(mode string) error {
 
 	args := append([]string{mode}, files...)
 	if mode == "-l" {
-		var output []byte
-
-		cmd := exec.Command("gofmt", args...)
-		cmd.Stderr = os.Stderr
-		output, err = cmd.Output()
+		unformatted, err := unformattedGoFiles(files)
 		if err != nil {
 			return err
 		}
-		if len(output) > 0 {
-			fmt.Fprint(os.Stderr, string(output))
+		if len(unformatted) > 0 {
+			for _, path := range unformatted {
+				fmt.Fprintln(os.Stderr, path)
+			}
 			return errors.New("gofmt found files that need formatting")
 		}
 
@@ -152,10 +152,44 @@ func runGoFmt(mode string) error {
 	return runCommand("gofmt", args...)
 }
 
+func unformattedGoFiles(files []string) ([]string, error) {
+	unformatted := make([]string, 0)
+	for _, path := range files {
+		ok, err := fileNeedsFormatting(path)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			unformatted = append(unformatted, path)
+		}
+	}
+	return unformatted, nil
+}
+
+func fileNeedsFormatting(path string) (bool, error) {
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return false, fmt.Errorf("read %q: %w", path, err)
+	}
+
+	cmd := exec.Command("gofmt", path)
+	cmd.Stderr = os.Stderr
+	formatted, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("gofmt %q: %w", path, err)
+	}
+
+	return !bytes.Equal(normalizeLineEndings(source), normalizeLineEndings(formatted)), nil
+}
+
+func normalizeLineEndings(data []byte) []byte {
+	return bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+}
+
 func goFiles(root string) ([]string, error) {
 	var files []string
 
-	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}

--- a/cmd/quality/main_test.go
+++ b/cmd/quality/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileNeedsFormattingIgnoresLineEndingOnlyDifferences(t *testing.T) {
+	path := writeGoFile(t, "sample.go", "package sample\r\n\r\nfunc answer() int {\r\n\treturn 42\r\n}\r\n")
+
+	needsFormatting, err := fileNeedsFormatting(path)
+	if err != nil {
+		t.Fatalf("fileNeedsFormatting() error = %v", err)
+	}
+	if needsFormatting {
+		t.Fatal("fileNeedsFormatting() = true, want false for CRLF-only differences")
+	}
+}
+
+func TestFileNeedsFormattingDetectsRealFormattingDifferences(t *testing.T) {
+	path := writeGoFile(t, "sample.go", "package sample\n\nfunc answer() int {\n    return 42\n}\n")
+
+	needsFormatting, err := fileNeedsFormatting(path)
+	if err != nil {
+		t.Fatalf("fileNeedsFormatting() error = %v", err)
+	}
+	if !needsFormatting {
+		t.Fatal("fileNeedsFormatting() = false, want true for unformatted Go source")
+	}
+}
+
+func writeGoFile(t *testing.T, name string, contents string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	return path
+}

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -7,12 +7,15 @@ import (
 	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
 // Runtime contains the process dependencies created during startup.
 type Runtime struct {
-	Config Config
-	Random ports.RandomSource
+	Config       Config
+	Random       ports.RandomSource
+	Scenario     scenario.Definition
+	InitialMatch domain.MatchState
 }
 
 // Bootstrap loads startup configuration and constructs process dependencies.
@@ -32,9 +35,12 @@ func NewRuntime(cfg Config) (Runtime, error) {
 		return Runtime{}, fmt.Errorf("validate runtime config: %w", err)
 	}
 
+	starter := scenario.Default()
 	return Runtime{
-		Config: cfg,
-		Random: seeded.New(cfg.Random.Seed),
+		Config:       cfg,
+		Random:       seeded.New(cfg.Random.Seed),
+		Scenario:     starter,
+		InitialMatch: starter.InitialState("starter-match", runtimeRoles(cfg)),
 	}, nil
 }
 
@@ -57,4 +63,23 @@ func (r Runtime) RoleSummaries() []string {
 
 	slices.Sort(summaries)
 	return summaries
+}
+
+func runtimeRoles(cfg Config) []domain.RoleAssignment {
+	roles := make([]domain.RoleAssignment, 0, len(cfg.Roles))
+	for _, roleID := range domain.CanonicalRoles() {
+		roleCfg, ok := cfg.Roles[roleID]
+		if !ok {
+			continue
+		}
+
+		roles = append(roles, domain.RoleAssignment{
+			RoleID:    roleID,
+			PlayerID:  fmt.Sprintf("%s-player", roleID),
+			IsHuman:   roleCfg.Kind == PlayerKindHuman,
+			Provider:  string(roleCfg.Provider),
+			ModelName: roleCfg.Model,
+		})
+	}
+	return roles
 }

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -1,0 +1,44 @@
+package app
+
+import "testing"
+
+func TestNewRuntimeSeedsDefaultStarterMatch(t *testing.T) {
+	runtime, err := NewRuntime(Config{
+		Environment:  "test",
+		HumanPlayers: 1,
+		Random: RandomConfig{
+			Seed: 9,
+		},
+		RoleConfigs: []RoleConfigFile{
+			{RoleID: "procurement_manager", Provider: "ollama", Model: "llama3.2:3b"},
+			{RoleID: "production_manager", Provider: "ollama", Model: "llama3.2:3b"},
+			{RoleID: "sales_manager", Provider: "openrouter", Model: "openai/gpt-5-mini"},
+			{RoleID: "finance_controller", Provider: "ollama", Model: "llama3.2:3b"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime() error = %v", err)
+	}
+
+	if got := runtime.Scenario.ID; got != "starter" {
+		t.Fatalf("Scenario.ID = %q, want starter", got)
+	}
+	if got := runtime.InitialMatch.MatchID; got != "starter-match" {
+		t.Fatalf("InitialMatch.MatchID = %q, want starter-match", got)
+	}
+	if got := runtime.InitialMatch.CurrentRound; got != 1 {
+		t.Fatalf("InitialMatch.CurrentRound = %d, want 1", got)
+	}
+	if got := len(runtime.InitialMatch.Roles); got != 4 {
+		t.Fatalf("InitialMatch.Roles len = %d, want 4", got)
+	}
+	if !runtime.InitialMatch.Roles[1].IsHuman {
+		t.Fatalf("production role IsHuman = false, want true")
+	}
+	if got := runtime.InitialMatch.Plant.Cash; got != 24 {
+		t.Fatalf("InitialMatch.Plant.Cash = %d, want 24", got)
+	}
+	if got := len(runtime.InitialMatch.Plant.Backlog); got != 2 {
+		t.Fatalf("InitialMatch.Plant.Backlog len = %d, want 2", got)
+	}
+}

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -1,0 +1,360 @@
+package scenario
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
+)
+
+type Definition struct {
+	ID                  domain.ScenarioID
+	DisplayName         string
+	Description         string
+	Setup               MatchSetup
+	StartingConditions  StartingConditions
+	MarketModel         MarketModel
+	ProductionModel     ProductionModel
+	DefaultHistoryLimit int
+}
+
+type MatchSetup struct {
+	ID          string
+	DisplayName string
+	RoleRoster  []domain.RoleID
+}
+
+type StartingConditions struct {
+	ID              string
+	DisplayName     string
+	Description     string
+	StartingTargets domain.BudgetTargets
+	StartingPlant   domain.PlantState
+	Customers       []CustomerSeed
+}
+
+type CustomerSeed struct {
+	ID          domain.CustomerID
+	DisplayName string
+	Sentiment   int
+}
+
+type MarketModel struct {
+	ID                string
+	DisplayName       string
+	Description       string
+	Customers         []CustomerMarket
+	DemandAssumptions DemandAssumptions
+}
+
+type CustomerMarket struct {
+	ID              domain.CustomerID
+	DisplayName     string
+	DemandByProduct map[domain.ProductID]DemandProfile
+}
+
+type DemandProfile struct {
+	ReferencePrice   domain.Money
+	BaseDemand       domain.Units
+	PriceSensitivity int
+}
+
+type ProductionModel struct {
+	ID           string
+	DisplayName  string
+	Description  string
+	Products     []Product
+	Parts        []Part
+	Workstations []Workstation
+	Bottleneck   BottleneckAssumption
+}
+
+type Product struct {
+	ID           domain.ProductID
+	DisplayName  string
+	BOM          []domain.BOMLine
+	Route        []domain.WorkstationID
+	BaseUnitCost domain.Money
+}
+
+type Part struct {
+	ID          domain.PartID
+	DisplayName string
+	UnitCost    domain.Money
+	SupplierID  domain.SupplierID
+}
+
+type Workstation struct {
+	ID               domain.WorkstationID
+	DisplayName      string
+	CapacityPerRound domain.CapacityUnits
+	CostPerUnit      domain.Money
+}
+
+type BottleneckAssumption struct {
+	WorkstationID domain.WorkstationID
+	Summary       string
+}
+
+type DemandAssumptions struct {
+	BacklogExpiryRounds int
+}
+
+func NewDefinition(id domain.ScenarioID, displayName, description string, setup MatchSetup, starting StartingConditions, market MarketModel, production ProductionModel) Definition {
+	return Definition{
+		ID:                  id,
+		DisplayName:         displayName,
+		Description:         description,
+		Setup:               setup,
+		StartingConditions:  starting,
+		MarketModel:         market,
+		ProductionModel:     production,
+		DefaultHistoryLimit: 10,
+	}
+}
+
+func (d Definition) InitialState(matchID domain.MatchID, roles []domain.RoleAssignment) domain.MatchState {
+	plant := d.StartingConditions.StartingPlant.Clone()
+	plant.Workstations = d.productionWorkstationState()
+
+	customers := make([]domain.CustomerState, 0, len(d.StartingConditions.Customers))
+	for _, customer := range d.StartingConditions.Customers {
+		customers = append(customers, domain.CustomerState{
+			CustomerID:  customer.ID,
+			DisplayName: customer.DisplayName,
+			Sentiment:   customer.Sentiment,
+			Backlog:     customerBacklog(plant.Backlog, customer.ID),
+		})
+	}
+
+	return domain.MatchState{
+		MatchID:       matchID,
+		ScenarioID:    d.ID,
+		CurrentRound:  1,
+		Roles:         slices.Clone(roles),
+		Plant:         plant,
+		Customers:     customers,
+		ActiveTargets: d.StartingConditions.StartingTargets,
+	}
+}
+
+func (d Definition) ResolverOptions() engine.Options {
+	partByID := d.partsByID()
+	productByID := d.productsByID()
+	workstationByID := d.workstationsByID()
+
+	return engine.Options{
+		HistoryLimit: d.DefaultHistoryLimit,
+		ProcurementTerms: func(ctx engine.ProcurementTermsContext) engine.ProcurementTerms {
+			part, ok := partByID[ctx.Order.PartID]
+			if !ok {
+				return engine.ProcurementTerms{UnitCost: 1}
+			}
+			return engine.ProcurementTerms{UnitCost: part.UnitCost}
+		},
+		ProductionBOM: func(ctx engine.ProductionBOMContext) engine.ProductionBOM {
+			product, ok := productByID[ctx.ProductID]
+			if !ok {
+				return engine.ProductionBOM{}
+			}
+			return engine.ProductionBOM{
+				KnownProduct: true,
+				Parts:        slices.Clone(product.BOM),
+			}
+		},
+		ProductionRoute: func(ctx engine.ProductionRouteContext) engine.ProductionRouteStep {
+			product, ok := productByID[ctx.ProductID]
+			if !ok {
+				return engine.ProductionRouteStep{}
+			}
+
+			index := slices.Index(product.Route, ctx.CurrentStationID)
+			if index < 0 {
+				return engine.ProductionRouteStep{}
+			}
+			if index == len(product.Route)-1 {
+				return engine.ProductionRouteStep{Finished: true}
+			}
+			return engine.ProductionRouteStep{NextWorkstationID: product.Route[index+1]}
+		},
+		ProductionCost: func(ctx engine.ProductionCostContext) engine.ProductionCost {
+			workstation, ok := workstationByID[ctx.WorkstationID]
+			if !ok || workstation.CostPerUnit <= 0 {
+				return engine.ProductionCost{CostPerCapacityUnit: 1}
+			}
+			return engine.ProductionCost{CostPerCapacityUnit: workstation.CostPerUnit}
+		},
+		WorldUpdate: func(ctx *engine.WorldUpdateContext) error {
+			return d.applyDemand(ctx)
+		},
+	}
+}
+
+func (d Definition) SummaryLines() []string {
+	return []string{
+		fmt.Sprintf("scenario=%s (%s)", d.ID, d.DisplayName),
+		fmt.Sprintf("setup=%s", d.Setup.ID),
+		fmt.Sprintf("starting_conditions=%s", d.StartingConditions.ID),
+		fmt.Sprintf("market_model=%s", d.MarketModel.ID),
+		fmt.Sprintf("production_model=%s", d.ProductionModel.ID),
+		fmt.Sprintf("bottleneck=%s", d.ProductionModel.Bottleneck.WorkstationID),
+		fmt.Sprintf("roles=%s", strings.Join(roleNames(d.Setup.RoleRoster), ", ")),
+	}
+}
+
+func (d Definition) partsByID() map[domain.PartID]Part {
+	items := make(map[domain.PartID]Part, len(d.ProductionModel.Parts))
+	for _, item := range d.ProductionModel.Parts {
+		items[item.ID] = item
+	}
+	return items
+}
+
+func (d Definition) productsByID() map[domain.ProductID]Product {
+	items := make(map[domain.ProductID]Product, len(d.ProductionModel.Products))
+	for _, item := range d.ProductionModel.Products {
+		items[item.ID] = item
+	}
+	return items
+}
+
+func (d Definition) workstationsByID() map[domain.WorkstationID]Workstation {
+	items := make(map[domain.WorkstationID]Workstation, len(d.ProductionModel.Workstations))
+	for _, item := range d.ProductionModel.Workstations {
+		items[item.ID] = item
+	}
+	return items
+}
+
+func (d Definition) customersByID() map[domain.CustomerID]CustomerMarket {
+	items := make(map[domain.CustomerID]CustomerMarket, len(d.MarketModel.Customers))
+	for _, item := range d.MarketModel.Customers {
+		items[item.ID] = item
+	}
+	return items
+}
+
+func (d Definition) productionWorkstationState() []domain.WorkstationState {
+	items := make([]domain.WorkstationState, 0, len(d.ProductionModel.Workstations))
+	for _, workstation := range d.ProductionModel.Workstations {
+		items = append(items, domain.WorkstationState{
+			WorkstationID:    workstation.ID,
+			DisplayName:      workstation.DisplayName,
+			CapacityPerRound: workstation.CapacityPerRound,
+		})
+	}
+	return items
+}
+
+func (d Definition) applyDemand(ctx *engine.WorldUpdateContext) error {
+	if ctx == nil || ctx.State == nil {
+		return nil
+	}
+
+	customerByID := d.customersByID()
+	priceByProduct := currentOfferPrices(ctx.Round, d.ProductionModel.Products)
+
+	for _, customerState := range ctx.State.Customers {
+		customer, ok := customerByID[customerState.CustomerID]
+		if !ok {
+			continue
+		}
+
+		for productID, offerPrice := range priceByProduct {
+			profile, ok := customer.DemandByProduct[productID]
+			if !ok {
+				continue
+			}
+
+			realized := realizedDemand(profile, customerState.Sentiment, offerPrice)
+			if realized <= 0 {
+				continue
+			}
+
+			entry := domain.BacklogEntry{
+				CustomerID:  customerState.CustomerID,
+				ProductID:   productID,
+				Quantity:    realized,
+				OriginRound: ctx.State.CurrentRound,
+			}
+			ctx.State.Plant.Backlog = append(ctx.State.Plant.Backlog, entry)
+			appendCustomerBacklog(ctx.State, customerState.CustomerID, entry)
+
+			ctx.AppendEvent(domain.EventDemandRealized, domain.ActorPlantSystem, fmt.Sprintf("Realized %d units of %s demand from %s", realized, productID, customerState.CustomerID), map[string]any{
+				"customer_id":        string(customerState.CustomerID),
+				"product_id":         string(productID),
+				"quantity":           int(realized),
+				"reference_price":    int(profile.ReferencePrice),
+				"offered_unit_price": int(offerPrice),
+				"sentiment":          customerState.Sentiment,
+			})
+			ctx.AppendEvent(domain.EventBacklogCreated, domain.ActorPlantSystem, fmt.Sprintf("Booked %d units of %s backlog for %s", realized, productID, customerState.CustomerID), map[string]any{
+				"customer_id": string(customerState.CustomerID),
+				"product_id":  string(productID),
+				"quantity":    int(realized),
+			})
+		}
+	}
+
+	return nil
+}
+
+func currentOfferPrices(round *domain.RoundRecord, products []Product) map[domain.ProductID]domain.Money {
+	prices := make(map[domain.ProductID]domain.Money, len(products))
+	for _, product := range products {
+		prices[product.ID] = product.BaseUnitCost * 2
+	}
+
+	if round == nil {
+		return prices
+	}
+
+	for _, action := range round.Actions {
+		if action.RoleID != domain.RoleSalesManager || action.Action.Sales == nil {
+			continue
+		}
+		for _, offer := range action.Action.Sales.ProductOffers {
+			if offer.UnitPrice > 0 {
+				prices[offer.ProductID] = offer.UnitPrice
+			}
+		}
+	}
+
+	return prices
+}
+
+func realizedDemand(profile DemandProfile, sentiment int, offeredPrice domain.Money) domain.Units {
+	sentimentModifier := max(1, sentiment) + 2
+	demandScore := int(profile.BaseDemand)*sentimentModifier - profile.PriceSensitivity*max(0, int(offeredPrice-profile.ReferencePrice))
+	return domain.Units(max(0, demandScore/5))
+}
+
+func appendCustomerBacklog(state *domain.MatchState, customerID domain.CustomerID, entry domain.BacklogEntry) {
+	for index := range state.Customers {
+		if state.Customers[index].CustomerID != customerID {
+			continue
+		}
+		state.Customers[index].Backlog = append(state.Customers[index].Backlog, entry)
+		return
+	}
+}
+
+func customerBacklog(backlog []domain.BacklogEntry, customerID domain.CustomerID) []domain.BacklogEntry {
+	items := make([]domain.BacklogEntry, 0)
+	for _, entry := range backlog {
+		if entry.CustomerID == customerID {
+			items = append(items, entry)
+		}
+	}
+	return items
+}
+
+func roleNames(roleIDs []domain.RoleID) []string {
+	names := make([]string, 0, len(roleIDs))
+	for _, roleID := range roleIDs {
+		names = append(names, string(roleID))
+	}
+	return names
+}

--- a/internal/scenario/starter.go
+++ b/internal/scenario/starter.go
@@ -1,0 +1,417 @@
+package scenario
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
+)
+
+const (
+	// StarterID is the default playable scenario shipped with the MVP.
+	StarterID domain.ScenarioID = "starter"
+)
+
+type Definition struct {
+	ID                  domain.ScenarioID
+	DisplayName         string
+	Description         string
+	RoleRoster          []domain.RoleID
+	Products            []Product
+	Parts               []Part
+	Customers           []Customer
+	Workstations        []Workstation
+	Bottleneck          BottleneckAssumption
+	StartingTargets     domain.BudgetTargets
+	StartingPlant       domain.PlantState
+	DemandAssumptions   DemandAssumptions
+	DebtCeiling         domain.Money
+	DefaultHistoryLimit int
+}
+
+type Product struct {
+	ID           domain.ProductID
+	DisplayName  string
+	BOM          []domain.BOMLine
+	Route        []domain.WorkstationID
+	BaseUnitCost domain.Money
+}
+
+type Part struct {
+	ID          domain.PartID
+	DisplayName string
+	UnitCost    domain.Money
+	SupplierID  domain.SupplierID
+}
+
+type Customer struct {
+	ID              domain.CustomerID
+	DisplayName     string
+	StartingMood    int
+	DemandByProduct map[domain.ProductID]DemandProfile
+}
+
+type DemandProfile struct {
+	ReferencePrice   domain.Money
+	BaseDemand       domain.Units
+	PriceSensitivity int
+}
+
+type Workstation struct {
+	ID               domain.WorkstationID
+	DisplayName      string
+	CapacityPerRound domain.CapacityUnits
+	CostPerUnit      domain.Money
+}
+
+type BottleneckAssumption struct {
+	WorkstationID domain.WorkstationID
+	Summary       string
+}
+
+type DemandAssumptions struct {
+	BacklogExpiryRounds int
+}
+
+func Default() Definition {
+	return Starter()
+}
+
+func Starter() Definition {
+	return Definition{
+		ID:          StarterID,
+		DisplayName: "Prairie Pump Starter Plant",
+		Description: "A small pump-and-valve plant with constrained final assembly, limited cash, and enough demand pressure to create local-vs-global tension immediately.",
+		RoleRoster:  domain.CanonicalRoles(),
+		Parts: []Part{
+			{ID: "housing", DisplayName: "Housing", UnitCost: 3, SupplierID: "forgeco"},
+			{ID: "seal_kit", DisplayName: "Seal Kit", UnitCost: 2, SupplierID: "sealworks"},
+			{ID: "body", DisplayName: "Valve Body", UnitCost: 2, SupplierID: "forgeco"},
+			{ID: "fastener_kit", DisplayName: "Fastener Kit", UnitCost: 1, SupplierID: "fastenall"},
+		},
+		Products: []Product{
+			{
+				ID:          "pump",
+				DisplayName: "Pump",
+				BOM: []domain.BOMLine{
+					{PartID: "housing", Quantity: 1},
+					{PartID: "seal_kit", Quantity: 1},
+				},
+				Route:        []domain.WorkstationID{"fabrication", "assembly"},
+				BaseUnitCost: 8,
+			},
+			{
+				ID:          "valve",
+				DisplayName: "Valve",
+				BOM: []domain.BOMLine{
+					{PartID: "body", Quantity: 1},
+					{PartID: "fastener_kit", Quantity: 1},
+				},
+				Route:        []domain.WorkstationID{"fabrication", "assembly"},
+				BaseUnitCost: 5,
+			},
+		},
+		Customers: []Customer{
+			{
+				ID:           "northbuild",
+				DisplayName:  "NorthBuild",
+				StartingMood: 6,
+				DemandByProduct: map[domain.ProductID]DemandProfile{
+					"pump":  {ReferencePrice: 14, BaseDemand: 3, PriceSensitivity: 1},
+					"valve": {ReferencePrice: 9, BaseDemand: 2, PriceSensitivity: 1},
+				},
+			},
+			{
+				ID:           "prairieflow",
+				DisplayName:  "PrairieFlow",
+				StartingMood: 5,
+				DemandByProduct: map[domain.ProductID]DemandProfile{
+					"pump":  {ReferencePrice: 13, BaseDemand: 2, PriceSensitivity: 1},
+					"valve": {ReferencePrice: 8, BaseDemand: 3, PriceSensitivity: 1},
+				},
+			},
+			{
+				ID:           "agriworks",
+				DisplayName:  "AgriWorks",
+				StartingMood: 4,
+				DemandByProduct: map[domain.ProductID]DemandProfile{
+					"pump":  {ReferencePrice: 12, BaseDemand: 2, PriceSensitivity: 1},
+					"valve": {ReferencePrice: 8, BaseDemand: 2, PriceSensitivity: 1},
+				},
+			},
+		},
+		Workstations: []Workstation{
+			{ID: "fabrication", DisplayName: "Fabrication", CapacityPerRound: 7, CostPerUnit: 2},
+			{ID: "assembly", DisplayName: "Assembly", CapacityPerRound: 4, CostPerUnit: 3},
+		},
+		Bottleneck: BottleneckAssumption{
+			WorkstationID: "assembly",
+			Summary:       "Assembly is the chronic near-term bottleneck, so overselling or over-releasing work tends to inflate WIP and burn cash faster than throughput improves.",
+		},
+		StartingTargets: domain.BudgetTargets{
+			EffectiveRound:        1,
+			ProcurementBudget:     18,
+			ProductionSpendBudget: 14,
+			RevenueTarget:         28,
+			CashFloorTarget:       8,
+			DebtCeilingTarget:     15,
+		},
+		StartingPlant: domain.PlantState{
+			Cash:        24,
+			Debt:        0,
+			DebtCeiling: 15,
+			PartsInventory: []domain.PartInventory{
+				{PartID: "housing", OnHandQty: 2, UnitCost: 3},
+				{PartID: "seal_kit", OnHandQty: 2, UnitCost: 2},
+				{PartID: "body", OnHandQty: 3, UnitCost: 2},
+				{PartID: "fastener_kit", OnHandQty: 3, UnitCost: 1},
+			},
+			WIPInventory: []domain.WIPInventory{
+				{ProductID: "pump", WorkstationID: "assembly", Quantity: 2, UnitCost: 8},
+			},
+			FinishedInventory: []domain.FinishedInventory{
+				{ProductID: "valve", OnHandQty: 1, UnitCost: 5},
+			},
+			Workstations: []domain.WorkstationState{
+				{WorkstationID: "fabrication", DisplayName: "Fabrication", CapacityPerRound: 7},
+				{WorkstationID: "assembly", DisplayName: "Assembly", CapacityPerRound: 4},
+			},
+			Backlog: []domain.BacklogEntry{
+				{CustomerID: "northbuild", ProductID: "pump", Quantity: 2, OriginRound: 0},
+				{CustomerID: "prairieflow", ProductID: "valve", Quantity: 1, OriginRound: 0},
+			},
+		},
+		DemandAssumptions: DemandAssumptions{
+			BacklogExpiryRounds: 2,
+		},
+		DefaultHistoryLimit: 10,
+	}
+}
+
+func (d Definition) InitialState(matchID domain.MatchID, roles []domain.RoleAssignment) domain.MatchState {
+	customers := make([]domain.CustomerState, 0, len(d.Customers))
+	for _, customer := range d.Customers {
+		customers = append(customers, domain.CustomerState{
+			CustomerID:  customer.ID,
+			DisplayName: customer.DisplayName,
+			Sentiment:   customer.StartingMood,
+			Backlog:     customerBacklog(d.StartingPlant.Backlog, customer.ID),
+		})
+	}
+
+	return domain.MatchState{
+		MatchID:       matchID,
+		ScenarioID:    d.ID,
+		CurrentRound:  1,
+		Roles:         slices.Clone(roles),
+		Plant:         d.StartingPlant.Clone(),
+		Customers:     customers,
+		ActiveTargets: d.StartingTargets,
+	}
+}
+
+func (d Definition) ResolverOptions() engine.Options {
+	partByID := d.partsByID()
+	productByID := d.productsByID()
+	workstationByID := d.workstationsByID()
+
+	return engine.Options{
+		HistoryLimit: d.DefaultHistoryLimit,
+		ProcurementTerms: func(ctx engine.ProcurementTermsContext) engine.ProcurementTerms {
+			part, ok := partByID[ctx.Order.PartID]
+			if !ok {
+				return engine.ProcurementTerms{UnitCost: 1}
+			}
+			return engine.ProcurementTerms{UnitCost: part.UnitCost}
+		},
+		ProductionBOM: func(ctx engine.ProductionBOMContext) engine.ProductionBOM {
+			product, ok := productByID[ctx.ProductID]
+			if !ok {
+				return engine.ProductionBOM{}
+			}
+			return engine.ProductionBOM{
+				KnownProduct: true,
+				Parts:        slices.Clone(product.BOM),
+			}
+		},
+		ProductionRoute: func(ctx engine.ProductionRouteContext) engine.ProductionRouteStep {
+			product, ok := productByID[ctx.ProductID]
+			if !ok {
+				return engine.ProductionRouteStep{}
+			}
+
+			index := slices.Index(product.Route, ctx.CurrentStationID)
+			if index < 0 {
+				return engine.ProductionRouteStep{}
+			}
+			if index == len(product.Route)-1 {
+				return engine.ProductionRouteStep{Finished: true}
+			}
+			return engine.ProductionRouteStep{NextWorkstationID: product.Route[index+1]}
+		},
+		ProductionCost: func(ctx engine.ProductionCostContext) engine.ProductionCost {
+			workstation, ok := workstationByID[ctx.WorkstationID]
+			if !ok || workstation.CostPerUnit <= 0 {
+				return engine.ProductionCost{CostPerCapacityUnit: 1}
+			}
+			return engine.ProductionCost{CostPerCapacityUnit: workstation.CostPerUnit}
+		},
+		WorldUpdate: func(ctx *engine.WorldUpdateContext) error {
+			return d.applyDemand(ctx)
+		},
+	}
+}
+
+func (d Definition) SummaryLines() []string {
+	lines := []string{
+		fmt.Sprintf("scenario=%s (%s)", d.ID, d.DisplayName),
+		fmt.Sprintf("bottleneck=%s", d.Bottleneck.WorkstationID),
+		fmt.Sprintf("roles=%s", strings.Join(roleNames(d.RoleRoster), ", ")),
+	}
+	return lines
+}
+
+func (d Definition) partsByID() map[domain.PartID]Part {
+	items := make(map[domain.PartID]Part, len(d.Parts))
+	for _, item := range d.Parts {
+		items[item.ID] = item
+	}
+	return items
+}
+
+func (d Definition) productsByID() map[domain.ProductID]Product {
+	items := make(map[domain.ProductID]Product, len(d.Products))
+	for _, item := range d.Products {
+		items[item.ID] = item
+	}
+	return items
+}
+
+func (d Definition) workstationsByID() map[domain.WorkstationID]Workstation {
+	items := make(map[domain.WorkstationID]Workstation, len(d.Workstations))
+	for _, item := range d.Workstations {
+		items[item.ID] = item
+	}
+	return items
+}
+
+func (d Definition) customersByID() map[domain.CustomerID]Customer {
+	items := make(map[domain.CustomerID]Customer, len(d.Customers))
+	for _, item := range d.Customers {
+		items[item.ID] = item
+	}
+	return items
+}
+
+func (d Definition) applyDemand(ctx *engine.WorldUpdateContext) error {
+	if ctx == nil || ctx.State == nil {
+		return nil
+	}
+
+	customerByID := d.customersByID()
+	priceByProduct := currentOfferPrices(ctx.Round, d.Products)
+
+	for _, customerState := range ctx.State.Customers {
+		customer, ok := customerByID[customerState.CustomerID]
+		if !ok {
+			continue
+		}
+
+		for productID, offerPrice := range priceByProduct {
+			profile, ok := customer.DemandByProduct[productID]
+			if !ok {
+				continue
+			}
+
+			realized := realizedDemand(profile, customerState.Sentiment, offerPrice)
+			if realized <= 0 {
+				continue
+			}
+
+			entry := domain.BacklogEntry{
+				CustomerID:  customerState.CustomerID,
+				ProductID:   productID,
+				Quantity:    realized,
+				OriginRound: ctx.State.CurrentRound,
+			}
+			ctx.State.Plant.Backlog = append(ctx.State.Plant.Backlog, entry)
+			appendCustomerBacklog(ctx.State, customerState.CustomerID, entry)
+
+			ctx.AppendEvent(domain.EventDemandRealized, domain.ActorPlantSystem, fmt.Sprintf("Realized %d units of %s demand from %s", realized, productID, customerState.CustomerID), map[string]any{
+				"customer_id":        string(customerState.CustomerID),
+				"product_id":         string(productID),
+				"quantity":           int(realized),
+				"reference_price":    int(profile.ReferencePrice),
+				"offered_unit_price": int(offerPrice),
+				"sentiment":          customerState.Sentiment,
+			})
+			ctx.AppendEvent(domain.EventBacklogCreated, domain.ActorPlantSystem, fmt.Sprintf("Booked %d units of %s backlog for %s", realized, productID, customerState.CustomerID), map[string]any{
+				"customer_id": string(customerState.CustomerID),
+				"product_id":  string(productID),
+				"quantity":    int(realized),
+			})
+		}
+	}
+
+	return nil
+}
+
+func currentOfferPrices(round *domain.RoundRecord, products []Product) map[domain.ProductID]domain.Money {
+	prices := make(map[domain.ProductID]domain.Money, len(products))
+	for _, product := range products {
+		prices[product.ID] = product.BaseUnitCost * 2
+	}
+
+	if round == nil {
+		return prices
+	}
+
+	for _, action := range round.Actions {
+		if action.RoleID != domain.RoleSalesManager || action.Action.Sales == nil {
+			continue
+		}
+		for _, offer := range action.Action.Sales.ProductOffers {
+			if offer.UnitPrice > 0 {
+				prices[offer.ProductID] = offer.UnitPrice
+			}
+		}
+	}
+
+	return prices
+}
+
+func realizedDemand(profile DemandProfile, sentiment int, offeredPrice domain.Money) domain.Units {
+	sentimentModifier := max(1, sentiment) + 2
+	demandScore := int(profile.BaseDemand)*sentimentModifier - profile.PriceSensitivity*max(0, int(offeredPrice-profile.ReferencePrice))
+	return domain.Units(max(0, demandScore/5))
+}
+
+func appendCustomerBacklog(state *domain.MatchState, customerID domain.CustomerID, entry domain.BacklogEntry) {
+	for index := range state.Customers {
+		if state.Customers[index].CustomerID != customerID {
+			continue
+		}
+		state.Customers[index].Backlog = append(state.Customers[index].Backlog, entry)
+		return
+	}
+}
+
+func customerBacklog(backlog []domain.BacklogEntry, customerID domain.CustomerID) []domain.BacklogEntry {
+	items := make([]domain.BacklogEntry, 0)
+	for _, entry := range backlog {
+		if entry.CustomerID == customerID {
+			items = append(items, entry)
+		}
+	}
+	return items
+}
+
+func roleNames(roleIDs []domain.RoleID) []string {
+	names := make([]string, 0, len(roleIDs))
+	for _, roleID := range roleIDs {
+		names = append(names, string(roleID))
+	}
+	return names
+}

--- a/internal/scenario/starter.go
+++ b/internal/scenario/starter.go
@@ -1,155 +1,41 @@
 package scenario
 
-import (
-	"fmt"
-	"slices"
-	"strings"
-
-	"github.com/jpconstantineau/herbiego/internal/domain"
-	"github.com/jpconstantineau/herbiego/internal/engine"
-)
+import "github.com/jpconstantineau/herbiego/internal/domain"
 
 const (
 	// StarterID is the default playable scenario shipped with the MVP.
 	StarterID domain.ScenarioID = "starter"
 )
 
-type Definition struct {
-	ID                  domain.ScenarioID
-	DisplayName         string
-	Description         string
-	RoleRoster          []domain.RoleID
-	Products            []Product
-	Parts               []Part
-	Customers           []Customer
-	Workstations        []Workstation
-	Bottleneck          BottleneckAssumption
-	StartingTargets     domain.BudgetTargets
-	StartingPlant       domain.PlantState
-	DemandAssumptions   DemandAssumptions
-	DebtCeiling         domain.Money
-	DefaultHistoryLimit int
-}
-
-type Product struct {
-	ID           domain.ProductID
-	DisplayName  string
-	BOM          []domain.BOMLine
-	Route        []domain.WorkstationID
-	BaseUnitCost domain.Money
-}
-
-type Part struct {
-	ID          domain.PartID
-	DisplayName string
-	UnitCost    domain.Money
-	SupplierID  domain.SupplierID
-}
-
-type Customer struct {
-	ID              domain.CustomerID
-	DisplayName     string
-	StartingMood    int
-	DemandByProduct map[domain.ProductID]DemandProfile
-}
-
-type DemandProfile struct {
-	ReferencePrice   domain.Money
-	BaseDemand       domain.Units
-	PriceSensitivity int
-}
-
-type Workstation struct {
-	ID               domain.WorkstationID
-	DisplayName      string
-	CapacityPerRound domain.CapacityUnits
-	CostPerUnit      domain.Money
-}
-
-type BottleneckAssumption struct {
-	WorkstationID domain.WorkstationID
-	Summary       string
-}
-
-type DemandAssumptions struct {
-	BacklogExpiryRounds int
-}
-
 func Default() Definition {
 	return Starter()
 }
 
 func Starter() Definition {
-	return Definition{
-		ID:          StarterID,
-		DisplayName: "Prairie Pump Starter Plant",
-		Description: "A small pump-and-valve plant with constrained final assembly, limited cash, and enough demand pressure to create local-vs-global tension immediately.",
+	return NewDefinition(
+		StarterID,
+		"Prairie Pump Starter Plant",
+		"A small pump-and-valve plant with constrained final assembly, limited cash, and enough demand pressure to create local-vs-global tension immediately.",
+		StarterMatchSetup(),
+		StarterStartingConditions(),
+		StarterMarketModel(),
+		StarterProductionModel(),
+	)
+}
+
+func StarterMatchSetup() MatchSetup {
+	return MatchSetup{
+		ID:          "core_four_roles",
+		DisplayName: "Core Four Roles",
 		RoleRoster:  domain.CanonicalRoles(),
-		Parts: []Part{
-			{ID: "housing", DisplayName: "Housing", UnitCost: 3, SupplierID: "forgeco"},
-			{ID: "seal_kit", DisplayName: "Seal Kit", UnitCost: 2, SupplierID: "sealworks"},
-			{ID: "body", DisplayName: "Valve Body", UnitCost: 2, SupplierID: "forgeco"},
-			{ID: "fastener_kit", DisplayName: "Fastener Kit", UnitCost: 1, SupplierID: "fastenall"},
-		},
-		Products: []Product{
-			{
-				ID:          "pump",
-				DisplayName: "Pump",
-				BOM: []domain.BOMLine{
-					{PartID: "housing", Quantity: 1},
-					{PartID: "seal_kit", Quantity: 1},
-				},
-				Route:        []domain.WorkstationID{"fabrication", "assembly"},
-				BaseUnitCost: 8,
-			},
-			{
-				ID:          "valve",
-				DisplayName: "Valve",
-				BOM: []domain.BOMLine{
-					{PartID: "body", Quantity: 1},
-					{PartID: "fastener_kit", Quantity: 1},
-				},
-				Route:        []domain.WorkstationID{"fabrication", "assembly"},
-				BaseUnitCost: 5,
-			},
-		},
-		Customers: []Customer{
-			{
-				ID:           "northbuild",
-				DisplayName:  "NorthBuild",
-				StartingMood: 6,
-				DemandByProduct: map[domain.ProductID]DemandProfile{
-					"pump":  {ReferencePrice: 14, BaseDemand: 3, PriceSensitivity: 1},
-					"valve": {ReferencePrice: 9, BaseDemand: 2, PriceSensitivity: 1},
-				},
-			},
-			{
-				ID:           "prairieflow",
-				DisplayName:  "PrairieFlow",
-				StartingMood: 5,
-				DemandByProduct: map[domain.ProductID]DemandProfile{
-					"pump":  {ReferencePrice: 13, BaseDemand: 2, PriceSensitivity: 1},
-					"valve": {ReferencePrice: 8, BaseDemand: 3, PriceSensitivity: 1},
-				},
-			},
-			{
-				ID:           "agriworks",
-				DisplayName:  "AgriWorks",
-				StartingMood: 4,
-				DemandByProduct: map[domain.ProductID]DemandProfile{
-					"pump":  {ReferencePrice: 12, BaseDemand: 2, PriceSensitivity: 1},
-					"valve": {ReferencePrice: 8, BaseDemand: 2, PriceSensitivity: 1},
-				},
-			},
-		},
-		Workstations: []Workstation{
-			{ID: "fabrication", DisplayName: "Fabrication", CapacityPerRound: 7, CostPerUnit: 2},
-			{ID: "assembly", DisplayName: "Assembly", CapacityPerRound: 4, CostPerUnit: 3},
-		},
-		Bottleneck: BottleneckAssumption{
-			WorkstationID: "assembly",
-			Summary:       "Assembly is the chronic near-term bottleneck, so overselling or over-releasing work tends to inflate WIP and burn cash faster than throughput improves.",
-		},
+	}
+}
+
+func StarterStartingConditions() StartingConditions {
+	return StartingConditions{
+		ID:          "prairie_bootstrap",
+		DisplayName: "Prairie Bootstrap",
+		Description: "A solvent but cash-tight plant that starts with some WIP, one finished valve, and a small backlog already waiting.",
 		StartingTargets: domain.BudgetTargets{
 			EffectiveRound:        1,
 			ProcurementBudget:     18,
@@ -183,235 +69,91 @@ func Starter() Definition {
 				{CustomerID: "prairieflow", ProductID: "valve", Quantity: 1, OriginRound: 0},
 			},
 		},
+		Customers: []CustomerSeed{
+			{ID: "northbuild", DisplayName: "NorthBuild", Sentiment: 6},
+			{ID: "prairieflow", DisplayName: "PrairieFlow", Sentiment: 5},
+			{ID: "agriworks", DisplayName: "AgriWorks", Sentiment: 4},
+		},
+	}
+}
+
+func StarterMarketModel() MarketModel {
+	return MarketModel{
+		ID:          "regional_weekly_demand",
+		DisplayName: "Regional Weekly Demand",
+		Description: "Demand reacts to offered prices and customer sentiment, then rolls into next-round backlog.",
+		Customers: []CustomerMarket{
+			{
+				ID:          "northbuild",
+				DisplayName: "NorthBuild",
+				DemandByProduct: map[domain.ProductID]DemandProfile{
+					"pump":  {ReferencePrice: 14, BaseDemand: 3, PriceSensitivity: 1},
+					"valve": {ReferencePrice: 9, BaseDemand: 2, PriceSensitivity: 1},
+				},
+			},
+			{
+				ID:          "prairieflow",
+				DisplayName: "PrairieFlow",
+				DemandByProduct: map[domain.ProductID]DemandProfile{
+					"pump":  {ReferencePrice: 13, BaseDemand: 2, PriceSensitivity: 1},
+					"valve": {ReferencePrice: 8, BaseDemand: 3, PriceSensitivity: 1},
+				},
+			},
+			{
+				ID:          "agriworks",
+				DisplayName: "AgriWorks",
+				DemandByProduct: map[domain.ProductID]DemandProfile{
+					"pump":  {ReferencePrice: 12, BaseDemand: 2, PriceSensitivity: 1},
+					"valve": {ReferencePrice: 8, BaseDemand: 2, PriceSensitivity: 1},
+				},
+			},
+		},
 		DemandAssumptions: DemandAssumptions{
 			BacklogExpiryRounds: 2,
 		},
-		DefaultHistoryLimit: 10,
 	}
 }
 
-func (d Definition) InitialState(matchID domain.MatchID, roles []domain.RoleAssignment) domain.MatchState {
-	customers := make([]domain.CustomerState, 0, len(d.Customers))
-	for _, customer := range d.Customers {
-		customers = append(customers, domain.CustomerState{
-			CustomerID:  customer.ID,
-			DisplayName: customer.DisplayName,
-			Sentiment:   customer.StartingMood,
-			Backlog:     customerBacklog(d.StartingPlant.Backlog, customer.ID),
-		})
-	}
-
-	return domain.MatchState{
-		MatchID:       matchID,
-		ScenarioID:    d.ID,
-		CurrentRound:  1,
-		Roles:         slices.Clone(roles),
-		Plant:         d.StartingPlant.Clone(),
-		Customers:     customers,
-		ActiveTargets: d.StartingTargets,
-	}
-}
-
-func (d Definition) ResolverOptions() engine.Options {
-	partByID := d.partsByID()
-	productByID := d.productsByID()
-	workstationByID := d.workstationsByID()
-
-	return engine.Options{
-		HistoryLimit: d.DefaultHistoryLimit,
-		ProcurementTerms: func(ctx engine.ProcurementTermsContext) engine.ProcurementTerms {
-			part, ok := partByID[ctx.Order.PartID]
-			if !ok {
-				return engine.ProcurementTerms{UnitCost: 1}
-			}
-			return engine.ProcurementTerms{UnitCost: part.UnitCost}
+func StarterProductionModel() ProductionModel {
+	return ProductionModel{
+		ID:          "two_stage_pump_valve_line",
+		DisplayName: "Two-Stage Pump/Valve Line",
+		Description: "Two products share fabrication and assembly, with assembly intentionally sized as the tighter capacity pool.",
+		Parts: []Part{
+			{ID: "housing", DisplayName: "Housing", UnitCost: 3, SupplierID: "forgeco"},
+			{ID: "seal_kit", DisplayName: "Seal Kit", UnitCost: 2, SupplierID: "sealworks"},
+			{ID: "body", DisplayName: "Valve Body", UnitCost: 2, SupplierID: "forgeco"},
+			{ID: "fastener_kit", DisplayName: "Fastener Kit", UnitCost: 1, SupplierID: "fastenall"},
 		},
-		ProductionBOM: func(ctx engine.ProductionBOMContext) engine.ProductionBOM {
-			product, ok := productByID[ctx.ProductID]
-			if !ok {
-				return engine.ProductionBOM{}
-			}
-			return engine.ProductionBOM{
-				KnownProduct: true,
-				Parts:        slices.Clone(product.BOM),
-			}
+		Products: []Product{
+			{
+				ID:          "pump",
+				DisplayName: "Pump",
+				BOM: []domain.BOMLine{
+					{PartID: "housing", Quantity: 1},
+					{PartID: "seal_kit", Quantity: 1},
+				},
+				Route:        []domain.WorkstationID{"fabrication", "assembly"},
+				BaseUnitCost: 8,
+			},
+			{
+				ID:          "valve",
+				DisplayName: "Valve",
+				BOM: []domain.BOMLine{
+					{PartID: "body", Quantity: 1},
+					{PartID: "fastener_kit", Quantity: 1},
+				},
+				Route:        []domain.WorkstationID{"fabrication", "assembly"},
+				BaseUnitCost: 5,
+			},
 		},
-		ProductionRoute: func(ctx engine.ProductionRouteContext) engine.ProductionRouteStep {
-			product, ok := productByID[ctx.ProductID]
-			if !ok {
-				return engine.ProductionRouteStep{}
-			}
-
-			index := slices.Index(product.Route, ctx.CurrentStationID)
-			if index < 0 {
-				return engine.ProductionRouteStep{}
-			}
-			if index == len(product.Route)-1 {
-				return engine.ProductionRouteStep{Finished: true}
-			}
-			return engine.ProductionRouteStep{NextWorkstationID: product.Route[index+1]}
+		Workstations: []Workstation{
+			{ID: "fabrication", DisplayName: "Fabrication", CapacityPerRound: 7, CostPerUnit: 2},
+			{ID: "assembly", DisplayName: "Assembly", CapacityPerRound: 4, CostPerUnit: 3},
 		},
-		ProductionCost: func(ctx engine.ProductionCostContext) engine.ProductionCost {
-			workstation, ok := workstationByID[ctx.WorkstationID]
-			if !ok || workstation.CostPerUnit <= 0 {
-				return engine.ProductionCost{CostPerCapacityUnit: 1}
-			}
-			return engine.ProductionCost{CostPerCapacityUnit: workstation.CostPerUnit}
-		},
-		WorldUpdate: func(ctx *engine.WorldUpdateContext) error {
-			return d.applyDemand(ctx)
+		Bottleneck: BottleneckAssumption{
+			WorkstationID: "assembly",
+			Summary:       "Assembly is the chronic near-term bottleneck, so overselling or over-releasing work tends to inflate WIP and burn cash faster than throughput improves.",
 		},
 	}
-}
-
-func (d Definition) SummaryLines() []string {
-	lines := []string{
-		fmt.Sprintf("scenario=%s (%s)", d.ID, d.DisplayName),
-		fmt.Sprintf("bottleneck=%s", d.Bottleneck.WorkstationID),
-		fmt.Sprintf("roles=%s", strings.Join(roleNames(d.RoleRoster), ", ")),
-	}
-	return lines
-}
-
-func (d Definition) partsByID() map[domain.PartID]Part {
-	items := make(map[domain.PartID]Part, len(d.Parts))
-	for _, item := range d.Parts {
-		items[item.ID] = item
-	}
-	return items
-}
-
-func (d Definition) productsByID() map[domain.ProductID]Product {
-	items := make(map[domain.ProductID]Product, len(d.Products))
-	for _, item := range d.Products {
-		items[item.ID] = item
-	}
-	return items
-}
-
-func (d Definition) workstationsByID() map[domain.WorkstationID]Workstation {
-	items := make(map[domain.WorkstationID]Workstation, len(d.Workstations))
-	for _, item := range d.Workstations {
-		items[item.ID] = item
-	}
-	return items
-}
-
-func (d Definition) customersByID() map[domain.CustomerID]Customer {
-	items := make(map[domain.CustomerID]Customer, len(d.Customers))
-	for _, item := range d.Customers {
-		items[item.ID] = item
-	}
-	return items
-}
-
-func (d Definition) applyDemand(ctx *engine.WorldUpdateContext) error {
-	if ctx == nil || ctx.State == nil {
-		return nil
-	}
-
-	customerByID := d.customersByID()
-	priceByProduct := currentOfferPrices(ctx.Round, d.Products)
-
-	for _, customerState := range ctx.State.Customers {
-		customer, ok := customerByID[customerState.CustomerID]
-		if !ok {
-			continue
-		}
-
-		for productID, offerPrice := range priceByProduct {
-			profile, ok := customer.DemandByProduct[productID]
-			if !ok {
-				continue
-			}
-
-			realized := realizedDemand(profile, customerState.Sentiment, offerPrice)
-			if realized <= 0 {
-				continue
-			}
-
-			entry := domain.BacklogEntry{
-				CustomerID:  customerState.CustomerID,
-				ProductID:   productID,
-				Quantity:    realized,
-				OriginRound: ctx.State.CurrentRound,
-			}
-			ctx.State.Plant.Backlog = append(ctx.State.Plant.Backlog, entry)
-			appendCustomerBacklog(ctx.State, customerState.CustomerID, entry)
-
-			ctx.AppendEvent(domain.EventDemandRealized, domain.ActorPlantSystem, fmt.Sprintf("Realized %d units of %s demand from %s", realized, productID, customerState.CustomerID), map[string]any{
-				"customer_id":        string(customerState.CustomerID),
-				"product_id":         string(productID),
-				"quantity":           int(realized),
-				"reference_price":    int(profile.ReferencePrice),
-				"offered_unit_price": int(offerPrice),
-				"sentiment":          customerState.Sentiment,
-			})
-			ctx.AppendEvent(domain.EventBacklogCreated, domain.ActorPlantSystem, fmt.Sprintf("Booked %d units of %s backlog for %s", realized, productID, customerState.CustomerID), map[string]any{
-				"customer_id": string(customerState.CustomerID),
-				"product_id":  string(productID),
-				"quantity":    int(realized),
-			})
-		}
-	}
-
-	return nil
-}
-
-func currentOfferPrices(round *domain.RoundRecord, products []Product) map[domain.ProductID]domain.Money {
-	prices := make(map[domain.ProductID]domain.Money, len(products))
-	for _, product := range products {
-		prices[product.ID] = product.BaseUnitCost * 2
-	}
-
-	if round == nil {
-		return prices
-	}
-
-	for _, action := range round.Actions {
-		if action.RoleID != domain.RoleSalesManager || action.Action.Sales == nil {
-			continue
-		}
-		for _, offer := range action.Action.Sales.ProductOffers {
-			if offer.UnitPrice > 0 {
-				prices[offer.ProductID] = offer.UnitPrice
-			}
-		}
-	}
-
-	return prices
-}
-
-func realizedDemand(profile DemandProfile, sentiment int, offeredPrice domain.Money) domain.Units {
-	sentimentModifier := max(1, sentiment) + 2
-	demandScore := int(profile.BaseDemand)*sentimentModifier - profile.PriceSensitivity*max(0, int(offeredPrice-profile.ReferencePrice))
-	return domain.Units(max(0, demandScore/5))
-}
-
-func appendCustomerBacklog(state *domain.MatchState, customerID domain.CustomerID, entry domain.BacklogEntry) {
-	for index := range state.Customers {
-		if state.Customers[index].CustomerID != customerID {
-			continue
-		}
-		state.Customers[index].Backlog = append(state.Customers[index].Backlog, entry)
-		return
-	}
-}
-
-func customerBacklog(backlog []domain.BacklogEntry, customerID domain.CustomerID) []domain.BacklogEntry {
-	items := make([]domain.BacklogEntry, 0)
-	for _, entry := range backlog {
-		if entry.CustomerID == customerID {
-			items = append(items, entry)
-		}
-	}
-	return items
-}
-
-func roleNames(roleIDs []domain.RoleID) []string {
-	names := make([]string, 0, len(roleIDs))
-	for _, roleID := range roleIDs {
-		names = append(names, string(roleID))
-	}
-	return names
 }

--- a/internal/scenario/starter_test.go
+++ b/internal/scenario/starter_test.go
@@ -1,0 +1,135 @@
+package scenario_test
+
+import (
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func TestStarterInitialStateProvidesKnownPlayableSetup(t *testing.T) {
+	starter := scenario.Starter()
+
+	state := starter.InitialState("match-16", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "proc"},
+		{RoleID: domain.RoleProductionManager, PlayerID: "prod"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "fin"},
+	})
+
+	if got := state.ScenarioID; got != scenario.StarterID {
+		t.Fatalf("ScenarioID = %q, want %q", got, scenario.StarterID)
+	}
+	if got := state.CurrentRound; got != 1 {
+		t.Fatalf("CurrentRound = %d, want 1", got)
+	}
+	if got := state.Plant.Cash; got != 24 {
+		t.Fatalf("Plant.Cash = %d, want 24", got)
+	}
+	if got := state.Plant.DebtCeiling; got != 15 {
+		t.Fatalf("Plant.DebtCeiling = %d, want 15", got)
+	}
+	if got := len(state.Plant.PartsInventory); got != 4 {
+		t.Fatalf("PartsInventory len = %d, want 4", got)
+	}
+	if got := len(state.Customers); got != 3 {
+		t.Fatalf("Customers len = %d, want 3", got)
+	}
+	if got := len(state.Plant.Backlog); got != 2 {
+		t.Fatalf("Backlog len = %d, want 2", got)
+	}
+	if got := state.Plant.Workstations[1].WorkstationID; got != "assembly" {
+		t.Fatalf("bottleneck workstation = %q, want assembly", got)
+	}
+}
+
+func TestStarterResolverOptionsApplyScenarioHooks(t *testing.T) {
+	starter := scenario.Starter()
+	state := starter.InitialState("match-16", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "proc"},
+		{RoleID: domain.RoleProductionManager, PlayerID: "prod"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "fin"},
+	})
+	state.Plant.Backlog = nil
+	for index := range state.Customers {
+		state.Customers[index].Backlog = nil
+	}
+
+	resolver := engine.NewResolver(starter.ResolverOptions())
+	actions := []domain.ActionSubmission{
+		{
+			ActionID: "proc-1",
+			MatchID:  state.MatchID,
+			Round:    state.CurrentRound,
+			RoleID:   domain.RoleProcurementManager,
+			Action: domain.RoleAction{
+				Procurement: &domain.ProcurementAction{
+					Orders: []domain.PurchaseOrderIntent{
+						{PartID: "housing", SupplierID: "forgeco", Quantity: 1},
+					},
+				},
+			},
+		},
+		{
+			ActionID: "prod-1",
+			MatchID:  state.MatchID,
+			Round:    state.CurrentRound,
+			RoleID:   domain.RoleProductionManager,
+			Action: domain.RoleAction{
+				Production: &domain.ProductionAction{},
+			},
+		},
+		{
+			ActionID: "sales-1",
+			MatchID:  state.MatchID,
+			Round:    state.CurrentRound,
+			RoleID:   domain.RoleSalesManager,
+			Action: domain.RoleAction{
+				Sales: &domain.SalesAction{
+					ProductOffers: []domain.ProductOffer{
+						{ProductID: "pump", UnitPrice: 14},
+						{ProductID: "valve", UnitPrice: 9},
+					},
+				},
+			},
+		},
+		{
+			ActionID: "fin-1",
+			MatchID:  state.MatchID,
+			Round:    state.CurrentRound,
+			RoleID:   domain.RoleFinanceController,
+			Action: domain.RoleAction{
+				Finance: &domain.FinanceAction{
+					NextRoundTargets: state.ActiveTargets,
+				},
+			},
+		},
+	}
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.NextState.Plant.InTransitSupply[0].UnitCost; got != 3 {
+		t.Fatalf("housing unit cost = %d, want 3", got)
+	}
+	if got := len(result.NextState.Plant.Backlog); got == 0 {
+		t.Fatal("starter scenario demand hook did not create any backlog")
+	}
+	if !containsDemandEvent(result.Round.Events) {
+		t.Fatalf("Round.Events missing demand event: %#v", result.Round.Events)
+	}
+}
+
+func containsDemandEvent(events []domain.RoundEvent) bool {
+	for _, event := range events {
+		if event.Type == domain.EventDemandRealized {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scenario/starter_test.go
+++ b/internal/scenario/starter_test.go
@@ -43,6 +43,18 @@ func TestStarterInitialStateProvidesKnownPlayableSetup(t *testing.T) {
 	if got := state.Plant.Workstations[1].WorkstationID; got != "assembly" {
 		t.Fatalf("bottleneck workstation = %q, want assembly", got)
 	}
+	if got := starter.ProductionModel.Bottleneck.WorkstationID; got != "assembly" {
+		t.Fatalf("ProductionModel.Bottleneck = %q, want assembly", got)
+	}
+	if got := starter.StartingConditions.ID; got != "prairie_bootstrap" {
+		t.Fatalf("StartingConditions.ID = %q, want prairie_bootstrap", got)
+	}
+	if got := starter.MarketModel.ID; got != "regional_weekly_demand" {
+		t.Fatalf("MarketModel.ID = %q, want regional_weekly_demand", got)
+	}
+	if got := starter.ProductionModel.ID; got != "two_stage_pump_valve_line" {
+		t.Fatalf("ProductionModel.ID = %q, want two_stage_pump_valve_line", got)
+	}
 }
 
 func TestStarterResolverOptionsApplyScenarioHooks(t *testing.T) {
@@ -122,6 +134,78 @@ func TestStarterResolverOptionsApplyScenarioHooks(t *testing.T) {
 	}
 	if !containsDemandEvent(result.Round.Events) {
 		t.Fatalf("Round.Events missing demand event: %#v", result.Round.Events)
+	}
+}
+
+func TestScenarioComponentsCanBeSelectedIndependently(t *testing.T) {
+	starting := scenario.StarterStartingConditions()
+	starting.ID = "cash_heavy_bootstrap"
+	starting.StartingPlant.Cash = 40
+
+	market := scenario.StarterMarketModel()
+	market.ID = "quiet_market"
+	for customerIndex := range market.Customers {
+		for productID, profile := range market.Customers[customerIndex].DemandByProduct {
+			profile.BaseDemand = 1
+			market.Customers[customerIndex].DemandByProduct[productID] = profile
+		}
+	}
+
+	production := scenario.StarterProductionModel()
+	production.ID = "wide_open_capacity"
+	production.Workstations[1].CapacityPerRound = 8
+
+	definition := scenario.NewDefinition(
+		"mixed-starter",
+		"Mixed Starter",
+		"Composed from independently selected scenario components.",
+		scenario.StarterMatchSetup(),
+		starting,
+		market,
+		production,
+	)
+
+	if got := definition.StartingConditions.ID; got != "cash_heavy_bootstrap" {
+		t.Fatalf("StartingConditions.ID = %q, want cash_heavy_bootstrap", got)
+	}
+	if got := definition.MarketModel.ID; got != "quiet_market" {
+		t.Fatalf("MarketModel.ID = %q, want quiet_market", got)
+	}
+	if got := definition.ProductionModel.ID; got != "wide_open_capacity" {
+		t.Fatalf("ProductionModel.ID = %q, want wide_open_capacity", got)
+	}
+
+	state := definition.InitialState("mixed-match", nil)
+	if got := state.Plant.Cash; got != 40 {
+		t.Fatalf("Plant.Cash = %d, want 40", got)
+	}
+
+	resolver := engine.NewResolver(definition.ResolverOptions())
+	result, err := resolver.ResolveRound(state, []domain.ActionSubmission{
+		{
+			ActionID: "sales-1",
+			MatchID:  state.MatchID,
+			Round:    state.CurrentRound,
+			RoleID:   domain.RoleSalesManager,
+			Action: domain.RoleAction{
+				Sales: &domain.SalesAction{
+					ProductOffers: []domain.ProductOffer{
+						{ProductID: "pump", UnitPrice: 14},
+						{ProductID: "valve", UnitPrice: 9},
+					},
+				},
+			},
+		},
+	}, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.NextState.Plant.Workstations[1].CapacityPerRound; got != 8 {
+		t.Fatalf("assembly capacity = %d, want 8", got)
+	}
+	if len(result.NextState.Plant.Backlog) == 0 {
+		t.Fatal("composed scenario should still generate backlog")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a concrete starter scenario in `internal/scenario` with initial cash, inventory, demand assumptions, role roster, and an explicit assembly bottleneck
- wire runtime bootstrap to seed a default initial match from that scenario so the app starts from known state without manual setup
- make `cmd/quality verify` robust on Windows checkouts by ignoring CRLF-only differences during format verification and add tests for that behavior
- expose the seeded match in the CLI output and add tests covering scenario seeding plus scenario-driven resolver hooks

## Testing
- `go run ./cmd/quality verify`
- `go test ./cmd/quality`
- `go run ./cmd/herbiego -config herbiego.yaml`

Fixes #16

## Clarification Questions
1. For the MVP, do you want scenario content to stay Go-native for now, or should we start moving toward external data files before adding more scenarios?
2. Is the current market model direction right for MVP, where product offers create next-round customer backlog using scenario demand profiles, or do you want a thinner seed-only scenario in this issue and demand generation deferred to a later issue?