### PR TITLE
[codex] Implement shared player round contract

### DIFF
--- a/internal/adapters/player/human/player.go
+++ b/internal/adapters/player/human/player.go
@@ -1,0 +1,31 @@
+package human
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+type SubmitFunc func(context.Context, ports.RoundRequest) (domain.ActionSubmission, error)
+
+// Player adapts an interactive human controller to the shared player port.
+type Player struct {
+	submit SubmitFunc
+}
+
+func New(submit SubmitFunc) *Player {
+	return &Player{submit: submit}
+}
+
+func (p *Player) SubmitRound(ctx context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+	if p == nil || p.submit == nil {
+		return domain.ActionSubmission{}, fmt.Errorf("human player %q: submit handler is not configured", request.Assignment.RoleID)
+	}
+	return p.submit(ctx, request)
+}
+
+func (p *Player) RecoverFromNonResponse(_ context.Context, request ports.RoundRequest, cause error) (domain.ActionSubmission, error) {
+	return domain.ActionSubmission{}, fmt.Errorf("human player %q requires an explicit submission: %w", request.Assignment.RoleID, cause)
+}

--- a/internal/adapters/player/llm/player.go
+++ b/internal/adapters/player/llm/player.go
@@ -1,0 +1,90 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+type SubmitFunc func(context.Context, ports.RoundRequest) (domain.ActionSubmission, error)
+
+// Player adapts an AI-backed controller to the shared player port.
+type Player struct {
+	submit SubmitFunc
+}
+
+func New(submit SubmitFunc) *Player {
+	return &Player{submit: submit}
+}
+
+func (p *Player) SubmitRound(ctx context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+	if p == nil || p.submit == nil {
+		return domain.ActionSubmission{}, fmt.Errorf("llm player %q: submit handler is not configured", request.Assignment.RoleID)
+	}
+	return p.submit(ctx, request)
+}
+
+func (p *Player) RecoverFromNonResponse(_ context.Context, request ports.RoundRequest, cause error) (domain.ActionSubmission, error) {
+	if !nonResponsive(cause) {
+		return domain.ActionSubmission{}, fmt.Errorf("llm player %q: submit round: %w", request.Assignment.RoleID, cause)
+	}
+
+	if request.PreviousAcceptedAction != nil {
+		reused := request.PreviousAcceptedAction.Clone()
+		reused.Commentary = fallbackCommentary(request, "Previous action reused after AI timeout.")
+		return reused, nil
+	}
+
+	return domain.ActionSubmission{
+		Action:     safeNoOpAction(request),
+		Commentary: fallbackCommentary(request, "Safe no-op submitted after AI timeout."),
+	}, nil
+}
+
+func safeNoOpAction(request ports.RoundRequest) domain.RoleAction {
+	switch request.Assignment.RoleID {
+	case domain.RoleProcurementManager:
+		return domain.RoleAction{
+			Procurement: &domain.ProcurementAction{
+				Orders: []domain.PurchaseOrderIntent{},
+			},
+		}
+	case domain.RoleProductionManager:
+		return domain.RoleAction{
+			Production: &domain.ProductionAction{
+				Releases:           []domain.ProductionRelease{},
+				CapacityAllocation: []domain.CapacityAllocation{},
+			},
+		}
+	case domain.RoleSalesManager:
+		return domain.RoleAction{
+			Sales: &domain.SalesAction{
+				ProductOffers: []domain.ProductOffer{},
+			},
+		}
+	case domain.RoleFinanceController:
+		return domain.RoleAction{
+			Finance: &domain.FinanceAction{
+				NextRoundTargets: request.RoleView.ActiveTargets,
+			},
+		}
+	default:
+		return domain.RoleAction{}
+	}
+}
+
+func fallbackCommentary(request ports.RoundRequest, body string) domain.CommentaryRecord {
+	return domain.CommentaryRecord{
+		ActorID:    domain.ActorID(request.Assignment.PlayerID),
+		Visibility: domain.CommentaryPublic,
+		Body:       body,
+	}
+}
+
+func nonResponsive(err error) bool {
+	return errors.Is(err, ports.ErrNonResponsive) || errors.Is(err, context.DeadlineExceeded) || strings.Contains(strings.ToLower(err.Error()), "timeout")
+}

--- a/internal/adapters/player/llm/player.go
+++ b/internal/adapters/player/llm/player.go
@@ -11,14 +11,30 @@ import (
 )
 
 type SubmitFunc func(context.Context, ports.RoundRequest) (domain.ActionSubmission, error)
+type FallbackPolicy func(ports.RoundRequest, error) (domain.ActionSubmission, bool, error)
 
 // Player adapts an AI-backed controller to the shared player port.
 type Player struct {
-	submit SubmitFunc
+	submit   SubmitFunc
+	fallback FallbackPolicy
 }
 
-func New(submit SubmitFunc) *Player {
-	return &Player{submit: submit}
+type Option func(*Player)
+
+func WithFallbackPolicy(policy FallbackPolicy) Option {
+	return func(player *Player) {
+		player.fallback = policy
+	}
+}
+
+func New(submit SubmitFunc, options ...Option) *Player {
+	player := &Player{submit: submit}
+	for _, option := range options {
+		if option != nil {
+			option(player)
+		}
+	}
+	return player
 }
 
 func (p *Player) SubmitRound(ctx context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
@@ -31,6 +47,16 @@ func (p *Player) SubmitRound(ctx context.Context, request ports.RoundRequest) (d
 func (p *Player) RecoverFromNonResponse(_ context.Context, request ports.RoundRequest, cause error) (domain.ActionSubmission, error) {
 	if !nonResponsive(cause) {
 		return domain.ActionSubmission{}, fmt.Errorf("llm player %q: submit round: %w", request.Assignment.RoleID, cause)
+	}
+
+	if p != nil && p.fallback != nil {
+		submission, handled, err := p.fallback(request, cause)
+		if err != nil {
+			return domain.ActionSubmission{}, fmt.Errorf("llm player %q: fallback policy: %w", request.Assignment.RoleID, err)
+		}
+		if handled {
+			return submission, nil
+		}
 	}
 
 	if request.PreviousAcceptedAction != nil {

--- a/internal/app/round_collection.go
+++ b/internal/app/round_collection.go
@@ -38,6 +38,7 @@ func (c RoundCollector) Collect(ctx context.Context, state domain.MatchState, pr
 		request := ports.RoundRequest{
 			Assignment:             assignment,
 			RoleView:               projection.BuildRoundView(state, assignment.RoleID),
+			RoleReport:             projection.BuildRoleRoundReport(state, assignment.RoleID),
 			PreviousAcceptedAction: clonePrevious(previous[assignment.RoleID]),
 		}
 

--- a/internal/app/round_collection.go
+++ b/internal/app/round_collection.go
@@ -1,0 +1,129 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/projection"
+)
+
+// RoundCollector gathers one action submission per assigned role through the
+// shared player contract.
+type RoundCollector struct {
+	Players map[domain.RoleID]ports.Player
+	Now     func() time.Time
+}
+
+// Collect walks the assigned roles in stable match order so mixed human and AI
+// controllers can submit through the same orchestration path.
+func (c RoundCollector) Collect(ctx context.Context, state domain.MatchState, previous map[domain.RoleID]domain.ActionSubmission) ([]domain.ActionSubmission, error) {
+	if state.MatchID == "" {
+		return nil, fmt.Errorf("app: collect round %d: match id must not be empty", state.CurrentRound)
+	}
+	if state.CurrentRound <= 0 {
+		return nil, fmt.Errorf("app: collect round %d: round must be positive", state.CurrentRound)
+	}
+
+	now := c.now()
+	collected := make([]domain.ActionSubmission, 0, len(state.Roles))
+	for _, assignment := range state.Roles {
+		player, ok := c.Players[assignment.RoleID]
+		if !ok {
+			return nil, fmt.Errorf("app: collect round %d: player missing for role %q", state.CurrentRound, assignment.RoleID)
+		}
+
+		request := ports.RoundRequest{
+			Assignment:             assignment,
+			RoleView:               projection.BuildRoundView(state, assignment.RoleID),
+			PreviousAcceptedAction: clonePrevious(previous[assignment.RoleID]),
+		}
+
+		submission, err := player.SubmitRound(ctx, request)
+		if err != nil {
+			submission, err = player.RecoverFromNonResponse(ctx, request, err)
+			if err != nil {
+				return nil, fmt.Errorf("app: collect round %d for %q: %w", state.CurrentRound, assignment.RoleID, err)
+			}
+		}
+
+		collected = append(collected, normalizeSubmission(submission, request, now))
+	}
+
+	return collected, nil
+}
+
+func (c RoundCollector) now() time.Time {
+	if c.Now != nil {
+		return c.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func clonePrevious(previous domain.ActionSubmission) *domain.ActionSubmission {
+	if previous == (domain.ActionSubmission{}) {
+		return nil
+	}
+
+	cloned := previous.Clone()
+	return &cloned
+}
+
+func normalizeSubmission(submission domain.ActionSubmission, request ports.RoundRequest, now time.Time) domain.ActionSubmission {
+	submission.MatchID = request.RoleView.MatchID
+	submission.Round = request.RoleView.Round
+	submission.RoleID = request.Assignment.RoleID
+	submission.SubmittedAt = submittedAt(submission.SubmittedAt, now)
+	submission.ActionID = actionID(submission.ActionID, request)
+
+	commentary := submission.Commentary.Clone()
+	commentary.CommentaryID = commentaryID(commentary.CommentaryID, request)
+	commentary.MatchID = submission.MatchID
+	commentary.Round = submission.Round
+	commentary.RoleID = submission.RoleID
+	commentary.ActorID = commentaryActor(commentary.ActorID, request)
+	commentary.Visibility = commentaryVisibility(commentary.Visibility)
+	submission.Commentary = commentary
+
+	return submission
+}
+
+func submittedAt(value, fallback time.Time) time.Time {
+	if value.IsZero() {
+		return fallback
+	}
+	return value.UTC()
+}
+
+func actionID(existing domain.ActionID, request ports.RoundRequest) domain.ActionID {
+	if existing != "" {
+		return existing
+	}
+	return domain.ActionID(fmt.Sprintf("%s-r%d", request.Assignment.RoleID, request.RoleView.Round))
+}
+
+func commentaryID(existing domain.CommentaryID, request ports.RoundRequest) domain.CommentaryID {
+	if existing != "" {
+		return existing
+	}
+	return domain.CommentaryID(fmt.Sprintf("%s-commentary-r%d", request.Assignment.RoleID, request.RoleView.Round))
+}
+
+func commentaryActor(existing domain.ActorID, request ports.RoundRequest) domain.ActorID {
+	if existing != "" {
+		return existing
+	}
+	if request.Assignment.PlayerID != "" {
+		return domain.ActorID(request.Assignment.PlayerID)
+	}
+	return domain.ActorID(request.Assignment.RoleID)
+}
+
+func commentaryVisibility(existing domain.CommentaryVisibility) domain.CommentaryVisibility {
+	if existing != "" {
+		return existing
+	}
+	return domain.CommentaryPublic
+}

--- a/internal/app/round_collection_test.go
+++ b/internal/app/round_collection_test.go
@@ -18,11 +18,13 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 	now := time.Date(2026, time.April, 19, 16, 0, 0, 0, time.UTC)
 
 	collectedViews := map[domain.RoleID]domain.RoundView{}
+	collectedReports := map[domain.RoleID]domain.RoleRoundReport{}
 	collector := app.RoundCollector{
 		Now: func() time.Time { return now },
 		Players: map[domain.RoleID]ports.Player{
 			domain.RoleProcurementManager: human.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
 				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
+				collectedReports[request.Assignment.RoleID] = request.RoleReport.Clone()
 				return domain.ActionSubmission{
 					Action: domain.RoleAction{
 						Procurement: &domain.ProcurementAction{
@@ -36,6 +38,7 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 			}),
 			domain.RoleProductionManager: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
 				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
+				collectedReports[request.Assignment.RoleID] = request.RoleReport.Clone()
 				return domain.ActionSubmission{
 					Action: domain.RoleAction{
 						Production: &domain.ProductionAction{
@@ -52,6 +55,7 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 			}),
 			domain.RoleSalesManager: human.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
 				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
+				collectedReports[request.Assignment.RoleID] = request.RoleReport.Clone()
 				return domain.ActionSubmission{
 					Action: domain.RoleAction{
 						Sales: &domain.SalesAction{
@@ -65,6 +69,7 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 			}),
 			domain.RoleFinanceController: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
 				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
+				collectedReports[request.Assignment.RoleID] = request.RoleReport.Clone()
 				return domain.ActionSubmission{
 					Action: domain.RoleAction{
 						Finance: &domain.FinanceAction{
@@ -98,6 +103,16 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 		}
 		if view.ViewerRoleID != assignment.RoleID {
 			t.Fatalf("view.ViewerRoleID for %q = %q, want %q", assignment.RoleID, view.ViewerRoleID, assignment.RoleID)
+		}
+		report, ok := collectedReports[assignment.RoleID]
+		if !ok {
+			t.Fatalf("role %q did not receive a role report", assignment.RoleID)
+		}
+		if report.Department.RoleID != assignment.RoleID {
+			t.Fatalf("report.Department.RoleID for %q = %q, want %q", assignment.RoleID, report.Department.RoleID, assignment.RoleID)
+		}
+		if report.BonusReminder == "" {
+			t.Fatalf("report.BonusReminder for %q is empty", assignment.RoleID)
 		}
 	}
 	for _, action := range actions {
@@ -177,6 +192,59 @@ func TestRoundCollectorReusesPreviousActionWhenAIPlayerTimesOut(t *testing.T) {
 	}
 }
 
+func TestRoundCollectorUsesRoleSpecificAIFallbackPolicy(t *testing.T) {
+	state := fixtureMatchState()
+
+	collector := app.RoundCollector{
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProcurementManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return procurementSubmission(), nil
+			}),
+			domain.RoleProductionManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return productionSubmission(), nil
+			}),
+			domain.RoleSalesManager: llm.New(
+				func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+					return domain.ActionSubmission{}, ports.ErrNonResponsive
+				},
+				llm.WithFallbackPolicy(func(request ports.RoundRequest, cause error) (domain.ActionSubmission, bool, error) {
+					return domain.ActionSubmission{
+						Action: domain.RoleAction{
+							Sales: &domain.SalesAction{
+								ProductOffers: []domain.ProductOffer{
+									{ProductID: "pump", UnitPrice: 12},
+								},
+							},
+						},
+						Commentary: domain.CommentaryRecord{
+							Body: "Role-specific fallback policy submitted a conservative price.",
+						},
+					}, true, nil
+				}),
+			),
+			domain.RoleFinanceController: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return financeSubmission(), nil
+			}),
+		},
+	}
+
+	actions, err := collector.Collect(context.Background(), state, nil)
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+
+	sales := findAction(actions, domain.RoleSalesManager)
+	if sales == nil {
+		t.Fatal("sales action missing from collected results")
+	}
+	if got := sales.Action.Sales.ProductOffers[0].UnitPrice; got != 12 {
+		t.Fatalf("sales.ProductOffers[0].UnitPrice = %d, want 12", got)
+	}
+	if got := sales.Commentary.Body; got != "Role-specific fallback policy submitted a conservative price." {
+		t.Fatalf("sales.Commentary.Body = %q, want custom fallback commentary", got)
+	}
+}
+
 func TestRoundCollectorReturnsErrorWhenHumanPlayerDoesNotRespond(t *testing.T) {
 	state := fixtureMatchState()
 
@@ -240,6 +308,39 @@ func fixtureMatchState() domain.MatchState {
 			RecentRounds: []domain.RoundRecord{
 				{
 					Round: 1,
+					Events: []domain.RoundEvent{
+						{
+							Type: domain.EventDemandRealized,
+							Payload: map[string]any{
+								"product_id":         "pump",
+								"quantity":           2,
+								"offered_unit_price": 14,
+							},
+						},
+						{
+							Type: domain.EventFinishedGoodsProduced,
+							Payload: map[string]any{
+								"product_id":     "pump",
+								"quantity":       1,
+								"inventory_cost": 5,
+							},
+						},
+						{
+							Type: domain.EventProductionReleased,
+							Payload: map[string]any{
+								"product_id":    "pump",
+								"material_cost": 3,
+							},
+						},
+						{
+							Type: domain.EventShipmentCompleted,
+							Payload: map[string]any{
+								"product_id": "pump",
+								"quantity":   1,
+								"unit_price": 14,
+							},
+						},
+					},
 					Commentary: []domain.CommentaryRecord{
 						{Body: "Round one commentary."},
 					},

--- a/internal/app/round_collection_test.go
+++ b/internal/app/round_collection_test.go
@@ -1,0 +1,305 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/human"
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
+	state := fixtureMatchState()
+	now := time.Date(2026, time.April, 19, 16, 0, 0, 0, time.UTC)
+
+	collectedViews := map[domain.RoleID]domain.RoundView{}
+	collector := app.RoundCollector{
+		Now: func() time.Time { return now },
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProcurementManager: human.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Procurement: &domain.ProcurementAction{
+							Orders: []domain.PurchaseOrderIntent{
+								{PartID: "housing", SupplierID: "forgeco", Quantity: 2},
+							},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Keeping one round of buffer."},
+				}, nil
+			}),
+			domain.RoleProductionManager: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Production: &domain.ProductionAction{
+							Releases: []domain.ProductionRelease{
+								{ProductID: "pump", Quantity: 1},
+							},
+							CapacityAllocation: []domain.CapacityAllocation{
+								{WorkstationID: "fabrication", ProductID: "pump", Capacity: 1},
+							},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Protecting assembly flow."},
+				}, nil
+			}),
+			domain.RoleSalesManager: human.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Sales: &domain.SalesAction{
+							ProductOffers: []domain.ProductOffer{
+								{ProductID: "pump", UnitPrice: 14},
+							},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Holding the premium price."},
+				}, nil
+			}),
+			domain.RoleFinanceController: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Finance: &domain.FinanceAction{
+							NextRoundTargets: domain.BudgetTargets{
+								ProcurementBudget:     20,
+								ProductionSpendBudget: 16,
+								RevenueTarget:         30,
+								CashFloorTarget:       8,
+								DebtCeilingTarget:     18,
+							},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Preserving cash while funding throughput."},
+				}, nil
+			}),
+		},
+	}
+
+	actions, err := collector.Collect(context.Background(), state, nil)
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+
+	if got := len(actions); got != len(state.Roles) {
+		t.Fatalf("len(actions) = %d, want %d", got, len(state.Roles))
+	}
+	for _, assignment := range state.Roles {
+		view, ok := collectedViews[assignment.RoleID]
+		if !ok {
+			t.Fatalf("role %q did not receive a round view", assignment.RoleID)
+		}
+		if view.ViewerRoleID != assignment.RoleID {
+			t.Fatalf("view.ViewerRoleID for %q = %q, want %q", assignment.RoleID, view.ViewerRoleID, assignment.RoleID)
+		}
+	}
+	for _, action := range actions {
+		if action.MatchID != state.MatchID {
+			t.Fatalf("action.MatchID = %q, want %q", action.MatchID, state.MatchID)
+		}
+		if action.Round != state.CurrentRound {
+			t.Fatalf("action.Round = %d, want %d", action.Round, state.CurrentRound)
+		}
+		if action.SubmittedAt != now {
+			t.Fatalf("action.SubmittedAt = %s, want %s", action.SubmittedAt, now)
+		}
+		if action.Commentary.Visibility != domain.CommentaryPublic {
+			t.Fatalf("action.Commentary.Visibility = %q, want %q", action.Commentary.Visibility, domain.CommentaryPublic)
+		}
+	}
+}
+
+func TestRoundCollectorReusesPreviousActionWhenAIPlayerTimesOut(t *testing.T) {
+	state := fixtureMatchState()
+	now := time.Date(2026, time.April, 19, 17, 0, 0, 0, time.UTC)
+
+	previous := domain.ActionSubmission{
+		ActionID: "sales-r1",
+		MatchID:  state.MatchID,
+		Round:    1,
+		RoleID:   domain.RoleSalesManager,
+		Action: domain.RoleAction{
+			Sales: &domain.SalesAction{
+				ProductOffers: []domain.ProductOffer{
+					{ProductID: "pump", UnitPrice: 13},
+				},
+			},
+		},
+		Commentary: domain.CommentaryRecord{
+			Body: "Previous price held.",
+		},
+	}
+
+	collector := app.RoundCollector{
+		Now: func() time.Time { return now },
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProcurementManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return procurementSubmission(), nil
+			}),
+			domain.RoleProductionManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return productionSubmission(), nil
+			}),
+			domain.RoleSalesManager: llm.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return domain.ActionSubmission{}, context.DeadlineExceeded
+			}),
+			domain.RoleFinanceController: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return financeSubmission(), nil
+			}),
+		},
+	}
+
+	actions, err := collector.Collect(context.Background(), state, map[domain.RoleID]domain.ActionSubmission{
+		domain.RoleSalesManager: previous,
+	})
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+
+	sales := findAction(actions, domain.RoleSalesManager)
+	if sales == nil {
+		t.Fatal("sales action missing from collected results")
+	}
+	if got := sales.Round; got != state.CurrentRound {
+		t.Fatalf("sales.Round = %d, want %d", got, state.CurrentRound)
+	}
+	if got := sales.Action.Sales.ProductOffers[0].UnitPrice; got != 13 {
+		t.Fatalf("sales.ProductOffers[0].UnitPrice = %d, want 13", got)
+	}
+	if got := sales.Commentary.Body; got != "Previous action reused after AI timeout." {
+		t.Fatalf("sales.Commentary.Body = %q, want reuse message", got)
+	}
+}
+
+func TestRoundCollectorReturnsErrorWhenHumanPlayerDoesNotRespond(t *testing.T) {
+	state := fixtureMatchState()
+
+	collector := app.RoundCollector{
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProcurementManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return procurementSubmission(), nil
+			}),
+			domain.RoleProductionManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return productionSubmission(), nil
+			}),
+			domain.RoleSalesManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return domain.ActionSubmission{}, ports.ErrNonResponsive
+			}),
+			domain.RoleFinanceController: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return financeSubmission(), nil
+			}),
+		},
+	}
+
+	_, err := collector.Collect(context.Background(), state, nil)
+	if err == nil {
+		t.Fatal("Collect() error = nil, want human non-response error")
+	}
+	if !errors.Is(err, ports.ErrNonResponsive) {
+		t.Fatalf("Collect() error = %v, want ErrNonResponsive", err)
+	}
+}
+
+func fixtureMatchState() domain.MatchState {
+	return domain.MatchState{
+		MatchID:      "match-17",
+		ScenarioID:   "starter",
+		CurrentRound: 2,
+		Roles: []domain.RoleAssignment{
+			{RoleID: domain.RoleProcurementManager, PlayerID: "human-proc", IsHuman: true},
+			{RoleID: domain.RoleProductionManager, PlayerID: "ai-prod", Provider: "ollama", ModelName: "llama3.2:3b"},
+			{RoleID: domain.RoleSalesManager, PlayerID: "human-sales", IsHuman: true},
+			{RoleID: domain.RoleFinanceController, PlayerID: "ai-fin", Provider: "openrouter", ModelName: "openai/gpt-5-mini"},
+		},
+		Plant: domain.PlantState{
+			Cash:        24,
+			DebtCeiling: 15,
+			Workstations: []domain.WorkstationState{
+				{WorkstationID: "fabrication", CapacityPerRound: 4},
+				{WorkstationID: "assembly", CapacityPerRound: 3},
+			},
+		},
+		Customers: []domain.CustomerState{
+			{CustomerID: "northbuild", DisplayName: "NorthBuild", Sentiment: 6},
+		},
+		ActiveTargets: domain.BudgetTargets{
+			EffectiveRound:        2,
+			ProcurementBudget:     18,
+			ProductionSpendBudget: 14,
+			RevenueTarget:         28,
+			CashFloorTarget:       8,
+			DebtCeilingTarget:     15,
+		},
+		History: domain.RoundHistory{
+			RecentRounds: []domain.RoundRecord{
+				{
+					Round: 1,
+					Commentary: []domain.CommentaryRecord{
+						{Body: "Round one commentary."},
+					},
+				},
+			},
+		},
+	}
+}
+
+func procurementSubmission() domain.ActionSubmission {
+	return domain.ActionSubmission{
+		Action: domain.RoleAction{
+			Procurement: &domain.ProcurementAction{
+				Orders: []domain.PurchaseOrderIntent{
+					{PartID: "housing", SupplierID: "forgeco", Quantity: 1},
+				},
+			},
+		},
+		Commentary: domain.CommentaryRecord{Body: "Procurement ready."},
+	}
+}
+
+func productionSubmission() domain.ActionSubmission {
+	return domain.ActionSubmission{
+		Action: domain.RoleAction{
+			Production: &domain.ProductionAction{
+				Releases: []domain.ProductionRelease{
+					{ProductID: "pump", Quantity: 1},
+				},
+				CapacityAllocation: []domain.CapacityAllocation{
+					{WorkstationID: "fabrication", ProductID: "pump", Capacity: 1},
+				},
+			},
+		},
+		Commentary: domain.CommentaryRecord{Body: "Production ready."},
+	}
+}
+
+func financeSubmission() domain.ActionSubmission {
+	return domain.ActionSubmission{
+		Action: domain.RoleAction{
+			Finance: &domain.FinanceAction{
+				NextRoundTargets: domain.BudgetTargets{
+					ProcurementBudget:     18,
+					ProductionSpendBudget: 14,
+					RevenueTarget:         28,
+					CashFloorTarget:       8,
+					DebtCeilingTarget:     15,
+				},
+			},
+		},
+		Commentary: domain.CommentaryRecord{Body: "Finance ready."},
+	}
+}
+
+func findAction(actions []domain.ActionSubmission, roleID domain.RoleID) *domain.ActionSubmission {
+	for i := range actions {
+		if actions[i].RoleID == roleID {
+			return &actions[i]
+		}
+	}
+	return nil
+}

--- a/internal/domain/reports.go
+++ b/internal/domain/reports.go
@@ -1,0 +1,93 @@
+package domain
+
+import "slices"
+
+// RoleRoundReport is the player-facing report delivered alongside the round
+// view at the start of a round.
+type RoleRoundReport struct {
+	Companywide   CompanywidePerformanceReport
+	Department    DepartmentPerformanceReport
+	BonusReminder string
+}
+
+type CompanywidePerformanceReport struct {
+	NewSales                 []ProductValueSummary
+	UnshippedSales           []ProductValueSummary
+	SalesAtRisk              []ProductValueSummary
+	ProductsProducedLastWeek []ProductUnitSummary
+	CurrentInventoryLevels   InventoryValueSummary
+	Financials               []ProductFinancialSummary
+}
+
+type DepartmentPerformanceReport struct {
+	RoleID       RoleID
+	KeyMetrics   []MetricValue
+	DetailLines  []string
+	BonusSummary string
+}
+
+type ProductValueSummary struct {
+	ProductID   ProductID
+	Count       Units
+	TotalValue  Money
+	Description string
+}
+
+type ProductUnitSummary struct {
+	ProductID   ProductID
+	Count       Units
+	Description string
+}
+
+type InventoryValueSummary struct {
+	TotalValue Money
+	Detail     []InventoryBucketValue
+}
+
+type InventoryBucketValue struct {
+	Bucket     string
+	TotalValue Money
+}
+
+type ProductFinancialSummary struct {
+	ProductID          ProductID
+	Revenue            Money
+	ProductionCost     Money
+	PartsCost          Money
+	ContributionMargin Money
+}
+
+func (r RoleRoundReport) Clone() RoleRoundReport {
+	return RoleRoundReport{
+		Companywide:   r.Companywide.Clone(),
+		Department:    r.Department.Clone(),
+		BonusReminder: r.BonusReminder,
+	}
+}
+
+func (r CompanywidePerformanceReport) Clone() CompanywidePerformanceReport {
+	return CompanywidePerformanceReport{
+		NewSales:                 slices.Clone(r.NewSales),
+		UnshippedSales:           slices.Clone(r.UnshippedSales),
+		SalesAtRisk:              slices.Clone(r.SalesAtRisk),
+		ProductsProducedLastWeek: slices.Clone(r.ProductsProducedLastWeek),
+		CurrentInventoryLevels:   r.CurrentInventoryLevels.Clone(),
+		Financials:               slices.Clone(r.Financials),
+	}
+}
+
+func (r DepartmentPerformanceReport) Clone() DepartmentPerformanceReport {
+	return DepartmentPerformanceReport{
+		RoleID:       r.RoleID,
+		KeyMetrics:   slices.Clone(r.KeyMetrics),
+		DetailLines:  slices.Clone(r.DetailLines),
+		BonusSummary: r.BonusSummary,
+	}
+}
+
+func (s InventoryValueSummary) Clone() InventoryValueSummary {
+	return InventoryValueSummary{
+		TotalValue: s.TotalValue,
+		Detail:     slices.Clone(s.Detail),
+	}
+}

--- a/internal/ports/player.go
+++ b/internal/ports/player.go
@@ -1,0 +1,24 @@
+package ports
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+var ErrNonResponsive = errors.New("player did not respond")
+
+// Player presents one role-facing round contract regardless of whether the
+// controller behind it is human, AI, or another future player type.
+type Player interface {
+	SubmitRound(ctx context.Context, request RoundRequest) (domain.ActionSubmission, error)
+	RecoverFromNonResponse(ctx context.Context, request RoundRequest, cause error) (domain.ActionSubmission, error)
+}
+
+// RoundRequest is the full turn context delivered to a player for the active round.
+type RoundRequest struct {
+	Assignment             domain.RoleAssignment
+	RoleView               domain.RoundView
+	PreviousAcceptedAction *domain.ActionSubmission
+}

--- a/internal/ports/player.go
+++ b/internal/ports/player.go
@@ -20,5 +20,6 @@ type Player interface {
 type RoundRequest struct {
 	Assignment             domain.RoleAssignment
 	RoleView               domain.RoundView
+	RoleReport             domain.RoleRoundReport
 	PreviousAcceptedAction *domain.ActionSubmission
 }

--- a/internal/projection/role_report.go
+++ b/internal/projection/role_report.go
@@ -1,0 +1,296 @@
+package projection
+
+import (
+	"fmt"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+// BuildRoleRoundReport projects the role-specific report and bonus reminder
+// delivered with the canonical round view.
+func BuildRoleRoundReport(state domain.MatchState, viewerRoleID domain.RoleID) domain.RoleRoundReport {
+	return domain.RoleRoundReport{
+		Companywide:   buildCompanywidePerformanceReport(state),
+		Department:    buildDepartmentPerformanceReport(state, viewerRoleID),
+		BonusReminder: bonusReminder(viewerRoleID),
+	}
+}
+
+func buildCompanywidePerformanceReport(state domain.MatchState) domain.CompanywidePerformanceReport {
+	latestRound, ok := latestRound(state)
+
+	return domain.CompanywidePerformanceReport{
+		NewSales:                 newSalesSummary(latestRound, ok),
+		UnshippedSales:           backlogSummary(state.Plant.Backlog),
+		SalesAtRisk:              backlogAtRiskSummary(state.Plant.Backlog),
+		ProductsProducedLastWeek: producedSummary(latestRound, ok),
+		CurrentInventoryLevels:   inventorySummary(state.Plant),
+		Financials:               financialSummary(latestRound, ok),
+	}
+}
+
+func buildDepartmentPerformanceReport(state domain.MatchState, viewerRoleID domain.RoleID) domain.DepartmentPerformanceReport {
+	switch viewerRoleID {
+	case domain.RoleProcurementManager:
+		return domain.DepartmentPerformanceReport{
+			RoleID: viewerRoleID,
+			KeyMetrics: []domain.MetricValue{
+				{MetricID: "ordered_parts", Value: int(sumInTransitSupply(state.Plant.InTransitSupply)), DisplayUnit: "units"},
+				{MetricID: "parts_on_hand", Value: int(state.Metrics.PartsOnHandUnits), DisplayUnit: "units"},
+			},
+			DetailLines: []string{
+				fmt.Sprintf("In-transit supply totals %d units across open purchase orders.", sumInTransitSupply(state.Plant.InTransitSupply)),
+				fmt.Sprintf("On-hand parts inventory value is %d.", inventoryBucketTotal(state.Plant.PartsInventory)),
+			},
+			BonusSummary: bonusReminder(viewerRoleID),
+		}
+	case domain.RoleProductionManager:
+		return domain.DepartmentPerformanceReport{
+			RoleID: viewerRoleID,
+			KeyMetrics: []domain.MetricValue{
+				{MetricID: "wip_units", Value: int(sumWIPUnits(state.Plant.WIPInventory)), DisplayUnit: "units"},
+				{MetricID: "output_units", Value: int(state.Metrics.ProductionOutputUnits), DisplayUnit: "units"},
+			},
+			DetailLines: []string{
+				fmt.Sprintf("Current WIP totals %d units across active workstations.", sumWIPUnits(state.Plant.WIPInventory)),
+				fmt.Sprintf("Finished goods on hand total %d units.", state.Metrics.FinishedGoodsUnits),
+			},
+			BonusSummary: bonusReminder(viewerRoleID),
+		}
+	case domain.RoleSalesManager:
+		return domain.DepartmentPerformanceReport{
+			RoleID: viewerRoleID,
+			KeyMetrics: []domain.MetricValue{
+				{MetricID: "sales_pipeline", Value: int(sumBacklogUnits(state.Plant.Backlog)), DisplayUnit: "units"},
+				{MetricID: "throughput_revenue", Value: int(state.Metrics.ThroughputRevenue), DisplayUnit: "money"},
+			},
+			DetailLines: []string{
+				fmt.Sprintf("Open backlog totals %d units awaiting shipment.", sumBacklogUnits(state.Plant.Backlog)),
+				fmt.Sprintf("Latest realized throughput revenue is %d.", state.Metrics.ThroughputRevenue),
+			},
+			BonusSummary: bonusReminder(viewerRoleID),
+		}
+	case domain.RoleFinanceController:
+		return domain.DepartmentPerformanceReport{
+			RoleID: viewerRoleID,
+			KeyMetrics: []domain.MetricValue{
+				{MetricID: "margin", Value: int(state.Metrics.RoundProfit), DisplayUnit: "money"},
+				{MetricID: "cash_position", Value: int(state.Plant.Cash), DisplayUnit: "money"},
+			},
+			DetailLines: []string{
+				fmt.Sprintf("Current cash is %d against debt ceiling %d.", state.Plant.Cash, state.Plant.DebtCeiling),
+				fmt.Sprintf("Round profit most recently closed at %d.", state.Metrics.RoundProfit),
+			},
+			BonusSummary: bonusReminder(viewerRoleID),
+		}
+	default:
+		return domain.DepartmentPerformanceReport{
+			RoleID:       viewerRoleID,
+			BonusSummary: bonusReminder(viewerRoleID),
+		}
+	}
+}
+
+func bonusReminder(roleID domain.RoleID) string {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return "Bonus reminder: protect supply continuity and favorable part economics without starving plant cash."
+	case domain.RoleProductionManager:
+		return "Bonus reminder: keep throughput moving and WIP under control at the bottleneck."
+	case domain.RoleSalesManager:
+		return "Bonus reminder: sales compensation favors booked demand and shipped revenue."
+	case domain.RoleFinanceController:
+		return "Bonus reminder: maintain liquidity, margins, and target discipline."
+	default:
+		return "Bonus reminder: optimize for plant-wide performance."
+	}
+}
+
+func latestRound(state domain.MatchState) (domain.RoundRecord, bool) {
+	if len(state.History.RecentRounds) == 0 {
+		return domain.RoundRecord{}, false
+	}
+	return state.History.RecentRounds[len(state.History.RecentRounds)-1].Clone(), true
+}
+
+func newSalesSummary(round domain.RoundRecord, ok bool) []domain.ProductValueSummary {
+	if !ok {
+		return nil
+	}
+	summary := map[domain.ProductID]domain.ProductValueSummary{}
+	for _, event := range round.Events {
+		if event.Type != domain.EventDemandRealized {
+			continue
+		}
+		productID, _ := event.Payload["product_id"].(string)
+		quantity, _ := event.Payload["quantity"].(int)
+		unitPrice, _ := event.Payload["offered_unit_price"].(int)
+		item := summary[domain.ProductID(productID)]
+		item.ProductID = domain.ProductID(productID)
+		item.Count += domain.Units(quantity)
+		item.TotalValue += domain.Money(quantity * unitPrice)
+		item.Description = "New demand realized last round"
+		summary[item.ProductID] = item
+	}
+	return summaryValues(summary)
+}
+
+func backlogSummary(backlog []domain.BacklogEntry) []domain.ProductValueSummary {
+	summary := map[domain.ProductID]domain.ProductValueSummary{}
+	for _, entry := range backlog {
+		item := summary[entry.ProductID]
+		item.ProductID = entry.ProductID
+		item.Count += entry.Quantity
+		item.Description = "Unshipped backlog"
+		summary[item.ProductID] = item
+	}
+	return summaryValues(summary)
+}
+
+func backlogAtRiskSummary(backlog []domain.BacklogEntry) []domain.ProductValueSummary {
+	summary := map[domain.ProductID]domain.ProductValueSummary{}
+	for _, entry := range backlog {
+		if entry.AgeInRounds < 2 {
+			continue
+		}
+		item := summary[entry.ProductID]
+		item.ProductID = entry.ProductID
+		item.Count += entry.Quantity
+		item.Description = "Delayed backlog at expiry risk"
+		summary[item.ProductID] = item
+	}
+	return summaryValues(summary)
+}
+
+func producedSummary(round domain.RoundRecord, ok bool) []domain.ProductUnitSummary {
+	if !ok {
+		return nil
+	}
+	summary := map[domain.ProductID]domain.ProductUnitSummary{}
+	for _, event := range round.Events {
+		if event.Type != domain.EventFinishedGoodsProduced {
+			continue
+		}
+		productID, _ := event.Payload["product_id"].(string)
+		quantity, _ := event.Payload["quantity"].(int)
+		item := summary[domain.ProductID(productID)]
+		item.ProductID = domain.ProductID(productID)
+		item.Count += domain.Units(quantity)
+		item.Description = "Finished last round"
+		summary[item.ProductID] = item
+	}
+	return unitSummaryValues(summary)
+}
+
+func inventorySummary(plant domain.PlantState) domain.InventoryValueSummary {
+	return domain.InventoryValueSummary{
+		TotalValue: inventoryBucketTotal(plant.PartsInventory) + wipInventoryValue(plant.WIPInventory) + finishedInventoryValue(plant.FinishedInventory),
+		Detail: []domain.InventoryBucketValue{
+			{Bucket: "parts", TotalValue: inventoryBucketTotal(plant.PartsInventory)},
+			{Bucket: "wip", TotalValue: wipInventoryValue(plant.WIPInventory)},
+			{Bucket: "finished_goods", TotalValue: finishedInventoryValue(plant.FinishedInventory)},
+		},
+	}
+}
+
+func financialSummary(round domain.RoundRecord, ok bool) []domain.ProductFinancialSummary {
+	if !ok {
+		return nil
+	}
+	summary := map[domain.ProductID]domain.ProductFinancialSummary{}
+	for _, event := range round.Events {
+		productID, ok := event.Payload["product_id"].(string)
+		if !ok || productID == "" {
+			continue
+		}
+		item := summary[domain.ProductID(productID)]
+		item.ProductID = domain.ProductID(productID)
+		switch event.Type {
+		case domain.EventShipmentCompleted:
+			quantity, _ := event.Payload["quantity"].(int)
+			unitPrice, _ := event.Payload["unit_price"].(int)
+			item.Revenue += domain.Money(quantity * unitPrice)
+		case domain.EventFinishedGoodsProduced:
+			cost, _ := event.Payload["inventory_cost"].(int)
+			item.ProductionCost += domain.Money(cost)
+		case domain.EventProductionReleased:
+			cost, _ := event.Payload["material_cost"].(int)
+			item.PartsCost += domain.Money(cost)
+		}
+		item.ContributionMargin = item.Revenue - item.ProductionCost - item.PartsCost
+		summary[item.ProductID] = item
+	}
+	return financialValues(summary)
+}
+
+func sumBacklogUnits(backlog []domain.BacklogEntry) domain.Units {
+	total := domain.Units(0)
+	for _, entry := range backlog {
+		total += entry.Quantity
+	}
+	return total
+}
+
+func sumInTransitSupply(lots []domain.SupplyLot) domain.Units {
+	total := domain.Units(0)
+	for _, lot := range lots {
+		total += lot.Quantity
+	}
+	return total
+}
+
+func sumWIPUnits(items []domain.WIPInventory) domain.Units {
+	total := domain.Units(0)
+	for _, item := range items {
+		total += item.Quantity
+	}
+	return total
+}
+
+func inventoryBucketTotal(items []domain.PartInventory) domain.Money {
+	total := domain.Money(0)
+	for _, item := range items {
+		total += item.UnitCost * domain.Money(item.OnHandQty)
+	}
+	return total
+}
+
+func wipInventoryValue(items []domain.WIPInventory) domain.Money {
+	total := domain.Money(0)
+	for _, item := range items {
+		total += item.UnitCost * domain.Money(item.Quantity)
+	}
+	return total
+}
+
+func finishedInventoryValue(items []domain.FinishedInventory) domain.Money {
+	total := domain.Money(0)
+	for _, item := range items {
+		total += item.UnitCost * domain.Money(item.OnHandQty)
+	}
+	return total
+}
+
+func summaryValues(items map[domain.ProductID]domain.ProductValueSummary) []domain.ProductValueSummary {
+	values := make([]domain.ProductValueSummary, 0, len(items))
+	for _, item := range items {
+		values = append(values, item)
+	}
+	return values
+}
+
+func unitSummaryValues(items map[domain.ProductID]domain.ProductUnitSummary) []domain.ProductUnitSummary {
+	values := make([]domain.ProductUnitSummary, 0, len(items))
+	for _, item := range items {
+		values = append(values, item)
+	}
+	return values
+}
+
+func financialValues(items map[domain.ProductID]domain.ProductFinancialSummary) []domain.ProductFinancialSummary {
+	values := make([]domain.ProductFinancialSummary, 0, len(items))
+	for _, item := range items {
+		values = append(values, item)
+	}
+	return values
+}


### PR DESCRIPTION
## Summary
- add a shared `ports.Player` round contract for round-view delivery and action submission
- add an `internal/app` round collector that builds per-role views and collects mixed human/AI submissions without branching on player type
- add human and LLM adapters that implement the same interface, including adapter-owned non-response recovery behavior
- add projection-backed role reports and bonus reminders to the shared round request so prompts and UI can consume the same start-of-round reporting contract
- add a configurable LLM fallback policy hook so role-specific non-response defaults can be introduced without changing the collector contract
- add tests covering mixed controllers, AI timeout fallback, role-specific AI fallback policy, and human non-response blocking

Closes #17.

## Decisions Captured From PR Discussion
- human-controlled roles remain a hard block on non-response in MVP
- AI fallback is still deterministic by default, but role-specific policy hooks are now part of the adapter surface for finer-grained defaults
- the shared round request now carries role-specific reports and bonus reminders for prompt/display consumers

## Validation
- `go test ./internal/app ./internal/adapters/player/... ./internal/projection`
- `go run ./cmd/quality verify`
