### PR TITLE
Implement terminal action drafting and commentary flow

### DIFF
--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/player/human"
-	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/engine"
@@ -36,6 +35,10 @@ func main() {
 	runtime, err := app.Bootstrap(options)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "bootstrap failed:\n%v\n", err)
+		os.Exit(1)
+	}
+	if err := requireAllHuman(runtime); err != nil {
+		fmt.Fprintf(os.Stderr, "startup rejected:\n%v\n", err)
 		os.Exit(1)
 	}
 
@@ -71,16 +74,24 @@ func main() {
 func buildPlayers(runtime app.Runtime, controller *terminalController) map[domain.RoleID]ports.Player {
 	players := make(map[domain.RoleID]ports.Player, len(runtime.InitialMatch.Roles))
 	for _, assignment := range runtime.InitialMatch.Roles {
-		if assignment.IsHuman {
-			players[assignment.RoleID] = human.New(controller.submitRound)
-			continue
-		}
-
-		players[assignment.RoleID] = llm.New(func(context.Context, ports.RoundRequest) (domain.ActionSubmission, error) {
-			return domain.ActionSubmission{}, ports.ErrNonResponsive
-		})
+		players[assignment.RoleID] = human.New(controller.submitRound)
 	}
 	return players
+}
+
+func requireAllHuman(runtime app.Runtime) error {
+	required := len(runtime.InitialMatch.Roles)
+	if runtime.Config.HumanPlayers != required {
+		return fmt.Errorf("terminal gameplay currently requires -human-players=%d until AI turn submission is wired into the CLI", required)
+	}
+
+	for _, assignment := range runtime.InitialMatch.Roles {
+		if !assignment.IsHuman {
+			return fmt.Errorf("role %q is not human-controlled; terminal gameplay currently requires all four roles to be human-controlled", assignment.RoleID)
+		}
+	}
+
+	return nil
 }
 
 func printRuntimeSummary(runtime app.Runtime) {
@@ -99,10 +110,6 @@ func printRuntimeSummary(runtime app.Runtime) {
 		len(runtime.InitialMatch.Plant.Backlog),
 		runtime.RoleSummaries(),
 	)
-
-	if runtime.Config.HumanPlayers < len(runtime.InitialMatch.Roles) {
-		fmt.Fprintln(os.Stdout, "Non-human roles currently use a safe placeholder no-op action until provider-backed AI submissions are wired in.")
-	}
 }
 
 func summarizeCollectedSubmission(action domain.ActionSubmission) []string {

--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/human"
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
 	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
+	"github.com/jpconstantineau/herbiego/internal/ports"
 )
 
 func main() {
@@ -32,6 +39,51 @@ func main() {
 		os.Exit(1)
 	}
 
+	controller := newTerminalController(runtime.Scenario, os.Stdin, os.Stdout)
+	collector := app.RoundCollector{
+		Players: buildPlayers(runtime, controller),
+	}
+
+	printRuntimeSummary(runtime)
+
+	actions, err := collector.Collect(context.Background(), runtime.InitialMatch, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "round collection failed:\n%v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "Collected submissions:")
+	for _, action := range actions {
+		fmt.Fprintf(os.Stdout, "%s\n", strings.Join(summarizeCollectedSubmission(action), "\n"))
+	}
+
+	resolver := engine.NewResolver(runtime.Scenario.ResolverOptions())
+	result, err := resolver.ResolveRound(runtime.InitialMatch, actions, runtime.Random)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "round resolution failed:\n%v\n", err)
+		os.Exit(1)
+	}
+
+	printRoundResolution(result)
+}
+
+func buildPlayers(runtime app.Runtime, controller *terminalController) map[domain.RoleID]ports.Player {
+	players := make(map[domain.RoleID]ports.Player, len(runtime.InitialMatch.Roles))
+	for _, assignment := range runtime.InitialMatch.Roles {
+		if assignment.IsHuman {
+			players[assignment.RoleID] = human.New(controller.submitRound)
+			continue
+		}
+
+		players[assignment.RoleID] = llm.New(func(context.Context, ports.RoundRequest) (domain.ActionSubmission, error) {
+			return domain.ActionSubmission{}, ports.ErrNonResponsive
+		})
+	}
+	return players
+}
+
+func printRuntimeSummary(runtime app.Runtime) {
 	fmt.Fprintf(
 		os.Stdout,
 		"HerbieGo runtime initialized (env=%s, human_players=%d, seed=%d)\nscenario: %s (%s)\nmatch: %s round=%d cash=%d debt=%d backlog=%d\nroles: %v\n",
@@ -47,4 +99,44 @@ func main() {
 		len(runtime.InitialMatch.Plant.Backlog),
 		runtime.RoleSummaries(),
 	)
+
+	if runtime.Config.HumanPlayers < len(runtime.InitialMatch.Roles) {
+		fmt.Fprintln(os.Stdout, "Non-human roles currently use a safe placeholder no-op action until provider-backed AI submissions are wired in.")
+	}
+}
+
+func summarizeCollectedSubmission(action domain.ActionSubmission) []string {
+	lines := []string{
+		fmt.Sprintf("- %s", displayRoleName(action.RoleID)),
+	}
+	for _, line := range summarizeAction(action.Action) {
+		lines = append(lines, fmt.Sprintf("  %s", line))
+	}
+	lines = append(lines, fmt.Sprintf("  Commentary: %s", action.Commentary.Body))
+	return lines
+}
+
+func printRoundResolution(result engine.Result) {
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintf(os.Stdout, "Round %d resolved.\n", result.Round.Round)
+	fmt.Fprintf(
+		os.Stdout,
+		"Next round %d | Cash %d | Debt %d | Backlog %d | Revenue %d | Profit %d\n",
+		result.NextState.CurrentRound,
+		result.NextState.Plant.Cash,
+		result.NextState.Plant.Debt,
+		len(result.NextState.Plant.Backlog),
+		result.Round.Metrics.ThroughputRevenue,
+		result.Round.Metrics.RoundProfit,
+	)
+
+	fmt.Fprintln(os.Stdout, "Commentary:")
+	for _, note := range result.Round.Commentary {
+		fmt.Fprintf(os.Stdout, "- %s: %s\n", displayRoleName(note.RoleID), note.Body)
+	}
+
+	fmt.Fprintln(os.Stdout, "Events:")
+	for _, event := range result.Round.Events {
+		fmt.Fprintf(os.Stdout, "- %s\n", event.Summary)
+	}
 }

--- a/cmd/herbiego/main_test.go
+++ b/cmd/herbiego/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func TestRequireAllHumanRejectsMixedRuntime(t *testing.T) {
+	runtime := app.Runtime{
+		Config: app.Config{
+			HumanPlayers: 1,
+		},
+		Scenario: scenario.Starter(),
+		InitialMatch: domain.MatchState{
+			Roles: []domain.RoleAssignment{
+				{RoleID: domain.RoleProductionManager, IsHuman: true},
+				{RoleID: domain.RoleProcurementManager, IsHuman: false},
+				{RoleID: domain.RoleSalesManager, IsHuman: false},
+				{RoleID: domain.RoleFinanceController, IsHuman: false},
+			},
+		},
+	}
+
+	err := requireAllHuman(runtime)
+	if err == nil {
+		t.Fatal("requireAllHuman() error = nil, want mixed-runtime rejection")
+	}
+	if !strings.Contains(err.Error(), "-human-players=4") {
+		t.Fatalf("requireAllHuman() error = %v, want flag guidance", err)
+	}
+}
+
+func TestRequireAllHumanAcceptsFullyHumanRuntime(t *testing.T) {
+	runtime := app.Runtime{
+		Config: app.Config{
+			HumanPlayers: 4,
+		},
+		Scenario: scenario.Starter(),
+		InitialMatch: domain.MatchState{
+			Roles: []domain.RoleAssignment{
+				{RoleID: domain.RoleProductionManager, IsHuman: true},
+				{RoleID: domain.RoleProcurementManager, IsHuman: true},
+				{RoleID: domain.RoleSalesManager, IsHuman: true},
+				{RoleID: domain.RoleFinanceController, IsHuman: true},
+			},
+		},
+	}
+
+	if err := requireAllHuman(runtime); err != nil {
+		t.Fatalf("requireAllHuman() error = %v, want nil", err)
+	}
+}

--- a/cmd/herbiego/terminal_controller.go
+++ b/cmd/herbiego/terminal_controller.go
@@ -1,0 +1,479 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+type terminalController struct {
+	scenario scenario.Definition
+	reader   *bufio.Reader
+	writer   io.Writer
+}
+
+func newTerminalController(definition scenario.Definition, input io.Reader, output io.Writer) *terminalController {
+	return &terminalController{
+		scenario: definition,
+		reader:   bufio.NewReader(input),
+		writer:   output,
+	}
+}
+
+func (c *terminalController) submitRound(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+	for {
+		c.renderRoundIntro(request)
+
+		action, err := c.draftAction(request)
+		if err != nil {
+			return domain.ActionSubmission{}, err
+		}
+
+		commentary, err := c.promptRequiredLine("Commentary", "Explain your reasoning for this round.")
+		if err != nil {
+			return domain.ActionSubmission{}, err
+		}
+
+		submission := domain.ActionSubmission{
+			Action: action,
+			Commentary: domain.CommentaryRecord{
+				ActorID:    domain.ActorID(request.Assignment.PlayerID),
+				Visibility: domain.CommentaryPublic,
+				Body:       commentary,
+			},
+		}
+
+		c.renderSubmissionDraft(request, submission)
+		confirmed, err := c.promptYesNo("Submit this action", true)
+		if err != nil {
+			return domain.ActionSubmission{}, err
+		}
+		if confirmed {
+			return submission, nil
+		}
+
+		fmt.Fprintln(c.writer, "Submission discarded. Let's draft it again.")
+	}
+}
+
+func (c *terminalController) renderRoundIntro(request ports.RoundRequest) {
+	fmt.Fprintln(c.writer)
+	fmt.Fprintf(c.writer, "=== Round %d: %s ===\n", request.RoleView.Round, displayRoleName(request.Assignment.RoleID))
+	fmt.Fprintf(c.writer, "Cash %d | Debt %d | Backlog %d | Revenue %d | Profit %d\n",
+		request.RoleView.Plant.Cash,
+		request.RoleView.Plant.Debt,
+		len(request.RoleView.Plant.Backlog),
+		request.RoleView.Metrics.ThroughputRevenue,
+		request.RoleView.Metrics.RoundProfit,
+	)
+	fmt.Fprintf(c.writer, "Bonus focus: %s\n", request.RoleReport.BonusReminder)
+	for _, line := range request.RoleReport.Department.DetailLines {
+		fmt.Fprintf(c.writer, "- %s\n", line)
+	}
+	if request.PreviousAcceptedAction != nil {
+		fmt.Fprintf(c.writer, "Previous commentary: %s\n", request.PreviousAcceptedAction.Commentary.Body)
+	}
+}
+
+func (c *terminalController) draftAction(request ports.RoundRequest) (domain.RoleAction, error) {
+	switch request.Assignment.RoleID {
+	case domain.RoleProcurementManager:
+		orders, err := c.promptPurchaseOrders()
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		return domain.RoleAction{
+			Procurement: &domain.ProcurementAction{Orders: orders},
+		}, nil
+	case domain.RoleProductionManager:
+		releases, err := c.promptProductionReleases()
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		allocations, err := c.promptCapacityAllocations()
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		return domain.RoleAction{
+			Production: &domain.ProductionAction{
+				Releases:           releases,
+				CapacityAllocation: allocations,
+			},
+		}, nil
+	case domain.RoleSalesManager:
+		offers, err := c.promptProductOffers()
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		return domain.RoleAction{
+			Sales: &domain.SalesAction{ProductOffers: offers},
+		}, nil
+	case domain.RoleFinanceController:
+		targets, err := c.promptBudgetTargets(request.RoleView.ActiveTargets)
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		return domain.RoleAction{
+			Finance: &domain.FinanceAction{NextRoundTargets: targets},
+		}, nil
+	default:
+		return domain.RoleAction{}, fmt.Errorf("unsupported role %q", request.Assignment.RoleID)
+	}
+}
+
+func (c *terminalController) promptPurchaseOrders() ([]domain.PurchaseOrderIntent, error) {
+	fmt.Fprintf(c.writer, "Available parts: %s\n", strings.Join(c.partOptions(), ", "))
+	count, err := c.promptCount("How many purchase orders", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	orders := make([]domain.PurchaseOrderIntent, 0, count)
+	for index := range count {
+		partID, err := c.promptChoice(fmt.Sprintf("Order %d part", index+1), c.partOptions())
+		if err != nil {
+			return nil, err
+		}
+		quantity, err := c.promptNonNegativeInt(fmt.Sprintf("Order %d quantity", index+1), 0)
+		if err != nil {
+			return nil, err
+		}
+		orders = append(orders, domain.PurchaseOrderIntent{
+			PartID:     domain.PartID(partID),
+			SupplierID: c.supplierForPart(domain.PartID(partID)),
+			Quantity:   domain.Units(quantity),
+		})
+	}
+
+	return orders, nil
+}
+
+func (c *terminalController) promptProductionReleases() ([]domain.ProductionRelease, error) {
+	fmt.Fprintf(c.writer, "Products: %s\n", strings.Join(c.productOptions(), ", "))
+	count, err := c.promptCount("How many production releases", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	releases := make([]domain.ProductionRelease, 0, count)
+	for index := range count {
+		productID, err := c.promptChoice(fmt.Sprintf("Release %d product", index+1), c.productOptions())
+		if err != nil {
+			return nil, err
+		}
+		quantity, err := c.promptNonNegativeInt(fmt.Sprintf("Release %d quantity", index+1), 0)
+		if err != nil {
+			return nil, err
+		}
+		releases = append(releases, domain.ProductionRelease{
+			ProductID: domain.ProductID(productID),
+			Quantity:  domain.Units(quantity),
+		})
+	}
+
+	return releases, nil
+}
+
+func (c *terminalController) promptCapacityAllocations() ([]domain.CapacityAllocation, error) {
+	fmt.Fprintf(c.writer, "Workstations: %s\n", strings.Join(c.workstationOptions(), ", "))
+	count, err := c.promptCount("How many capacity allocations", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	allocations := make([]domain.CapacityAllocation, 0, count)
+	for index := range count {
+		workstationID, err := c.promptChoice(fmt.Sprintf("Allocation %d workstation", index+1), c.workstationOptions())
+		if err != nil {
+			return nil, err
+		}
+		productID, err := c.promptChoice(fmt.Sprintf("Allocation %d product", index+1), c.productOptions())
+		if err != nil {
+			return nil, err
+		}
+		capacity, err := c.promptNonNegativeInt(fmt.Sprintf("Allocation %d capacity", index+1), 0)
+		if err != nil {
+			return nil, err
+		}
+		allocations = append(allocations, domain.CapacityAllocation{
+			WorkstationID: domain.WorkstationID(workstationID),
+			ProductID:     domain.ProductID(productID),
+			Capacity:      domain.CapacityUnits(capacity),
+		})
+	}
+
+	return allocations, nil
+}
+
+func (c *terminalController) promptProductOffers() ([]domain.ProductOffer, error) {
+	fmt.Fprintf(c.writer, "Products: %s\n", strings.Join(c.productOptions(), ", "))
+	count, err := c.promptCount("How many product offers", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	offers := make([]domain.ProductOffer, 0, count)
+	for index := range count {
+		productID, err := c.promptChoice(fmt.Sprintf("Offer %d product", index+1), c.productOptions())
+		if err != nil {
+			return nil, err
+		}
+		unitPrice, err := c.promptNonNegativeInt(fmt.Sprintf("Offer %d unit price", index+1), 0)
+		if err != nil {
+			return nil, err
+		}
+		offers = append(offers, domain.ProductOffer{
+			ProductID: domain.ProductID(productID),
+			UnitPrice: domain.Money(unitPrice),
+		})
+	}
+
+	return offers, nil
+}
+
+func (c *terminalController) promptBudgetTargets(current domain.BudgetTargets) (domain.BudgetTargets, error) {
+	fmt.Fprintln(c.writer, "Leave the defaults in place if you just want to keep the current target posture.")
+
+	procurementBudget, err := c.promptNonNegativeInt("Next procurement budget", int(current.ProcurementBudget))
+	if err != nil {
+		return domain.BudgetTargets{}, err
+	}
+	productionBudget, err := c.promptNonNegativeInt("Next production spend budget", int(current.ProductionSpendBudget))
+	if err != nil {
+		return domain.BudgetTargets{}, err
+	}
+	revenueTarget, err := c.promptNonNegativeInt("Next revenue target", int(current.RevenueTarget))
+	if err != nil {
+		return domain.BudgetTargets{}, err
+	}
+	cashFloor, err := c.promptNonNegativeInt("Next cash floor target", int(current.CashFloorTarget))
+	if err != nil {
+		return domain.BudgetTargets{}, err
+	}
+	debtCeiling, err := c.promptNonNegativeInt("Next debt ceiling target", int(current.DebtCeilingTarget))
+	if err != nil {
+		return domain.BudgetTargets{}, err
+	}
+
+	return domain.BudgetTargets{
+		EffectiveRound:        current.EffectiveRound + 1,
+		ProcurementBudget:     domain.Money(procurementBudget),
+		ProductionSpendBudget: domain.Money(productionBudget),
+		RevenueTarget:         domain.Money(revenueTarget),
+		CashFloorTarget:       domain.Money(cashFloor),
+		DebtCeilingTarget:     domain.Money(debtCeiling),
+	}, nil
+}
+
+func (c *terminalController) renderSubmissionDraft(request ports.RoundRequest, submission domain.ActionSubmission) {
+	fmt.Fprintln(c.writer)
+	fmt.Fprintln(c.writer, "Draft submission:")
+	fmt.Fprintf(c.writer, "Role: %s\n", displayRoleName(request.Assignment.RoleID))
+	for _, line := range summarizeAction(submission.Action) {
+		fmt.Fprintf(c.writer, "- %s\n", line)
+	}
+	fmt.Fprintf(c.writer, "Commentary: %s\n", submission.Commentary.Body)
+}
+
+func summarizeAction(action domain.RoleAction) []string {
+	switch {
+	case action.Procurement != nil:
+		if len(action.Procurement.Orders) == 0 {
+			return []string{"No purchase orders"}
+		}
+
+		lines := make([]string, 0, len(action.Procurement.Orders))
+		for _, order := range action.Procurement.Orders {
+			lines = append(lines, fmt.Sprintf("Order %d of %s from %s", order.Quantity, order.PartID, order.SupplierID))
+		}
+		return lines
+	case action.Production != nil:
+		lines := make([]string, 0, len(action.Production.Releases)+len(action.Production.CapacityAllocation))
+		if len(action.Production.Releases) == 0 {
+			lines = append(lines, "No production releases")
+		}
+		for _, release := range action.Production.Releases {
+			lines = append(lines, fmt.Sprintf("Release %d of %s", release.Quantity, release.ProductID))
+		}
+		if len(action.Production.CapacityAllocation) == 0 {
+			lines = append(lines, "No capacity allocations")
+		}
+		for _, allocation := range action.Production.CapacityAllocation {
+			lines = append(lines, fmt.Sprintf("Allocate %d capacity at %s for %s", allocation.Capacity, allocation.WorkstationID, allocation.ProductID))
+		}
+		return lines
+	case action.Sales != nil:
+		if len(action.Sales.ProductOffers) == 0 {
+			return []string{"No product offers"}
+		}
+
+		lines := make([]string, 0, len(action.Sales.ProductOffers))
+		for _, offer := range action.Sales.ProductOffers {
+			lines = append(lines, fmt.Sprintf("Offer %s at %d", offer.ProductID, offer.UnitPrice))
+		}
+		return lines
+	case action.Finance != nil:
+		targets := action.Finance.NextRoundTargets
+		return []string{
+			fmt.Sprintf("Effective round %d", targets.EffectiveRound),
+			fmt.Sprintf("Procurement budget %d", targets.ProcurementBudget),
+			fmt.Sprintf("Production budget %d", targets.ProductionSpendBudget),
+			fmt.Sprintf("Revenue target %d", targets.RevenueTarget),
+			fmt.Sprintf("Cash floor %d", targets.CashFloorTarget),
+			fmt.Sprintf("Debt ceiling %d", targets.DebtCeilingTarget),
+		}
+	default:
+		return []string{"No action payload"}
+	}
+}
+
+func (c *terminalController) promptCount(label string, defaultValue int) (int, error) {
+	return c.promptNonNegativeInt(label, defaultValue)
+}
+
+func (c *terminalController) promptChoice(label string, options []string) (string, error) {
+	allowed := make(map[string]string, len(options))
+	for _, option := range options {
+		allowed[strings.ToLower(option)] = option
+	}
+
+	for {
+		value, err := c.promptLine(label, "")
+		if err != nil {
+			return "", err
+		}
+		choice, ok := allowed[strings.ToLower(value)]
+		if ok {
+			return choice, nil
+		}
+		fmt.Fprintf(c.writer, "Choose one of: %s\n", strings.Join(options, ", "))
+	}
+}
+
+func (c *terminalController) promptNonNegativeInt(label string, defaultValue int) (int, error) {
+	for {
+		value, err := c.promptLine(label, strconv.Itoa(defaultValue))
+		if err != nil {
+			return 0, err
+		}
+
+		number, convErr := strconv.Atoi(value)
+		if convErr == nil && number >= 0 {
+			return number, nil
+		}
+		fmt.Fprintln(c.writer, "Enter a whole number that is 0 or greater.")
+	}
+}
+
+func (c *terminalController) promptRequiredLine(label, help string) (string, error) {
+	for {
+		value, err := c.promptLine(label, "")
+		if err != nil {
+			return "", err
+		}
+		if strings.TrimSpace(value) != "" {
+			return value, nil
+		}
+		fmt.Fprintln(c.writer, help)
+	}
+}
+
+func (c *terminalController) promptYesNo(label string, defaultYes bool) (bool, error) {
+	defaultText := "y/N"
+	if defaultYes {
+		defaultText = "Y/n"
+	}
+
+	for {
+		fmt.Fprintf(c.writer, "%s [%s]: ", label, defaultText)
+		line, err := c.reader.ReadString('\n')
+		if err != nil {
+			return false, err
+		}
+
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "":
+			return defaultYes, nil
+		case "y", "yes":
+			return true, nil
+		case "n", "no":
+			return false, nil
+		default:
+			fmt.Fprintln(c.writer, "Enter y or n.")
+		}
+	}
+}
+
+func (c *terminalController) promptLine(label, defaultValue string) (string, error) {
+	if defaultValue == "" {
+		fmt.Fprintf(c.writer, "%s: ", label)
+	} else {
+		fmt.Fprintf(c.writer, "%s [%s]: ", label, defaultValue)
+	}
+
+	line, err := c.reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	value := strings.TrimSpace(line)
+	if value == "" && defaultValue != "" {
+		return defaultValue, nil
+	}
+	return value, nil
+}
+
+func (c *terminalController) partOptions() []string {
+	options := make([]string, 0, len(c.scenario.ProductionModel.Parts))
+	for _, part := range c.scenario.ProductionModel.Parts {
+		options = append(options, string(part.ID))
+	}
+	return options
+}
+
+func (c *terminalController) productOptions() []string {
+	options := make([]string, 0, len(c.scenario.ProductionModel.Products))
+	for _, product := range c.scenario.ProductionModel.Products {
+		options = append(options, string(product.ID))
+	}
+	return options
+}
+
+func (c *terminalController) workstationOptions() []string {
+	options := make([]string, 0, len(c.scenario.ProductionModel.Workstations))
+	for _, workstation := range c.scenario.ProductionModel.Workstations {
+		options = append(options, string(workstation.ID))
+	}
+	return options
+}
+
+func (c *terminalController) supplierForPart(partID domain.PartID) domain.SupplierID {
+	for _, part := range c.scenario.ProductionModel.Parts {
+		if part.ID == partID {
+			return part.SupplierID
+		}
+	}
+	return ""
+}
+
+func displayRoleName(roleID domain.RoleID) string {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return "Procurement Manager"
+	case domain.RoleProductionManager:
+		return "Production Manager"
+	case domain.RoleSalesManager:
+		return "Sales Manager"
+	case domain.RoleFinanceController:
+		return "Finance Controller"
+	default:
+		return string(roleID)
+	}
+}

--- a/cmd/herbiego/terminal_controller_test.go
+++ b/cmd/herbiego/terminal_controller_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func TestTerminalControllerProcurementSubmissionRequiresConfirmation(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		"1",
+		"housing",
+		"3",
+		"Building a small buffer.",
+		"n",
+		"1",
+		"seal_kit",
+		"2",
+		"Ordering only what assembly can absorb.",
+		"y",
+	}, "\n") + "\n")
+	output := &bytes.Buffer{}
+	controller := newTerminalController(scenario.Starter(), input, output)
+
+	submission, err := controller.submitRound(context.Background(), fixtureRequest(domain.RoleProcurementManager))
+	if err != nil {
+		t.Fatalf("submitRound() error = %v", err)
+	}
+
+	if got := len(submission.Action.Procurement.Orders); got != 1 {
+		t.Fatalf("len(Orders) = %d, want 1", got)
+	}
+	order := submission.Action.Procurement.Orders[0]
+	if order.PartID != "seal_kit" {
+		t.Fatalf("order.PartID = %q, want seal_kit", order.PartID)
+	}
+	if order.SupplierID != "sealworks" {
+		t.Fatalf("order.SupplierID = %q, want sealworks", order.SupplierID)
+	}
+	if order.Quantity != 2 {
+		t.Fatalf("order.Quantity = %d, want 2", order.Quantity)
+	}
+	if got := submission.Commentary.Body; got != "Ordering only what assembly can absorb." {
+		t.Fatalf("submission.Commentary.Body = %q, want final commentary", got)
+	}
+	if !strings.Contains(output.String(), "Submission discarded. Let's draft it again.") {
+		t.Fatalf("output missing redraft message:\n%s", output.String())
+	}
+}
+
+func TestTerminalControllerFinanceUsesCurrentTargetsAsDefaults(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		"",
+		"",
+		"",
+		"",
+		"",
+		"Keeping target posture stable while we learn the plant.",
+		"",
+	}, "\n") + "\n")
+	output := &bytes.Buffer{}
+	controller := newTerminalController(scenario.Starter(), input, output)
+
+	request := fixtureRequest(domain.RoleFinanceController)
+	request.RoleView.ActiveTargets = domain.BudgetTargets{
+		EffectiveRound:        3,
+		ProcurementBudget:     21,
+		ProductionSpendBudget: 17,
+		RevenueTarget:         33,
+		CashFloorTarget:       9,
+		DebtCeilingTarget:     14,
+	}
+
+	submission, err := controller.submitRound(context.Background(), request)
+	if err != nil {
+		t.Fatalf("submitRound() error = %v", err)
+	}
+
+	targets := submission.Action.Finance.NextRoundTargets
+	if targets.EffectiveRound != 4 {
+		t.Fatalf("targets.EffectiveRound = %d, want 4", targets.EffectiveRound)
+	}
+	if targets.ProcurementBudget != 21 || targets.ProductionSpendBudget != 17 || targets.RevenueTarget != 33 || targets.CashFloorTarget != 9 || targets.DebtCeilingTarget != 14 {
+		t.Fatalf("targets = %+v, want defaults copied forward", targets)
+	}
+}
+
+func TestTerminalControllerRejectsBlankCommentary(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		"1",
+		"pump",
+		"14",
+		"",
+		"Holding price while inventory is still thin.",
+		"y",
+	}, "\n") + "\n")
+	output := &bytes.Buffer{}
+	controller := newTerminalController(scenario.Starter(), input, output)
+
+	submission, err := controller.submitRound(context.Background(), fixtureRequest(domain.RoleSalesManager))
+	if err != nil {
+		t.Fatalf("submitRound() error = %v", err)
+	}
+
+	if got := submission.Commentary.Body; got != "Holding price while inventory is still thin." {
+		t.Fatalf("submission.Commentary.Body = %q, want recovered commentary", got)
+	}
+	if !strings.Contains(output.String(), "Explain your reasoning for this round.") {
+		t.Fatalf("output missing blank commentary prompt:\n%s", output.String())
+	}
+}
+
+func fixtureRequest(roleID domain.RoleID) ports.RoundRequest {
+	return ports.RoundRequest{
+		Assignment: domain.RoleAssignment{
+			RoleID:   roleID,
+			PlayerID: "human-role",
+			IsHuman:  true,
+		},
+		RoleView: domain.RoundView{
+			MatchID:      "starter-match",
+			Round:        1,
+			ViewerRoleID: roleID,
+			Plant: domain.PlantState{
+				Cash: 24,
+				Debt: 0,
+				Backlog: []domain.BacklogEntry{
+					{CustomerID: "northbuild", ProductID: "pump", Quantity: 2},
+				},
+			},
+			Metrics: domain.PlantMetrics{
+				ThroughputRevenue: 12,
+				RoundProfit:       3,
+			},
+			ActiveTargets: domain.BudgetTargets{
+				EffectiveRound:        1,
+				ProcurementBudget:     18,
+				ProductionSpendBudget: 14,
+				RevenueTarget:         28,
+				CashFloorTarget:       8,
+				DebtCeilingTarget:     15,
+			},
+		},
+		RoleReport: domain.RoleRoundReport{
+			Department: domain.DepartmentPerformanceReport{
+				RoleID:      roleID,
+				DetailLines: []string{"Role-specific detail line."},
+			},
+			BonusReminder: "Bonus reminder.",
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add a terminal controller that drafts role-specific human actions, captures required commentary, and confirms submission before accepting it
- wire `cmd/herbiego` into a playable single-round collect-and-resolve loop using the shared player contract and scenario resolver
- add controller tests covering confirmation retries, required commentary, and finance target defaults

## Verification
- `go test ./cmd/herbiego ./internal/app`
- `go run ./cmd/quality verify`
- scripted smoke run: `go run ./cmd/herbiego -human-players=1`

Closes #18.

## Clarification Questions
- For the near term, should the CLI keep using safe placeholder no-op submissions for non-human roles until provider integrations land, or should we require `-human-players=4` for the playable terminal loop so every round action is explicitly chosen by a person?