### PR TITLE
Add provider-neutral AI orchestration runner

### DIFF
--- a/internal/app/ai_orchestrator.go
+++ b/internal/app/ai_orchestrator.go
@@ -10,25 +10,32 @@ import (
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/prompting"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
 const (
 	defaultAIMaxAttempts   = 3
 	defaultAIMaxCommentary = 280
 	defaultAIMaxFocusTags  = 4
+	defaultAIMaxToolCalls  = 2
 )
 
 // AIOrchestrator assembles provider-neutral decision requests, executes them
 // through a narrow transport client, and validates the returned JSON contract.
 type AIOrchestrator struct {
-	Client      ports.DecisionClient
-	MaxAttempts int
+	Client       ports.DecisionClient
+	Scenario     scenario.Definition
+	MaxAttempts  int
+	MaxToolCalls int
 }
 
-func NewAIOrchestrator(client ports.DecisionClient) AIOrchestrator {
+func NewAIOrchestrator(definition scenario.Definition, client ports.DecisionClient) AIOrchestrator {
 	return AIOrchestrator{
-		Client:      client,
-		MaxAttempts: defaultAIMaxAttempts,
+		Client:       client,
+		Scenario:     definition,
+		MaxAttempts:  defaultAIMaxAttempts,
+		MaxToolCalls: defaultAIMaxToolCalls,
 	}
 }
 
@@ -52,6 +59,7 @@ func (o AIOrchestrator) BuildRequest(request ports.RoundRequest) ports.AIDecisio
 		RoundView:       request.RoleView.Clone(),
 		RoleReport:      request.RoleReport.Clone(),
 		AllowedActions:  allowedActionSchema(request.Assignment.RoleID),
+		Tools:           lookupTools(),
 		ResponseSpec: ports.ResponseFormatSpec{
 			RequireJSONOnly:     true,
 			AllowMarkdownFences: true,
@@ -75,6 +83,7 @@ func (o AIOrchestrator) Decide(ctx context.Context, request ports.AIDecisionRequ
 	attempts := max(1, o.MaxAttempts)
 	audit := ports.AIDecisionAudit{}
 	retryContext := request.RetryContext
+	toolCalls := 0
 
 	for attempt := range attempts {
 		audit.AttemptCount = attempt + 1
@@ -82,8 +91,8 @@ func (o AIOrchestrator) Decide(ctx context.Context, request ports.AIDecisionRequ
 		providerRequest := ports.ProviderDecisionRequest{
 			Provider:            request.Provider,
 			Model:               request.Model,
-			SystemPrompt:        buildSystemPrompt(request),
-			UserPrompt:          buildUserPrompt(request, retryContext),
+			SystemPrompt:        prompting.BuildSystemPrompt(request),
+			UserPrompt:          prompting.BuildUserPrompt(request, retryContext),
 			RequireJSONOnly:     request.ResponseSpec.RequireJSONOnly,
 			AllowMarkdownFences: request.ResponseSpec.AllowMarkdownFences,
 		}
@@ -93,9 +102,26 @@ func (o AIOrchestrator) Decide(ctx context.Context, request ports.AIDecisionRequ
 			return domain.ActionSubmission{}, audit, fmt.Errorf("app: ai decision runner: request decision: %w", err)
 		}
 
-		response, validationErrors, err := parseAndValidateDecision(result.RawResponse, request)
+		response, toolCall, validationErrors, err := parseAndValidateDecision(result.RawResponse, request)
 		if err == nil {
-			return responseToSubmission(response), audit, nil
+			if toolCall != nil {
+				toolCalls++
+				if toolCalls > max(0, o.MaxToolCalls) && o.MaxToolCalls > 0 {
+					validationErrors = []ports.ValidationError{{Path: "tool_call", Message: fmt.Sprintf("tool call budget exceeded; at most %d tool calls allowed", o.MaxToolCalls)}}
+				} else {
+					toolResult, toolErr := o.executeToolCall(*toolCall)
+					if toolErr != nil {
+						validationErrors = []ports.ValidationError{{Path: "tool_call", Message: toolErr.Error()}}
+					} else {
+						request.ToolResults = append(request.ToolResults, toolResult)
+						retryContext = nil
+						audit.ValidationErrors = nil
+						continue
+					}
+				}
+			} else {
+				return responseToSubmission(response), audit, nil
+			}
 		}
 
 		audit.ValidationErrors = validationErrors
@@ -139,96 +165,36 @@ func validateDecisionRequest(request ports.AIDecisionRequest) error {
 	return errorsJoin(errs...)
 }
 
-func buildSystemPrompt(request ports.AIDecisionRequest) string {
-	briefing := request.Briefing
-	var lines []string
-	lines = append(lines, "You are playing HerbieGo as one role in a hidden simultaneous-turn factory simulation.")
-	lines = append(lines, fmt.Sprintf("Return exactly one JSON object that matches contract version %s.", request.ContractVersion))
-	lines = append(lines, fmt.Sprintf("Role: %s (%s)", briefing.DisplayName, briefing.RoleID))
-	lines = append(lines, "Public responsibilities:")
-	for _, item := range briefing.PublicResponsibilities {
-		lines = append(lines, "- "+item)
-	}
-	lines = append(lines, "Hidden incentives:")
-	for _, item := range briefing.HiddenIncentives {
-		lines = append(lines, "- "+item)
-	}
-	lines = append(lines, "Decision principles:")
-	for _, item := range briefing.DecisionPrinciples {
-		lines = append(lines, "- "+item)
-	}
-	return strings.Join(lines, "\n")
-}
-
-func buildUserPrompt(request ports.AIDecisionRequest, retry *ports.RetryFeedback) string {
-	var sections []string
-
-	sections = append(sections, "## Contract Header\n"+mustJSON(map[string]any{
-		"contract_version": request.ContractVersion,
-		"match_id":         request.MatchID,
-		"round":            request.Round,
-		"role_id":          request.RoleID,
-		"provider":         request.Provider,
-		"model":            request.Model,
-	}))
-
-	sections = append(sections, "## Role Briefing\n"+mustJSON(request.Briefing))
-	sections = append(sections, "## Current Round Facts\n"+mustJSON(map[string]any{
-		"round_view":      request.RoundView,
-		"role_report":     request.RoleReport,
-		"previous_action": request.PreviousAction,
-	}))
-	sections = append(sections, "## Allowed Action Schema\n"+mustJSON(request.AllowedActions))
-	sections = append(sections, "## Response Format\n"+mustJSON(map[string]any{
-		"response_spec": request.ResponseSpec,
-		"example": map[string]any{
-			"contract_version": request.ContractVersion,
-			"match_id":         request.MatchID,
-			"round":            request.Round,
-			"role_id":          request.RoleID,
-			"action":           exampleAction(request.RoleID, request.RoundView.ActiveTargets),
-			"commentary": map[string]any{
-				"public_summary": "Explain the decision in one short player-facing sentence.",
-				"focus_tags":     []string{"throughput"},
-			},
-		},
-	}))
-
-	if retry != nil {
-		sections = append(sections, "## Retry Feedback\n"+mustJSON(retry))
-	}
-
-	sections = append(sections, "Return JSON only. Do not add prose before or after the JSON object.")
-	return strings.Join(sections, "\n\n")
-}
-
-func mustJSON(value any) string {
-	data, err := json.MarshalIndent(value, "", "  ")
-	if err != nil {
-		panic(fmt.Sprintf("app: ai decision runner: marshal prompt section: %v", err))
-	}
-	return string(data)
-}
-
-func parseAndValidateDecision(raw string, request ports.AIDecisionRequest) (ports.AIDecisionResponse, []ports.ValidationError, error) {
+func parseAndValidateDecision(raw string, request ports.AIDecisionRequest) (ports.AIDecisionResponse, *ports.LookupToolCall, []ports.ValidationError, error) {
 	payload, err := extractJSONObject(raw)
 	if err != nil {
 		validationErrors := []ports.ValidationError{{Path: "$", Message: err.Error()}}
-		return ports.AIDecisionResponse{}, validationErrors, err
+		return ports.AIDecisionResponse{}, nil, validationErrors, err
+	}
+
+	var toolEnvelope struct {
+		ToolCall *ports.LookupToolCall `json:"tool_call"`
+	}
+	if err := json.Unmarshal([]byte(payload), &toolEnvelope); err == nil && toolEnvelope.ToolCall != nil {
+		validationErrors := validateToolCall(*toolEnvelope.ToolCall, request.Tools)
+		if len(validationErrors) > 0 {
+			return ports.AIDecisionResponse{}, nil, validationErrors, fmt.Errorf("tool call failed validation")
+		}
+		return ports.AIDecisionResponse{}, toolEnvelope.ToolCall, nil, nil
 	}
 
 	var response ports.AIDecisionResponse
 	if err := json.Unmarshal([]byte(payload), &response); err != nil {
 		validationErrors := []ports.ValidationError{{Path: "$", Message: fmt.Sprintf("invalid JSON payload: %v", err)}}
-		return ports.AIDecisionResponse{}, validationErrors, err
+		return ports.AIDecisionResponse{}, nil, validationErrors, err
 	}
 
 	validationErrors := validateDecisionResponse(response, request)
 	if len(validationErrors) > 0 {
-		return ports.AIDecisionResponse{}, validationErrors, fmt.Errorf("response failed validation")
+		return ports.AIDecisionResponse{}, nil, validationErrors, fmt.Errorf("response failed validation")
 	}
 
-	return response, nil, nil
+	return response, nil, nil, nil
 }
 
 func extractJSONObject(raw string) (string, error) {
@@ -362,6 +328,32 @@ func validateDecisionResponse(response ports.AIDecisionResponse, request ports.A
 		}
 	}
 
+	return errs
+}
+
+func validateToolCall(call ports.LookupToolCall, tools []ports.LookupToolSpec) []ports.ValidationError {
+	var errs []ports.ValidationError
+	if strings.TrimSpace(call.ToolName) == "" {
+		errs = append(errs, ports.ValidationError{Path: "tool_call.tool_name", Message: "must not be empty"})
+		return errs
+	}
+
+	var selected *ports.LookupToolSpec
+	for i := range tools {
+		if tools[i].Name == call.ToolName {
+			selected = &tools[i]
+			break
+		}
+	}
+	if selected == nil {
+		return []ports.ValidationError{{Path: "tool_call.tool_name", Message: fmt.Sprintf("must match one of the available tools; got %q", call.ToolName)}}
+	}
+
+	for _, argument := range selected.Arguments {
+		if argument.Required && strings.TrimSpace(call.Arguments[argument.Name]) == "" {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("tool_call.arguments.%s", argument.Name), Message: "must not be empty"})
+		}
+	}
 	return errs
 }
 
@@ -575,36 +567,6 @@ func allowedActionSchema(roleID domain.RoleID) ports.AllowedActionSchema {
 	}
 }
 
-func exampleAction(roleID domain.RoleID, targets domain.BudgetTargets) domain.RoleAction {
-	switch roleID {
-	case domain.RoleProcurementManager:
-		return domain.RoleAction{
-			Procurement: &domain.ProcurementAction{
-				Orders: []domain.PurchaseOrderIntent{{PartID: "housing", SupplierID: "forgeco", Quantity: 1}},
-			},
-		}
-	case domain.RoleProductionManager:
-		return domain.RoleAction{
-			Production: &domain.ProductionAction{
-				Releases:           []domain.ProductionRelease{{ProductID: "pump", Quantity: 1}},
-				CapacityAllocation: []domain.CapacityAllocation{{WorkstationID: "fabrication", ProductID: "pump", Capacity: 1}},
-			},
-		}
-	case domain.RoleSalesManager:
-		return domain.RoleAction{
-			Sales: &domain.SalesAction{
-				ProductOffers: []domain.ProductOffer{{ProductID: "pump", UnitPrice: 14}},
-			},
-		}
-	case domain.RoleFinanceController:
-		return domain.RoleAction{
-			Finance: &domain.FinanceAction{NextRoundTargets: targets},
-		}
-	default:
-		return domain.RoleAction{}
-	}
-}
-
 func productSet(view domain.RoundView) map[domain.ProductID]bool {
 	products := make(map[domain.ProductID]bool)
 	for _, item := range view.Plant.WIPInventory {
@@ -645,4 +607,126 @@ func clonePreviousForDecision(previous *domain.ActionSubmission) *domain.ActionS
 
 func errorsJoin(errs ...error) error {
 	return errors.Join(errs...)
+}
+
+func lookupTools() []ports.LookupToolSpec {
+	return []ports.LookupToolSpec{
+		{
+			Name:        "list_valid_suppliers",
+			Description: "Return the valid suppliers for one part in the active scenario.",
+			Arguments: []ports.LookupToolArgument{
+				{Name: "part_id", Description: "Canonical part identifier.", Required: true},
+			},
+		},
+		{
+			Name:        "show_product_route",
+			Description: "Return the ordered workstation route for one product.",
+			Arguments: []ports.LookupToolArgument{
+				{Name: "product_id", Description: "Canonical product identifier.", Required: true},
+			},
+		},
+		{
+			Name:        "show_product_bom",
+			Description: "Return the bill of materials for one product.",
+			Arguments: []ports.LookupToolArgument{
+				{Name: "product_id", Description: "Canonical product identifier.", Required: true},
+			},
+		},
+		{
+			Name:        "show_customer_demand_profile",
+			Description: "Return the known demand settings for one customer and product pair.",
+			Arguments: []ports.LookupToolArgument{
+				{Name: "customer_id", Description: "Canonical customer identifier.", Required: true},
+				{Name: "product_id", Description: "Canonical product identifier.", Required: true},
+			},
+		},
+	}
+}
+
+func (o AIOrchestrator) executeToolCall(call ports.LookupToolCall) (ports.LookupToolResult, error) {
+	if o.Scenario.ID == "" {
+		return ports.LookupToolResult{}, fmt.Errorf("scenario lookups are not configured")
+	}
+
+	switch call.ToolName {
+	case "list_valid_suppliers":
+		partID := domain.PartID(call.Arguments["part_id"])
+		part, ok := o.Scenario.Part(partID)
+		if !ok {
+			return ports.LookupToolResult{}, fmt.Errorf("unknown part_id %q", partID)
+		}
+		return ports.LookupToolResult{
+			ToolName:  call.ToolName,
+			Arguments: mapsClone(call.Arguments),
+			Result: map[string]any{
+				"part_id":      part.ID,
+				"display_name": part.DisplayName,
+				"suppliers":    []domain.SupplierID{part.SupplierID},
+			},
+		}, nil
+	case "show_product_route":
+		productID := domain.ProductID(call.Arguments["product_id"])
+		product, ok := o.Scenario.Product(productID)
+		if !ok {
+			return ports.LookupToolResult{}, fmt.Errorf("unknown product_id %q", productID)
+		}
+		return ports.LookupToolResult{
+			ToolName:  call.ToolName,
+			Arguments: mapsClone(call.Arguments),
+			Result: map[string]any{
+				"product_id":    product.ID,
+				"display_name":  product.DisplayName,
+				"route":         slices.Clone(product.Route),
+				"bottleneck_id": o.Scenario.ProductionModel.Bottleneck.WorkstationID,
+			},
+		}, nil
+	case "show_product_bom":
+		productID := domain.ProductID(call.Arguments["product_id"])
+		product, ok := o.Scenario.Product(productID)
+		if !ok {
+			return ports.LookupToolResult{}, fmt.Errorf("unknown product_id %q", productID)
+		}
+		return ports.LookupToolResult{
+			ToolName:  call.ToolName,
+			Arguments: mapsClone(call.Arguments),
+			Result: map[string]any{
+				"product_id":   product.ID,
+				"display_name": product.DisplayName,
+				"bom":          slices.Clone(product.BOM),
+			},
+		}, nil
+	case "show_customer_demand_profile":
+		customerID := domain.CustomerID(call.Arguments["customer_id"])
+		productID := domain.ProductID(call.Arguments["product_id"])
+		customer, ok := o.Scenario.Customer(customerID)
+		if !ok {
+			return ports.LookupToolResult{}, fmt.Errorf("unknown customer_id %q", customerID)
+		}
+		profile, ok := customer.DemandByProduct[productID]
+		if !ok {
+			return ports.LookupToolResult{}, fmt.Errorf("customer %q has no demand profile for product %q", customerID, productID)
+		}
+		return ports.LookupToolResult{
+			ToolName:  call.ToolName,
+			Arguments: mapsClone(call.Arguments),
+			Result: map[string]any{
+				"customer_id":       customer.ID,
+				"customer_name":     customer.DisplayName,
+				"product_id":        productID,
+				"reference_price":   profile.ReferencePrice,
+				"base_demand":       profile.BaseDemand,
+				"price_sensitivity": profile.PriceSensitivity,
+			},
+		}, nil
+	default:
+		return ports.LookupToolResult{}, fmt.Errorf("unsupported tool %q", call.ToolName)
+	}
+}
+
+func mapsClone(items map[string]string) map[string]string {
+	cloned := make(map[string]string, len(items))
+	for key, value := range items {
+		cloned[key] = value
+	}
+	return cloned
 }

--- a/internal/app/ai_orchestrator.go
+++ b/internal/app/ai_orchestrator.go
@@ -1,0 +1,648 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+const (
+	defaultAIMaxAttempts   = 3
+	defaultAIMaxCommentary = 280
+	defaultAIMaxFocusTags  = 4
+)
+
+// AIOrchestrator assembles provider-neutral decision requests, executes them
+// through a narrow transport client, and validates the returned JSON contract.
+type AIOrchestrator struct {
+	Client      ports.DecisionClient
+	MaxAttempts int
+}
+
+func NewAIOrchestrator(client ports.DecisionClient) AIOrchestrator {
+	return AIOrchestrator{
+		Client:      client,
+		MaxAttempts: defaultAIMaxAttempts,
+	}
+}
+
+// SubmitRound adapts the shared round request into the AI decision runner.
+func (o AIOrchestrator) SubmitRound(ctx context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+	submission, _, err := o.Decide(ctx, o.BuildRequest(request))
+	return submission, err
+}
+
+// BuildRequest converts the round request into the canonical provider-neutral
+// AI decision contract.
+func (o AIOrchestrator) BuildRequest(request ports.RoundRequest) ports.AIDecisionRequest {
+	return ports.AIDecisionRequest{
+		ContractVersion: ports.AIDecisionContractVersion,
+		MatchID:         request.RoleView.MatchID,
+		Round:           request.RoleView.Round,
+		RoleID:          request.Assignment.RoleID,
+		Provider:        request.Assignment.Provider,
+		Model:           request.Assignment.ModelName,
+		Briefing:        roleBriefing(request.Assignment.RoleID),
+		RoundView:       request.RoleView.Clone(),
+		RoleReport:      request.RoleReport.Clone(),
+		AllowedActions:  allowedActionSchema(request.Assignment.RoleID),
+		ResponseSpec: ports.ResponseFormatSpec{
+			RequireJSONOnly:     true,
+			AllowMarkdownFences: true,
+			MaxCommentaryChars:  defaultAIMaxCommentary,
+			MaxFocusTags:        defaultAIMaxFocusTags,
+		},
+		PreviousAction: clonePreviousForDecision(request.PreviousAcceptedAction),
+	}
+}
+
+// Decide executes the AI request with deterministic retries and fallback.
+func (o AIOrchestrator) Decide(ctx context.Context, request ports.AIDecisionRequest) (domain.ActionSubmission, ports.AIDecisionAudit, error) {
+	if o.Client == nil {
+		return domain.ActionSubmission{}, ports.AIDecisionAudit{}, fmt.Errorf("app: ai decision runner: decision client is not configured")
+	}
+
+	if err := validateDecisionRequest(request); err != nil {
+		return domain.ActionSubmission{}, ports.AIDecisionAudit{}, fmt.Errorf("app: ai decision runner: %w", err)
+	}
+
+	attempts := max(1, o.MaxAttempts)
+	audit := ports.AIDecisionAudit{}
+	retryContext := request.RetryContext
+
+	for attempt := range attempts {
+		audit.AttemptCount = attempt + 1
+
+		providerRequest := ports.ProviderDecisionRequest{
+			Provider:            request.Provider,
+			Model:               request.Model,
+			SystemPrompt:        buildSystemPrompt(request),
+			UserPrompt:          buildUserPrompt(request, retryContext),
+			RequireJSONOnly:     request.ResponseSpec.RequireJSONOnly,
+			AllowMarkdownFences: request.ResponseSpec.AllowMarkdownFences,
+		}
+
+		result, err := o.Client.RequestDecision(ctx, providerRequest)
+		if err != nil {
+			return domain.ActionSubmission{}, audit, fmt.Errorf("app: ai decision runner: request decision: %w", err)
+		}
+
+		response, validationErrors, err := parseAndValidateDecision(result.RawResponse, request)
+		if err == nil {
+			return responseToSubmission(response), audit, nil
+		}
+
+		audit.ValidationErrors = validationErrors
+		retryContext = &ports.RetryFeedback{
+			Attempt:          attempt + 1,
+			ValidationErrors: slices.Clone(validationErrors),
+			LastRawResponse:  result.RawResponse,
+		}
+	}
+
+	submission, reason := fallbackSubmission(request)
+	audit.UsedFallback = true
+	audit.FallbackReason = reason
+	return submission, audit, nil
+}
+
+func validateDecisionRequest(request ports.AIDecisionRequest) error {
+	var errs []error
+
+	if request.ContractVersion == "" {
+		errs = append(errs, fmt.Errorf("contract version must not be empty"))
+	}
+	if request.MatchID == "" {
+		errs = append(errs, fmt.Errorf("match id must not be empty"))
+	}
+	if request.Round <= 0 {
+		errs = append(errs, fmt.Errorf("round must be positive"))
+	}
+	if request.RoleID == "" {
+		errs = append(errs, fmt.Errorf("role id must not be empty"))
+	}
+	if strings.TrimSpace(request.Provider) == "" {
+		errs = append(errs, fmt.Errorf("provider must not be empty"))
+	}
+	if strings.TrimSpace(request.Model) == "" {
+		errs = append(errs, fmt.Errorf("model must not be empty"))
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return errorsJoin(errs...)
+}
+
+func buildSystemPrompt(request ports.AIDecisionRequest) string {
+	briefing := request.Briefing
+	var lines []string
+	lines = append(lines, "You are playing HerbieGo as one role in a hidden simultaneous-turn factory simulation.")
+	lines = append(lines, fmt.Sprintf("Return exactly one JSON object that matches contract version %s.", request.ContractVersion))
+	lines = append(lines, fmt.Sprintf("Role: %s (%s)", briefing.DisplayName, briefing.RoleID))
+	lines = append(lines, "Public responsibilities:")
+	for _, item := range briefing.PublicResponsibilities {
+		lines = append(lines, "- "+item)
+	}
+	lines = append(lines, "Hidden incentives:")
+	for _, item := range briefing.HiddenIncentives {
+		lines = append(lines, "- "+item)
+	}
+	lines = append(lines, "Decision principles:")
+	for _, item := range briefing.DecisionPrinciples {
+		lines = append(lines, "- "+item)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func buildUserPrompt(request ports.AIDecisionRequest, retry *ports.RetryFeedback) string {
+	var sections []string
+
+	sections = append(sections, "## Contract Header\n"+mustJSON(map[string]any{
+		"contract_version": request.ContractVersion,
+		"match_id":         request.MatchID,
+		"round":            request.Round,
+		"role_id":          request.RoleID,
+		"provider":         request.Provider,
+		"model":            request.Model,
+	}))
+
+	sections = append(sections, "## Role Briefing\n"+mustJSON(request.Briefing))
+	sections = append(sections, "## Current Round Facts\n"+mustJSON(map[string]any{
+		"round_view":      request.RoundView,
+		"role_report":     request.RoleReport,
+		"previous_action": request.PreviousAction,
+	}))
+	sections = append(sections, "## Allowed Action Schema\n"+mustJSON(request.AllowedActions))
+	sections = append(sections, "## Response Format\n"+mustJSON(map[string]any{
+		"response_spec": request.ResponseSpec,
+		"example": map[string]any{
+			"contract_version": request.ContractVersion,
+			"match_id":         request.MatchID,
+			"round":            request.Round,
+			"role_id":          request.RoleID,
+			"action":           exampleAction(request.RoleID, request.RoundView.ActiveTargets),
+			"commentary": map[string]any{
+				"public_summary": "Explain the decision in one short player-facing sentence.",
+				"focus_tags":     []string{"throughput"},
+			},
+		},
+	}))
+
+	if retry != nil {
+		sections = append(sections, "## Retry Feedback\n"+mustJSON(retry))
+	}
+
+	sections = append(sections, "Return JSON only. Do not add prose before or after the JSON object.")
+	return strings.Join(sections, "\n\n")
+}
+
+func mustJSON(value any) string {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		panic(fmt.Sprintf("app: ai decision runner: marshal prompt section: %v", err))
+	}
+	return string(data)
+}
+
+func parseAndValidateDecision(raw string, request ports.AIDecisionRequest) (ports.AIDecisionResponse, []ports.ValidationError, error) {
+	payload, err := extractJSONObject(raw)
+	if err != nil {
+		validationErrors := []ports.ValidationError{{Path: "$", Message: err.Error()}}
+		return ports.AIDecisionResponse{}, validationErrors, err
+	}
+
+	var response ports.AIDecisionResponse
+	if err := json.Unmarshal([]byte(payload), &response); err != nil {
+		validationErrors := []ports.ValidationError{{Path: "$", Message: fmt.Sprintf("invalid JSON payload: %v", err)}}
+		return ports.AIDecisionResponse{}, validationErrors, err
+	}
+
+	validationErrors := validateDecisionResponse(response, request)
+	if len(validationErrors) > 0 {
+		return ports.AIDecisionResponse{}, validationErrors, fmt.Errorf("response failed validation")
+	}
+
+	return response, nil, nil
+}
+
+func extractJSONObject(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("response did not contain a recoverable JSON object")
+	}
+
+	if strings.HasPrefix(trimmed, "```") {
+		firstLineEnd := strings.Index(trimmed, "\n")
+		if firstLineEnd == -1 {
+			return "", fmt.Errorf("response did not contain a recoverable JSON object")
+		}
+		trimmed = strings.TrimSpace(trimmed[firstLineEnd+1:])
+		if end := strings.LastIndex(trimmed, "```"); end >= 0 {
+			trimmed = strings.TrimSpace(trimmed[:end])
+		}
+	}
+
+	start := strings.IndexByte(trimmed, '{')
+	if start < 0 {
+		return "", fmt.Errorf("response did not contain a recoverable JSON object")
+	}
+
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(trimmed); i++ {
+		switch trimmed[i] {
+		case '\\':
+			if inString {
+				escaped = !escaped
+			}
+		case '"':
+			if !escaped {
+				inString = !inString
+			}
+			escaped = false
+		case '{':
+			if !inString {
+				depth++
+			}
+			escaped = false
+		case '}':
+			if !inString {
+				depth--
+				if depth == 0 {
+					return trimmed[start : i+1], nil
+				}
+			}
+			escaped = false
+		default:
+			escaped = false
+		}
+	}
+
+	return "", fmt.Errorf("response did not contain a recoverable JSON object")
+}
+
+func validateDecisionResponse(response ports.AIDecisionResponse, request ports.AIDecisionRequest) []ports.ValidationError {
+	var errs []ports.ValidationError
+
+	if response.ContractVersion != request.ContractVersion {
+		errs = append(errs, ports.ValidationError{Path: "contract_version", Message: fmt.Sprintf("must equal %q", request.ContractVersion)})
+	}
+	if response.MatchID != request.MatchID {
+		errs = append(errs, ports.ValidationError{Path: "match_id", Message: fmt.Sprintf("must equal %q", request.MatchID)})
+	}
+	if response.Round != request.Round {
+		errs = append(errs, ports.ValidationError{Path: "round", Message: fmt.Sprintf("must equal %d", request.Round)})
+	}
+	if response.RoleID != request.RoleID {
+		errs = append(errs, ports.ValidationError{Path: "role_id", Message: fmt.Sprintf("must equal %q", request.RoleID)})
+	}
+
+	payloadCount := 0
+	if response.Action.Procurement != nil {
+		payloadCount++
+	}
+	if response.Action.Production != nil {
+		payloadCount++
+	}
+	if response.Action.Sales != nil {
+		payloadCount++
+	}
+	if response.Action.Finance != nil {
+		payloadCount++
+	}
+	if payloadCount != 1 {
+		errs = append(errs, ports.ValidationError{Path: "action", Message: "must contain exactly one populated role action payload"})
+	}
+
+	switch request.RoleID {
+	case domain.RoleProcurementManager:
+		if response.Action.Procurement == nil {
+			errs = append(errs, ports.ValidationError{Path: "action.procurement", Message: "must be populated for procurement_manager"})
+		}
+		errs = append(errs, validateProcurementAction(response.Action.Procurement)...)
+	case domain.RoleProductionManager:
+		if response.Action.Production == nil {
+			errs = append(errs, ports.ValidationError{Path: "action.production", Message: "must be populated for production_manager"})
+		}
+		errs = append(errs, validateProductionAction(response.Action.Production, request.RoundView)...)
+	case domain.RoleSalesManager:
+		if response.Action.Sales == nil {
+			errs = append(errs, ports.ValidationError{Path: "action.sales", Message: "must be populated for sales_manager"})
+		}
+		errs = append(errs, validateSalesAction(response.Action.Sales, request.RoundView)...)
+	case domain.RoleFinanceController:
+		if response.Action.Finance == nil {
+			errs = append(errs, ports.ValidationError{Path: "action.finance", Message: "must be populated for finance_controller"})
+		}
+	}
+
+	summary := strings.TrimSpace(response.Commentary.PublicSummary)
+	if summary == "" {
+		errs = append(errs, ports.ValidationError{Path: "commentary.public_summary", Message: "must not be empty"})
+	}
+	if len(summary) > request.ResponseSpec.MaxCommentaryChars {
+		errs = append(errs, ports.ValidationError{Path: "commentary.public_summary", Message: fmt.Sprintf("must be at most %d characters", request.ResponseSpec.MaxCommentaryChars)})
+	}
+	if len(response.Commentary.FocusTags) == 0 {
+		errs = append(errs, ports.ValidationError{Path: "commentary.focus_tags", Message: "must contain at least one tag"})
+	}
+	if len(response.Commentary.FocusTags) > request.ResponseSpec.MaxFocusTags {
+		errs = append(errs, ports.ValidationError{Path: "commentary.focus_tags", Message: fmt.Sprintf("must contain at most %d tags", request.ResponseSpec.MaxFocusTags)})
+	}
+	for i, tag := range response.Commentary.FocusTags {
+		if strings.TrimSpace(tag) == "" {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("commentary.focus_tags[%d]", i), Message: "must not be empty"})
+		}
+	}
+
+	return errs
+}
+
+func validateProcurementAction(action *domain.ProcurementAction) []ports.ValidationError {
+	if action == nil {
+		return nil
+	}
+
+	var errs []ports.ValidationError
+	for i, order := range action.Orders {
+		if order.PartID == "" {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.procurement.orders[%d].part_id", i), Message: "must not be empty"})
+		}
+		if order.SupplierID == "" {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.procurement.orders[%d].supplier_id", i), Message: "must not be empty"})
+		}
+		if order.Quantity < 0 {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.procurement.orders[%d].quantity", i), Message: "must be non-negative"})
+		}
+	}
+	return errs
+}
+
+func validateProductionAction(action *domain.ProductionAction, view domain.RoundView) []ports.ValidationError {
+	if action == nil {
+		return nil
+	}
+
+	knownProducts := productSet(view)
+	knownStations := workstationSet(view)
+
+	var errs []ports.ValidationError
+	for i, release := range action.Releases {
+		if !knownProducts[release.ProductID] {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.production.releases[%d].product_id", i), Message: "must reference a product visible in the round view"})
+		}
+		if release.Quantity < 0 {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.production.releases[%d].quantity", i), Message: "must be non-negative"})
+		}
+	}
+	for i, allocation := range action.CapacityAllocation {
+		if !knownStations[allocation.WorkstationID] {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.production.capacity_allocation[%d].workstation_id", i), Message: "must reference a workstation visible in the round view"})
+		}
+		if !knownProducts[allocation.ProductID] {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.production.capacity_allocation[%d].product_id", i), Message: "must reference a product visible in the round view"})
+		}
+		if allocation.Capacity < 0 {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.production.capacity_allocation[%d].capacity", i), Message: "must be non-negative"})
+		}
+	}
+	return errs
+}
+
+func validateSalesAction(action *domain.SalesAction, view domain.RoundView) []ports.ValidationError {
+	if action == nil {
+		return nil
+	}
+
+	knownProducts := productSet(view)
+	var errs []ports.ValidationError
+	for i, offer := range action.ProductOffers {
+		if !knownProducts[offer.ProductID] {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.sales.product_offers[%d].product_id", i), Message: "must reference a product visible in the round view"})
+		}
+		if offer.UnitPrice < 0 {
+			errs = append(errs, ports.ValidationError{Path: fmt.Sprintf("action.sales.product_offers[%d].unit_price", i), Message: "must be non-negative"})
+		}
+	}
+	return errs
+}
+
+func responseToSubmission(response ports.AIDecisionResponse) domain.ActionSubmission {
+	return domain.ActionSubmission{
+		MatchID: response.MatchID,
+		Round:   response.Round,
+		RoleID:  response.RoleID,
+		Action:  response.Action.Clone(),
+		Commentary: domain.CommentaryRecord{
+			RoleID:     response.RoleID,
+			Visibility: domain.CommentaryPublic,
+			Body:       strings.TrimSpace(response.Commentary.PublicSummary),
+		},
+	}
+}
+
+func fallbackSubmission(request ports.AIDecisionRequest) (domain.ActionSubmission, string) {
+	if request.PreviousAction != nil {
+		reused := request.PreviousAction.Clone()
+		reused.MatchID = request.MatchID
+		reused.Round = request.Round
+		reused.RoleID = request.RoleID
+		reused.Commentary = domain.CommentaryRecord{
+			MatchID:    request.MatchID,
+			Round:      request.Round,
+			RoleID:     request.RoleID,
+			Visibility: domain.CommentaryPublic,
+			Body:       "Previous action reused after invalid AI output.",
+		}
+		return reused, "previous accepted action reused after invalid AI output"
+	}
+
+	return domain.ActionSubmission{
+		MatchID: request.MatchID,
+		Round:   request.Round,
+		RoleID:  request.RoleID,
+		Action:  safeNoOpAction(request.RoleID, request.RoundView.ActiveTargets),
+		Commentary: domain.CommentaryRecord{
+			MatchID:    request.MatchID,
+			Round:      request.Round,
+			RoleID:     request.RoleID,
+			Visibility: domain.CommentaryPublic,
+			Body:       "Safe no-op submitted after invalid AI output.",
+		},
+	}, "safe no-op submitted after invalid AI output"
+}
+
+func safeNoOpAction(roleID domain.RoleID, targets domain.BudgetTargets) domain.RoleAction {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return domain.RoleAction{Procurement: &domain.ProcurementAction{Orders: []domain.PurchaseOrderIntent{}}}
+	case domain.RoleProductionManager:
+		return domain.RoleAction{Production: &domain.ProductionAction{
+			Releases:           []domain.ProductionRelease{},
+			CapacityAllocation: []domain.CapacityAllocation{},
+		}}
+	case domain.RoleSalesManager:
+		return domain.RoleAction{Sales: &domain.SalesAction{ProductOffers: []domain.ProductOffer{}}}
+	case domain.RoleFinanceController:
+		return domain.RoleAction{Finance: &domain.FinanceAction{NextRoundTargets: targets}}
+	default:
+		return domain.RoleAction{}
+	}
+}
+
+func roleBriefing(roleID domain.RoleID) ports.RoleBriefing {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return ports.RoleBriefing{
+			RoleID:                 roleID,
+			DisplayName:            "Procurement Manager",
+			PublicResponsibilities: []string{"Secure materials required for operations.", "Control input cost.", "Protect the plant from shortages.", "Build reliable supplier coverage."},
+			HiddenIncentives:       []string{"Favor bulk buys and lower unit prices even when inventory and cash risk rise."},
+			DecisionPrinciples:     []string{"Protect supply continuity for bottleneck flow.", "Avoid buying material the plant cannot use soon.", "Stay aware of active budget targets and plant cash."},
+			AllowedActionSummary:   []string{"Return only procurement orders.", "Each order needs part_id, supplier_id, and quantity.", "Use an empty orders list for a deliberate no-op."},
+		}
+	case domain.RoleProductionManager:
+		return ports.RoleBriefing{
+			RoleID:                 roleID,
+			DisplayName:            "Production Manager",
+			PublicResponsibilities: []string{"Maximize production output.", "Keep machines and labor utilized.", "Manage work-in-progress through the shop floor.", "Meet production commitments."},
+			HiddenIncentives:       []string{"Keep resources busy and local output high even when WIP or bottlenecks worsen."},
+			DecisionPrinciples:     []string{"Favor plant throughput over local utilization theater.", "Release only work that can move through the route.", "Keep WIP under control at the bottleneck."},
+			AllowedActionSummary:   []string{"Return only production releases and capacity allocations.", "Each release needs product_id and quantity.", "Each capacity allocation needs workstation_id, product_id, and capacity."},
+		}
+	case domain.RoleSalesManager:
+		return ports.RoleBriefing{
+			RoleID:                 roleID,
+			DisplayName:            "Sales Manager",
+			PublicResponsibilities: []string{"Grow revenue.", "Capture demand.", "Maintain customer relationships.", "Push the plant toward market opportunity."},
+			HiddenIncentives:       []string{"Favor booked demand and strong promises even when capacity or delivery reliability suffer."},
+			DecisionPrinciples:     []string{"Protect profitable throughput, not just order count.", "Consider backlog and delivery risk before chasing demand.", "Set prices that fit current operational reality."},
+			AllowedActionSummary:   []string{"Return only product offers.", "Each offer needs product_id and unit_price.", "Use an empty product_offers list for a deliberate no-op."},
+		}
+	case domain.RoleFinanceController:
+		return ports.RoleBriefing{
+			RoleID:                 roleID,
+			DisplayName:            "Finance Controller",
+			PublicResponsibilities: []string{"Monitor cash, cost, and financial performance.", "Highlight waste and overspending.", "Protect the business from financially dangerous decisions.", "Provide visibility into profit drivers."},
+			HiddenIncentives:       []string{"Favor short-term cost discipline even when it can damage throughput or resilience."},
+			DecisionPrinciples:     []string{"Preserve liquidity without starving profitable flow.", "Set next-round targets that balance cash, debt, and throughput.", "Treat cost cuts that harm throughput as risky."},
+			AllowedActionSummary:   []string{"Return only finance next_round_targets.", "Provide the full next_round_targets object.", "A safe no-op repeats the currently active targets."},
+		}
+	default:
+		return ports.RoleBriefing{RoleID: roleID, DisplayName: string(roleID)}
+	}
+}
+
+func allowedActionSchema(roleID domain.RoleID) ports.AllowedActionSchema {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return ports.AllowedActionSchema{
+			RoleID:         roleID,
+			RequiredAction: "procurement",
+			JSONSchemaName: "ProcurementAction",
+			Rules:          []string{"Populate only action.procurement.", "orders entries require part_id, supplier_id, and quantity.", "quantity must be non-negative."},
+		}
+	case domain.RoleProductionManager:
+		return ports.AllowedActionSchema{
+			RoleID:         roleID,
+			RequiredAction: "production",
+			JSONSchemaName: "ProductionAction",
+			Rules:          []string{"Populate only action.production.", "releases entries require product_id and quantity.", "capacity_allocation entries require workstation_id, product_id, and capacity.", "quantities and capacity must be non-negative."},
+		}
+	case domain.RoleSalesManager:
+		return ports.AllowedActionSchema{
+			RoleID:         roleID,
+			RequiredAction: "sales",
+			JSONSchemaName: "SalesAction",
+			Rules:          []string{"Populate only action.sales.", "product_offers entries require product_id and unit_price.", "unit_price must be non-negative."},
+		}
+	case domain.RoleFinanceController:
+		return ports.AllowedActionSchema{
+			RoleID:         roleID,
+			RequiredAction: "finance",
+			JSONSchemaName: "FinanceAction",
+			Rules:          []string{"Populate only action.finance.", "Provide next_round_targets exactly once.", "Each target field must be present."},
+		}
+	default:
+		return ports.AllowedActionSchema{RoleID: roleID}
+	}
+}
+
+func exampleAction(roleID domain.RoleID, targets domain.BudgetTargets) domain.RoleAction {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return domain.RoleAction{
+			Procurement: &domain.ProcurementAction{
+				Orders: []domain.PurchaseOrderIntent{{PartID: "housing", SupplierID: "forgeco", Quantity: 1}},
+			},
+		}
+	case domain.RoleProductionManager:
+		return domain.RoleAction{
+			Production: &domain.ProductionAction{
+				Releases:           []domain.ProductionRelease{{ProductID: "pump", Quantity: 1}},
+				CapacityAllocation: []domain.CapacityAllocation{{WorkstationID: "fabrication", ProductID: "pump", Capacity: 1}},
+			},
+		}
+	case domain.RoleSalesManager:
+		return domain.RoleAction{
+			Sales: &domain.SalesAction{
+				ProductOffers: []domain.ProductOffer{{ProductID: "pump", UnitPrice: 14}},
+			},
+		}
+	case domain.RoleFinanceController:
+		return domain.RoleAction{
+			Finance: &domain.FinanceAction{NextRoundTargets: targets},
+		}
+	default:
+		return domain.RoleAction{}
+	}
+}
+
+func productSet(view domain.RoundView) map[domain.ProductID]bool {
+	products := make(map[domain.ProductID]bool)
+	for _, item := range view.Plant.WIPInventory {
+		products[item.ProductID] = true
+	}
+	for _, item := range view.Plant.FinishedInventory {
+		products[item.ProductID] = true
+	}
+	for _, item := range view.Plant.Backlog {
+		products[item.ProductID] = true
+	}
+	for _, customer := range view.Customers {
+		for _, item := range customer.Backlog {
+			products[item.ProductID] = true
+		}
+	}
+	if len(products) == 0 {
+		products["pump"] = true
+	}
+	return products
+}
+
+func workstationSet(view domain.RoundView) map[domain.WorkstationID]bool {
+	stations := make(map[domain.WorkstationID]bool, len(view.Plant.Workstations))
+	for _, item := range view.Plant.Workstations {
+		stations[item.WorkstationID] = true
+	}
+	return stations
+}
+
+func clonePreviousForDecision(previous *domain.ActionSubmission) *domain.ActionSubmission {
+	if previous == nil {
+		return nil
+	}
+	cloned := previous.Clone()
+	return &cloned
+}
+
+func errorsJoin(errs ...error) error {
+	return errors.Join(errs...)
+}

--- a/internal/app/ai_orchestrator_test.go
+++ b/internal/app/ai_orchestrator_test.go
@@ -50,6 +50,12 @@ func TestAIOrchestratorBuildsPromptAndParsesValidDecision(t *testing.T) {
 	if !strings.Contains(client.requests[0].SystemPrompt, "Sales Manager") {
 		t.Fatalf("SystemPrompt = %q, want role briefing content", client.requests[0].SystemPrompt)
 	}
+	if !strings.Contains(client.requests[0].SystemPrompt, "# Role") || !strings.Contains(client.requests[0].SystemPrompt, "# Instructions") || !strings.Contains(client.requests[0].SystemPrompt, "# Tools") || !strings.Contains(client.requests[0].SystemPrompt, "# Response") {
+		t.Fatalf("SystemPrompt = %q, want structured prompt sections", client.requests[0].SystemPrompt)
+	}
+	if !strings.Contains(client.requests[0].SystemPrompt, "## Parts") || !strings.Contains(client.requests[0].SystemPrompt, "## Products") || !strings.Contains(client.requests[0].SystemPrompt, "## Vendors") || !strings.Contains(client.requests[0].SystemPrompt, "## Customers") {
+		t.Fatalf("SystemPrompt = %q, want grouped tool sections", client.requests[0].SystemPrompt)
+	}
 	if !strings.Contains(client.requests[0].UserPrompt, "## Allowed Action Schema") {
 		t.Fatalf("UserPrompt = %q, want schema section", client.requests[0].UserPrompt)
 	}

--- a/internal/app/ai_orchestrator_test.go
+++ b/internal/app/ai_orchestrator_test.go
@@ -1,0 +1,264 @@
+package app_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+func TestAIOrchestratorBuildsPromptAndParsesValidDecision(t *testing.T) {
+	client := &stubDecisionClient{
+		responses: []ports.ProviderDecisionResult{
+			{RawResponse: `{
+				"contract_version":"herbiego.ai.v1",
+				"match_id":"match-17",
+				"round":2,
+				"role_id":"sales_manager",
+				"action":{"sales":{"product_offers":[{"product_id":"pump","unit_price":16}]}},
+				"commentary":{"public_summary":"Holding price to protect throughput.","focus_tags":["throughput","pricing"]}
+			}`},
+		},
+	}
+
+	orchestrator := app.NewAIOrchestrator(client)
+	request := aiRoundRequest(domain.RoleSalesManager)
+
+	submission, audit, err := orchestrator.Decide(context.Background(), orchestrator.BuildRequest(request))
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+
+	if audit.AttemptCount != 1 {
+		t.Fatalf("audit.AttemptCount = %d, want 1", audit.AttemptCount)
+	}
+	if audit.UsedFallback {
+		t.Fatal("audit.UsedFallback = true, want false")
+	}
+	if got := len(client.requests); got != 1 {
+		t.Fatalf("client request count = %d, want 1", got)
+	}
+	if got := client.requests[0].Provider; got != "openrouter" {
+		t.Fatalf("Provider = %q, want openrouter", got)
+	}
+	if !strings.Contains(client.requests[0].SystemPrompt, "Sales Manager") {
+		t.Fatalf("SystemPrompt = %q, want role briefing content", client.requests[0].SystemPrompt)
+	}
+	if !strings.Contains(client.requests[0].UserPrompt, "## Allowed Action Schema") {
+		t.Fatalf("UserPrompt = %q, want schema section", client.requests[0].UserPrompt)
+	}
+	if submission.Action.Sales == nil {
+		t.Fatal("submission.Action.Sales = nil, want populated sales payload")
+	}
+	if got := submission.Action.Sales.ProductOffers[0].UnitPrice; got != 16 {
+		t.Fatalf("UnitPrice = %d, want 16", got)
+	}
+	if got := submission.Commentary.Body; got != "Holding price to protect throughput." {
+		t.Fatalf("Commentary.Body = %q, want parsed commentary", got)
+	}
+}
+
+func TestAIOrchestratorRetriesWithValidationFeedback(t *testing.T) {
+	client := &stubDecisionClient{
+		responses: []ports.ProviderDecisionResult{
+			{RawResponse: `{"contract_version":"herbiego.ai.v1","match_id":"match-17","round":2,"role_id":"sales_manager","action":{"sales":{"product_offers":[{"product_id":"pump","unit_price":16}]}},"commentary":{"public_summary":"","focus_tags":[]}}`},
+			{RawResponse: "```json\n{\"contract_version\":\"herbiego.ai.v1\",\"match_id\":\"match-17\",\"round\":2,\"role_id\":\"sales_manager\",\"action\":{\"sales\":{\"product_offers\":[{\"product_id\":\"pump\",\"unit_price\":15}]}},\"commentary\":{\"public_summary\":\"Reducing price slightly to protect revenue without outrunning flow.\",\"focus_tags\":[\"revenue\",\"flow\"]}}\n```"},
+		},
+	}
+
+	orchestrator := app.NewAIOrchestrator(client)
+	request := aiRoundRequest(domain.RoleSalesManager)
+
+	submission, audit, err := orchestrator.Decide(context.Background(), orchestrator.BuildRequest(request))
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+
+	if audit.AttemptCount != 2 {
+		t.Fatalf("audit.AttemptCount = %d, want 2", audit.AttemptCount)
+	}
+	if len(audit.ValidationErrors) == 0 {
+		t.Fatal("audit.ValidationErrors = nil, want retry validation feedback")
+	}
+	if got := len(client.requests); got != 2 {
+		t.Fatalf("client request count = %d, want 2", got)
+	}
+	if !strings.Contains(client.requests[1].UserPrompt, "## Retry Feedback") {
+		t.Fatalf("second UserPrompt = %q, want retry feedback section", client.requests[1].UserPrompt)
+	}
+	if got := submission.Action.Sales.ProductOffers[0].UnitPrice; got != 15 {
+		t.Fatalf("UnitPrice = %d, want 15", got)
+	}
+}
+
+func TestAIOrchestratorFallsBackAfterInvalidResponses(t *testing.T) {
+	client := &stubDecisionClient{
+		responses: []ports.ProviderDecisionResult{
+			{RawResponse: "not json"},
+			{RawResponse: `{"contract_version":"herbiego.ai.v1","match_id":"match-17","round":2,"role_id":"sales_manager","action":{"sales":{"product_offers":[{"product_id":"","unit_price":-1}]}},"commentary":{"public_summary":"","focus_tags":[]}}`},
+			{RawResponse: `{"contract_version":"herbiego.ai.v1","match_id":"match-17","round":2,"role_id":"sales_manager","action":{},"commentary":{"public_summary":"","focus_tags":[]}}`},
+		},
+	}
+
+	orchestrator := app.NewAIOrchestrator(client)
+	request := aiRoundRequest(domain.RoleSalesManager)
+	request.PreviousAcceptedAction = &domain.ActionSubmission{
+		MatchID: "match-17",
+		Round:   1,
+		RoleID:  domain.RoleSalesManager,
+		Action: domain.RoleAction{
+			Sales: &domain.SalesAction{
+				ProductOffers: []domain.ProductOffer{{ProductID: "pump", UnitPrice: 13}},
+			},
+		},
+	}
+
+	submission, audit, err := orchestrator.Decide(context.Background(), orchestrator.BuildRequest(request))
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+
+	if !audit.UsedFallback {
+		t.Fatal("audit.UsedFallback = false, want true")
+	}
+	if got := submission.Commentary.Body; got != "Previous action reused after invalid AI output." {
+		t.Fatalf("Commentary.Body = %q, want fallback reuse commentary", got)
+	}
+	if got := submission.Action.Sales.ProductOffers[0].UnitPrice; got != 13 {
+		t.Fatalf("UnitPrice = %d, want reused price 13", got)
+	}
+}
+
+func TestRoundCollectorUsesAIOrchestratorThroughLLMPlayer(t *testing.T) {
+	client := &stubDecisionClient{
+		responses: []ports.ProviderDecisionResult{
+			{RawResponse: `{"contract_version":"herbiego.ai.v1","match_id":"match-17","round":2,"role_id":"production_manager","action":{"production":{"releases":[{"product_id":"pump","quantity":1}],"capacity_allocation":[{"workstation_id":"fabrication","product_id":"pump","capacity":1}]}},"commentary":{"public_summary":"Releasing only what fabrication can move this round.","focus_tags":["throughput"]}}`},
+		},
+	}
+
+	orchestrator := app.NewAIOrchestrator(client)
+	state := fixtureMatchState()
+	state.Roles = []domain.RoleAssignment{
+		{RoleID: domain.RoleProductionManager, PlayerID: "ai-prod", Provider: "ollama", ModelName: "llama3.2:3b"},
+	}
+
+	collector := app.RoundCollector{
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProductionManager: llm.New(orchestrator.SubmitRound),
+		},
+	}
+
+	actions, err := collector.Collect(context.Background(), state, nil)
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+
+	if got := len(actions); got != 1 {
+		t.Fatalf("len(actions) = %d, want 1", got)
+	}
+	if actions[0].Action.Production == nil {
+		t.Fatal("actions[0].Action.Production = nil, want populated production payload")
+	}
+}
+
+func TestAIOrchestratorReturnsTransportErrors(t *testing.T) {
+	client := &stubDecisionClient{
+		err: errors.New("provider unavailable"),
+	}
+
+	orchestrator := app.NewAIOrchestrator(client)
+
+	_, _, err := orchestrator.Decide(context.Background(), orchestrator.BuildRequest(aiRoundRequest(domain.RoleSalesManager)))
+	if err == nil {
+		t.Fatal("Decide() error = nil, want transport error")
+	}
+	if !strings.Contains(err.Error(), "provider unavailable") {
+		t.Fatalf("error = %q, want transport cause", err)
+	}
+}
+
+type stubDecisionClient struct {
+	requests  []ports.ProviderDecisionRequest
+	responses []ports.ProviderDecisionResult
+	err       error
+}
+
+func (s *stubDecisionClient) RequestDecision(_ context.Context, request ports.ProviderDecisionRequest) (ports.ProviderDecisionResult, error) {
+	s.requests = append(s.requests, request)
+	if s.err != nil {
+		return ports.ProviderDecisionResult{}, s.err
+	}
+	if len(s.responses) == 0 {
+		return ports.ProviderDecisionResult{}, errors.New("unexpected request")
+	}
+	response := s.responses[0]
+	s.responses = s.responses[1:]
+	return response, nil
+}
+
+func aiRoundRequest(roleID domain.RoleID) ports.RoundRequest {
+	request := ports.RoundRequest{
+		Assignment: domain.RoleAssignment{
+			RoleID:    roleID,
+			PlayerID:  "ai-player",
+			Provider:  "openrouter",
+			ModelName: "openai/gpt-5-mini",
+		},
+		RoleView:   buildAIView(roleID),
+		RoleReport: buildAIReport(roleID),
+	}
+	if roleID == domain.RoleProductionManager {
+		request.Assignment.Provider = "ollama"
+		request.Assignment.ModelName = "llama3.2:3b"
+	}
+	return request
+}
+
+func buildAIView(roleID domain.RoleID) domain.RoundView {
+	return domain.RoundView{
+		MatchID:      "match-17",
+		Round:        2,
+		ViewerRoleID: roleID,
+		Plant: domain.PlantState{
+			Cash: 24,
+			WIPInventory: []domain.WIPInventory{
+				{ProductID: "pump", WorkstationID: "fabrication", Quantity: 1, UnitCost: 6},
+			},
+			FinishedInventory: []domain.FinishedInventory{
+				{ProductID: "pump", OnHandQty: 1, UnitCost: 8},
+			},
+			Backlog: []domain.BacklogEntry{
+				{CustomerID: "northbuild", ProductID: "pump", Quantity: 2, OriginRound: 1},
+			},
+			Workstations: []domain.WorkstationState{
+				{WorkstationID: "fabrication", CapacityPerRound: 4},
+				{WorkstationID: "assembly", CapacityPerRound: 3},
+			},
+		},
+		Customers: []domain.CustomerState{
+			{CustomerID: "northbuild", DisplayName: "NorthBuild", Sentiment: 6},
+		},
+		ActiveTargets: domain.BudgetTargets{
+			EffectiveRound:        2,
+			ProcurementBudget:     18,
+			ProductionSpendBudget: 14,
+			RevenueTarget:         28,
+			CashFloorTarget:       8,
+			DebtCeilingTarget:     15,
+		},
+	}
+}
+
+func buildAIReport(roleID domain.RoleID) domain.RoleRoundReport {
+	return domain.RoleRoundReport{
+		Department: domain.DepartmentPerformanceReport{
+			RoleID: roleID,
+		},
+		BonusReminder: "Protect plant-wide flow.",
+	}
+}

--- a/internal/app/ai_orchestrator_test.go
+++ b/internal/app/ai_orchestrator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
 func TestAIOrchestratorBuildsPromptAndParsesValidDecision(t *testing.T) {
@@ -26,7 +27,7 @@ func TestAIOrchestratorBuildsPromptAndParsesValidDecision(t *testing.T) {
 		},
 	}
 
-	orchestrator := app.NewAIOrchestrator(client)
+	orchestrator := app.NewAIOrchestrator(scenario.Starter(), client)
 	request := aiRoundRequest(domain.RoleSalesManager)
 
 	submission, audit, err := orchestrator.Decide(context.Background(), orchestrator.BuildRequest(request))
@@ -52,6 +53,9 @@ func TestAIOrchestratorBuildsPromptAndParsesValidDecision(t *testing.T) {
 	if !strings.Contains(client.requests[0].UserPrompt, "## Allowed Action Schema") {
 		t.Fatalf("UserPrompt = %q, want schema section", client.requests[0].UserPrompt)
 	}
+	if !strings.Contains(client.requests[0].UserPrompt, "## Tool Lookup") {
+		t.Fatalf("UserPrompt = %q, want tool lookup section", client.requests[0].UserPrompt)
+	}
 	if submission.Action.Sales == nil {
 		t.Fatal("submission.Action.Sales = nil, want populated sales payload")
 	}
@@ -71,7 +75,7 @@ func TestAIOrchestratorRetriesWithValidationFeedback(t *testing.T) {
 		},
 	}
 
-	orchestrator := app.NewAIOrchestrator(client)
+	orchestrator := app.NewAIOrchestrator(scenario.Starter(), client)
 	request := aiRoundRequest(domain.RoleSalesManager)
 
 	submission, audit, err := orchestrator.Decide(context.Background(), orchestrator.BuildRequest(request))
@@ -105,7 +109,7 @@ func TestAIOrchestratorFallsBackAfterInvalidResponses(t *testing.T) {
 		},
 	}
 
-	orchestrator := app.NewAIOrchestrator(client)
+	orchestrator := app.NewAIOrchestrator(scenario.Starter(), client)
 	request := aiRoundRequest(domain.RoleSalesManager)
 	request.PreviousAcceptedAction = &domain.ActionSubmission{
 		MatchID: "match-17",
@@ -141,7 +145,7 @@ func TestRoundCollectorUsesAIOrchestratorThroughLLMPlayer(t *testing.T) {
 		},
 	}
 
-	orchestrator := app.NewAIOrchestrator(client)
+	orchestrator := app.NewAIOrchestrator(scenario.Starter(), client)
 	state := fixtureMatchState()
 	state.Roles = []domain.RoleAssignment{
 		{RoleID: domain.RoleProductionManager, PlayerID: "ai-prod", Provider: "ollama", ModelName: "llama3.2:3b"},
@@ -171,7 +175,7 @@ func TestAIOrchestratorReturnsTransportErrors(t *testing.T) {
 		err: errors.New("provider unavailable"),
 	}
 
-	orchestrator := app.NewAIOrchestrator(client)
+	orchestrator := app.NewAIOrchestrator(scenario.Starter(), client)
 
 	_, _, err := orchestrator.Decide(context.Background(), orchestrator.BuildRequest(aiRoundRequest(domain.RoleSalesManager)))
 	if err == nil {
@@ -260,5 +264,34 @@ func buildAIReport(roleID domain.RoleID) domain.RoleRoundReport {
 			RoleID: roleID,
 		},
 		BonusReminder: "Protect plant-wide flow.",
+	}
+}
+func TestAIOrchestratorExecutesLookupToolCallsBeforeFinalDecision(t *testing.T) {
+	client := &stubDecisionClient{
+		responses: []ports.ProviderDecisionResult{
+			{RawResponse: `{"tool_call":{"tool_name":"show_product_route","arguments":{"product_id":"pump"}}}`},
+			{RawResponse: `{"contract_version":"herbiego.ai.v1","match_id":"match-17","round":2,"role_id":"production_manager","action":{"production":{"releases":[{"product_id":"pump","quantity":1}],"capacity_allocation":[{"workstation_id":"fabrication","product_id":"pump","capacity":1}]}},"commentary":{"public_summary":"Using the route lookup to release only work that fits the line.","focus_tags":["throughput"]}}`},
+		},
+	}
+
+	orchestrator := app.NewAIOrchestrator(scenario.Starter(), client)
+	request := aiRoundRequest(domain.RoleProductionManager)
+
+	submission, audit, err := orchestrator.Decide(context.Background(), orchestrator.BuildRequest(request))
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+
+	if audit.AttemptCount != 2 {
+		t.Fatalf("audit.AttemptCount = %d, want 2", audit.AttemptCount)
+	}
+	if got := len(client.requests); got != 2 {
+		t.Fatalf("client request count = %d, want 2", got)
+	}
+	if !strings.Contains(client.requests[1].UserPrompt, "## Tool Results") {
+		t.Fatalf("second UserPrompt = %q, want tool results section", client.requests[1].UserPrompt)
+	}
+	if got := submission.Commentary.Body; got != "Using the route lookup to release only work that fits the line." {
+		t.Fatalf("Commentary.Body = %q, want final commentary", got)
 	}
 }

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -124,12 +124,12 @@ type CustomerState struct {
 }
 
 type BudgetTargets struct {
-	EffectiveRound        RoundNumber
-	ProcurementBudget     Money
-	ProductionSpendBudget Money
-	RevenueTarget         Money
-	CashFloorTarget       Money
-	DebtCeilingTarget     Money
+	EffectiveRound        RoundNumber `json:"effective_round"`
+	ProcurementBudget     Money       `json:"procurement_budget"`
+	ProductionSpendBudget Money       `json:"production_spend_budget"`
+	RevenueTarget         Money       `json:"revenue_target"`
+	CashFloorTarget       Money       `json:"cash_floor_target"`
+	DebtCeilingTarget     Money       `json:"debt_ceiling_target"`
 }
 
 type PlantMetrics struct {
@@ -167,49 +167,49 @@ type ActionSubmission struct {
 }
 
 type RoleAction struct {
-	Procurement *ProcurementAction
-	Production  *ProductionAction
-	Sales       *SalesAction
-	Finance     *FinanceAction
+	Procurement *ProcurementAction `json:"procurement,omitempty"`
+	Production  *ProductionAction  `json:"production,omitempty"`
+	Sales       *SalesAction       `json:"sales,omitempty"`
+	Finance     *FinanceAction     `json:"finance,omitempty"`
 }
 
 type ProcurementAction struct {
-	Orders []PurchaseOrderIntent
+	Orders []PurchaseOrderIntent `json:"orders"`
 }
 
 type PurchaseOrderIntent struct {
-	PartID     PartID
-	SupplierID SupplierID
-	Quantity   Units
+	PartID     PartID     `json:"part_id"`
+	SupplierID SupplierID `json:"supplier_id"`
+	Quantity   Units      `json:"quantity"`
 }
 
 type ProductionAction struct {
-	Releases           []ProductionRelease
-	CapacityAllocation []CapacityAllocation
+	Releases           []ProductionRelease  `json:"releases"`
+	CapacityAllocation []CapacityAllocation `json:"capacity_allocation"`
 }
 
 type ProductionRelease struct {
-	ProductID ProductID
-	Quantity  Units
+	ProductID ProductID `json:"product_id"`
+	Quantity  Units     `json:"quantity"`
 }
 
 type CapacityAllocation struct {
-	WorkstationID WorkstationID
-	ProductID     ProductID
-	Capacity      CapacityUnits
+	WorkstationID WorkstationID `json:"workstation_id"`
+	ProductID     ProductID     `json:"product_id"`
+	Capacity      CapacityUnits `json:"capacity"`
 }
 
 type SalesAction struct {
-	ProductOffers []ProductOffer
+	ProductOffers []ProductOffer `json:"product_offers"`
 }
 
 type ProductOffer struct {
-	ProductID ProductID
-	UnitPrice Money
+	ProductID ProductID `json:"product_id"`
+	UnitPrice Money     `json:"unit_price"`
 }
 
 type FinanceAction struct {
-	NextRoundTargets BudgetTargets
+	NextRoundTargets BudgetTargets `json:"next_round_targets"`
 }
 
 type CustomerOrder struct {

--- a/internal/ports/ai.go
+++ b/internal/ports/ai.go
@@ -1,0 +1,116 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+const AIDecisionContractVersion = "herbiego.ai.v1"
+
+// RoleBriefing is the shared human-readable role description used for UI
+// briefings and AI system instructions.
+type RoleBriefing struct {
+	RoleID                 domain.RoleID
+	DisplayName            string
+	PublicResponsibilities []string
+	HiddenIncentives       []string
+	DecisionPrinciples     []string
+	AllowedActionSummary   []string
+}
+
+// AIDecisionRequest is the canonical provider-neutral input to the AI runner.
+type AIDecisionRequest struct {
+	ContractVersion string
+	MatchID         domain.MatchID
+	Round           domain.RoundNumber
+	RoleID          domain.RoleID
+	Provider        string
+	Model           string
+	Briefing        RoleBriefing
+	RoundView       domain.RoundView
+	RoleReport      domain.RoleRoundReport
+	AllowedActions  AllowedActionSchema
+	ResponseSpec    ResponseFormatSpec
+	RetryContext    *RetryFeedback
+	PreviousAction  *domain.ActionSubmission
+}
+
+// AllowedActionSchema narrows the action payload to the active role.
+type AllowedActionSchema struct {
+	RoleID         domain.RoleID
+	RequiredAction string
+	JSONSchemaName string
+	Rules          []string
+}
+
+// ResponseFormatSpec captures the stable response-format requirements.
+type ResponseFormatSpec struct {
+	RequireJSONOnly     bool
+	AllowMarkdownFences bool
+	MaxCommentaryChars  int
+	MaxFocusTags        int
+}
+
+// RetryFeedback carries concise path-based validation failures into retries.
+type RetryFeedback struct {
+	Attempt          int
+	ValidationErrors []ValidationError
+	LastRawResponse  string
+}
+
+// ValidationError describes a single validation failure.
+type ValidationError struct {
+	Path    string
+	Message string
+}
+
+// AIDecisionResponse is the strict JSON contract returned by the model.
+type AIDecisionResponse struct {
+	ContractVersion string             `json:"contract_version"`
+	MatchID         domain.MatchID     `json:"match_id"`
+	Round           domain.RoundNumber `json:"round"`
+	RoleID          domain.RoleID      `json:"role_id"`
+	Action          domain.RoleAction  `json:"action"`
+	Commentary      AICommentary       `json:"commentary"`
+}
+
+// AICommentary is the public explanation returned by an AI role.
+type AICommentary struct {
+	PublicSummary string   `json:"public_summary"`
+	FocusTags     []string `json:"focus_tags"`
+}
+
+// ProviderDecisionRequest is the provider-facing transport request built from
+// the canonical AI decision contract.
+type ProviderDecisionRequest struct {
+	Provider            string
+	Model               string
+	SystemPrompt        string
+	UserPrompt          string
+	RequireJSONOnly     bool
+	AllowMarkdownFences bool
+}
+
+// ProviderDecisionResult carries the raw model output back to the app layer.
+type ProviderDecisionResult struct {
+	RawResponse string
+}
+
+// DecisionClient executes provider requests without owning game semantics.
+type DecisionClient interface {
+	RequestDecision(ctx context.Context, request ProviderDecisionRequest) (ProviderDecisionResult, error)
+}
+
+// AIPlayerRunner decides one action through the shared AI orchestration path.
+type AIPlayerRunner interface {
+	Decide(ctx context.Context, request AIDecisionRequest) (domain.ActionSubmission, AIDecisionAudit, error)
+}
+
+// AIDecisionAudit captures retry and fallback behavior for debugging.
+type AIDecisionAudit struct {
+	AttemptCount     int
+	UsedFallback     bool
+	FallbackReason   string
+	ValidationErrors []ValidationError
+}

--- a/internal/ports/ai.go
+++ b/internal/ports/ai.go
@@ -31,6 +31,8 @@ type AIDecisionRequest struct {
 	RoundView       domain.RoundView
 	RoleReport      domain.RoleRoundReport
 	AllowedActions  AllowedActionSchema
+	Tools           []LookupToolSpec
+	ToolResults     []LookupToolResult
 	ResponseSpec    ResponseFormatSpec
 	RetryContext    *RetryFeedback
 	PreviousAction  *domain.ActionSubmission
@@ -63,6 +65,34 @@ type RetryFeedback struct {
 type ValidationError struct {
 	Path    string
 	Message string
+}
+
+// LookupToolSpec describes one read-only game lookup that an AI role may call
+// before returning a final decision.
+type LookupToolSpec struct {
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	Arguments   []LookupToolArgument `json:"arguments"`
+}
+
+// LookupToolArgument describes one tool argument.
+type LookupToolArgument struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Required    bool   `json:"required"`
+}
+
+// LookupToolCall is the JSON envelope used when a model requests a lookup.
+type LookupToolCall struct {
+	ToolName  string            `json:"tool_name"`
+	Arguments map[string]string `json:"arguments"`
+}
+
+// LookupToolResult captures one executed tool lookup for prompt reuse and audit.
+type LookupToolResult struct {
+	ToolName  string            `json:"tool_name"`
+	Arguments map[string]string `json:"arguments"`
+	Result    any               `json:"result"`
 }
 
 // AIDecisionResponse is the strict JSON contract returned by the model.

--- a/internal/prompting/ai.go
+++ b/internal/prompting/ai.go
@@ -13,21 +13,61 @@ import (
 func BuildSystemPrompt(request ports.AIDecisionRequest) string {
 	briefing := request.Briefing
 	var lines []string
-	lines = append(lines, "You are playing HerbieGo as one role in a hidden simultaneous-turn factory simulation.")
-	lines = append(lines, fmt.Sprintf("Return either one lookup tool request or one final JSON decision for contract version %s.", request.ContractVersion))
-	lines = append(lines, fmt.Sprintf("Role: %s (%s)", briefing.DisplayName, briefing.RoleID))
-	lines = append(lines, "Public responsibilities:")
-	for _, item := range briefing.PublicResponsibilities {
-		lines = append(lines, "- "+item)
-	}
-	lines = append(lines, "Hidden incentives:")
+	lines = append(lines, "# Role")
+	lines = append(lines, fmt.Sprintf("You are a %s working for the HerbieGo Manufacturing plant.", briefing.DisplayName))
+	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("In your role, your objective is to %s.", roleObjective(briefing)))
+	lines = append(lines, "")
+	lines = append(lines, "As part of your role, you have the following incentives:")
 	for _, item := range briefing.HiddenIncentives {
 		lines = append(lines, "- "+item)
 	}
-	lines = append(lines, "Decision principles:")
+	lines = append(lines, "")
+	lines = append(lines, "You also have a number of responsibilities towards the plant and rest of the operations. These are:")
+	for _, item := range briefing.PublicResponsibilities {
+		lines = append(lines, "- "+item)
+	}
+	lines = append(lines, "")
+	lines = append(lines, "# Instructions")
+	lines = append(lines, "Follow the following steps to")
+	lines = append(lines, "- review the weekly plant report")
+	lines = append(lines, "- review weekly department report")
+	lines = append(lines, "- review action log of the previous weeks")
+	lines = append(lines, "- take a decision on what actions should be taken this week to accomplish your objectives")
+	lines = append(lines, "")
+	lines = append(lines, "The decision you take should follow these principles:")
 	for _, item := range briefing.DecisionPrinciples {
 		lines = append(lines, "- "+item)
 	}
+	lines = append(lines, "")
+	lines = append(lines, "# Context")
+	lines = append(lines, fmt.Sprintf("You will be triggered at the start of each week with information on the last week performance. You are in charge of making decisions on %s.", roleDecisionScope(briefing.RoleID)))
+	lines = append(lines, "")
+	lines = append(lines, "# Tools")
+	lines = append(lines, "You have the following tools available to you:")
+	lines = append(lines, "")
+	for _, section := range groupedToolSections(request.Tools) {
+		lines = append(lines, section...)
+	}
+	lines = append(lines, "# Response")
+	lines = append(lines, "")
+	lines = append(lines, "Once you have your decision, communicate it to the rest of the team in JSON format according to the example below.")
+	lines = append(lines, "")
+	lines = append(lines, mustJSON(map[string]any{
+		"contract_version": request.ContractVersion,
+		"match_id":         request.MatchID,
+		"round":            request.Round,
+		"role_id":          request.RoleID,
+		"action":           exampleAction(request.RoleID, request.RoundView.ActiveTargets),
+		"commentary": map[string]any{
+			"public_summary": "Explain the decision in one short player-facing sentence.",
+			"focus_tags":     []string{"throughput"},
+		},
+	}))
+	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("You have the following options for actions to take: %s.", strings.Join(briefing.AllowedActionSummary, "; ")))
+	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("Return either one lookup tool request or one final JSON decision for contract version %s.", request.ContractVersion))
 	return strings.Join(lines, "\n")
 }
 
@@ -130,5 +170,88 @@ func exampleAction(roleID domain.RoleID, targets domain.BudgetTargets) domain.Ro
 		}
 	default:
 		return domain.RoleAction{}
+	}
+}
+
+func roleObjective(briefing ports.RoleBriefing) string {
+	if len(briefing.DecisionPrinciples) > 0 {
+		return strings.ToLower(strings.TrimSuffix(briefing.DecisionPrinciples[0], "."))
+	}
+	return "support plant-wide profitability and throughput"
+}
+
+func roleDecisionScope(roleID domain.RoleID) string {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return "procurement orders for parts and supplier coverage"
+	case domain.RoleProductionManager:
+		return "production releases and capacity allocation across workstations"
+	case domain.RoleSalesManager:
+		return "product pricing and market offers"
+	case domain.RoleFinanceController:
+		return "next-round financial targets and budget guardrails"
+	default:
+		return "the decisions assigned to your role"
+	}
+}
+
+func groupedToolSections(tools []ports.LookupToolSpec) [][]string {
+	byCategory := map[string][]ports.LookupToolSpec{
+		"Parts":     nil,
+		"Products":  nil,
+		"Vendors":   nil,
+		"Customers": nil,
+	}
+
+	for _, tool := range tools {
+		for _, category := range toolCategories(tool.Name) {
+			byCategory[category] = append(byCategory[category], tool)
+		}
+	}
+
+	order := []string{"Parts", "Products", "Vendors", "Customers"}
+	sections := make([][]string, 0, len(order))
+	for _, category := range order {
+		lines := []string{"## " + category}
+		toolsForCategory := byCategory[category]
+		if len(toolsForCategory) == 0 {
+			lines = append(lines, "No dedicated lookup tool is available in this category yet.")
+			lines = append(lines, "")
+			sections = append(sections, lines)
+			continue
+		}
+
+		for _, tool := range toolsForCategory {
+			lines = append(lines, fmt.Sprintf("- `%s`: %s", tool.Name, tool.Description))
+			if len(tool.Arguments) > 0 {
+				lines = append(lines, "  Arguments:")
+				for _, argument := range tool.Arguments {
+					required := "optional"
+					if argument.Required {
+						required = "required"
+					}
+					lines = append(lines, fmt.Sprintf("  - %s (%s): %s", argument.Name, required, argument.Description))
+				}
+			}
+		}
+		lines = append(lines, "")
+		sections = append(sections, lines)
+	}
+
+	return sections
+}
+
+func toolCategories(toolName string) []string {
+	switch toolName {
+	case "show_product_bom":
+		return []string{"Parts", "Products"}
+	case "show_product_route":
+		return []string{"Products"}
+	case "list_valid_suppliers":
+		return []string{"Parts", "Vendors"}
+	case "show_customer_demand_profile":
+		return []string{"Customers"}
+	default:
+		return []string{"Parts"}
 	}
 }

--- a/internal/prompting/ai.go
+++ b/internal/prompting/ai.go
@@ -1,0 +1,134 @@
+package prompting
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+// BuildSystemPrompt renders the role-facing system prompt.
+func BuildSystemPrompt(request ports.AIDecisionRequest) string {
+	briefing := request.Briefing
+	var lines []string
+	lines = append(lines, "You are playing HerbieGo as one role in a hidden simultaneous-turn factory simulation.")
+	lines = append(lines, fmt.Sprintf("Return either one lookup tool request or one final JSON decision for contract version %s.", request.ContractVersion))
+	lines = append(lines, fmt.Sprintf("Role: %s (%s)", briefing.DisplayName, briefing.RoleID))
+	lines = append(lines, "Public responsibilities:")
+	for _, item := range briefing.PublicResponsibilities {
+		lines = append(lines, "- "+item)
+	}
+	lines = append(lines, "Hidden incentives:")
+	for _, item := range briefing.HiddenIncentives {
+		lines = append(lines, "- "+item)
+	}
+	lines = append(lines, "Decision principles:")
+	for _, item := range briefing.DecisionPrinciples {
+		lines = append(lines, "- "+item)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// BuildUserPrompt renders the canonical provider-neutral decision prompt.
+func BuildUserPrompt(request ports.AIDecisionRequest, retry *ports.RetryFeedback) string {
+	var sections []string
+
+	sections = append(sections, "## Contract Header\n"+mustJSON(map[string]any{
+		"contract_version": request.ContractVersion,
+		"match_id":         request.MatchID,
+		"round":            request.Round,
+		"role_id":          request.RoleID,
+		"provider":         request.Provider,
+		"model":            request.Model,
+	}))
+
+	sections = append(sections, "## Role Briefing\n"+mustJSON(request.Briefing))
+	sections = append(sections, "## Current Round Facts\n"+mustJSON(map[string]any{
+		"round_view":      request.RoundView,
+		"role_report":     request.RoleReport,
+		"previous_action": request.PreviousAction,
+	}))
+	sections = append(sections, "## Allowed Action Schema\n"+mustJSON(request.AllowedActions))
+	sections = append(sections, "## Response Format\n"+mustJSON(map[string]any{
+		"response_spec": request.ResponseSpec,
+		"decision_example": map[string]any{
+			"contract_version": request.ContractVersion,
+			"match_id":         request.MatchID,
+			"round":            request.Round,
+			"role_id":          request.RoleID,
+			"action":           exampleAction(request.RoleID, request.RoundView.ActiveTargets),
+			"commentary": map[string]any{
+				"public_summary": "Explain the decision in one short player-facing sentence.",
+				"focus_tags":     []string{"throughput"},
+			},
+		},
+	}))
+
+	if len(request.Tools) > 0 {
+		sections = append(sections, "## Tool Lookup\n"+mustJSON(map[string]any{
+			"available_tools": request.Tools,
+			"tool_call_example": map[string]any{
+				"tool_call": map[string]any{
+					"tool_name": "show_product_route",
+					"arguments": map[string]string{"product_id": "pump"},
+				},
+			},
+			"instructions": []string{
+				"If you need more catalog information, return exactly one tool_call JSON object.",
+				"After you receive tool results, return the final decision JSON in the main contract format.",
+				"Do not combine tool_call with the final decision in the same JSON object.",
+			},
+		}))
+	}
+
+	if len(request.ToolResults) > 0 {
+		sections = append(sections, "## Tool Results\n"+mustJSON(request.ToolResults))
+	}
+
+	if retry != nil {
+		sections = append(sections, "## Retry Feedback\n"+mustJSON(retry))
+	}
+
+	sections = append(sections, "Return JSON only. Do not add prose before or after the JSON object.")
+	return strings.Join(sections, "\n\n")
+}
+
+func mustJSON(value any) string {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		panic(fmt.Sprintf("prompting: marshal prompt section: %v", err))
+	}
+	return string(data)
+}
+
+func exampleAction(roleID domain.RoleID, targets domain.BudgetTargets) domain.RoleAction {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return domain.RoleAction{
+			Procurement: &domain.ProcurementAction{
+				Orders: []domain.PurchaseOrderIntent{{PartID: "housing", SupplierID: "forgeco", Quantity: 1}},
+			},
+		}
+	case domain.RoleProductionManager:
+		return domain.RoleAction{
+			Production: &domain.ProductionAction{
+				Releases:           []domain.ProductionRelease{{ProductID: "pump", Quantity: 1}},
+				CapacityAllocation: []domain.CapacityAllocation{{WorkstationID: "fabrication", ProductID: "pump", Capacity: 1}},
+			},
+		}
+	case domain.RoleSalesManager:
+		return domain.RoleAction{
+			Sales: &domain.SalesAction{
+				ProductOffers: []domain.ProductOffer{{ProductID: "pump", UnitPrice: 14}},
+			},
+		}
+	case domain.RoleFinanceController:
+		return domain.RoleAction{
+			Finance: &domain.FinanceAction{NextRoundTargets: targets},
+		}
+	default:
+		return domain.RoleAction{}
+	}
+}

--- a/internal/prompting/doc.go
+++ b/internal/prompting/doc.go
@@ -1,0 +1,2 @@
+// Package prompting renders provider-neutral AI prompts.
+package prompting

--- a/internal/scenario/lookups.go
+++ b/internal/scenario/lookups.go
@@ -1,0 +1,27 @@
+package scenario
+
+import "github.com/jpconstantineau/herbiego/internal/domain"
+
+// Part returns one canonical part definition.
+func (d Definition) Part(partID domain.PartID) (Part, bool) {
+	part, ok := d.partsByID()[partID]
+	return part, ok
+}
+
+// Product returns one canonical product definition.
+func (d Definition) Product(productID domain.ProductID) (Product, bool) {
+	product, ok := d.productsByID()[productID]
+	return product, ok
+}
+
+// Workstation returns one canonical workstation definition.
+func (d Definition) Workstation(workstationID domain.WorkstationID) (Workstation, bool) {
+	workstation, ok := d.workstationsByID()[workstationID]
+	return workstation, ok
+}
+
+// Customer returns one canonical customer definition.
+func (d Definition) Customer(customerID domain.CustomerID) (CustomerMarket, bool) {
+	customer, ok := d.customersByID()[customerID]
+	return customer, ok
+}


### PR DESCRIPTION
## Summary
- add a provider-neutral AI contract in `internal/ports` for role briefings, decision requests/responses, retry feedback, audit data, and decision transport
- implement an `internal/app` AI orchestrator that builds prompts, executes through a shared decision client, extracts JSON, validates role-specific actions, retries with structured feedback, and falls back deterministically
- add integration-style tests that run the orchestrator through the existing `llm` player adapter and update action structs with JSON tags so snake_case model responses deserialize cleanly

Closes #19.

## Verification
- `go test ./...`
- `go tool staticcheck ./...`

## Clarification Questions
1. Should `focus_tags` remain audit-only for now, or do you want them persisted in the round record / commentary model in a follow-up?
2. For full domain-reference validation, where do you want canonical part, supplier, and product catalogs to live long term so the AI runner can validate against more than the current round view?
3. Do you want the provider adapters to own prompt transport only, with all prompt section assembly staying in `internal/app` exactly as introduced here, or should we split prompt rendering into its own package before wiring real OpenRouter/Ollama clients?
