### PR TITLE
[codex] Implement Ollama AI provider adapter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ The repository tracks its preferred toolchain in [go.mod](go.mod), so a recent G
    go mod download
    ```
 
-3. Review the checked-in runtime config in [herbiego.yaml](herbiego.yaml).
+3. Review the checked-in runtime config in [herbiego.yaml](herbiego.yaml) and the provider/model catalog in [llm.yaml](llm.yaml).
 
 ## Run the app
 
@@ -80,12 +80,12 @@ Today, runtime provider selection is driven by YAML configuration, not by enviro
 
 ## How AI providers are configured
 
-AI role configuration lives in [herbiego.yaml](herbiego.yaml).
+AI role assignments live in [herbiego.yaml](herbiego.yaml). Provider/model connection details live in [llm.yaml](llm.yaml).
 
 Each entry under `roles` configures one canonical role with:
 
 - `role_id`: the role being configured
-- `provider`: the AI backend name, currently `ollama` or `openrouter`
+- `provider`: the named provider entry to use from `llm.yaml`
 - `model`: the model identifier to use for that role
 
 Example:
@@ -93,10 +93,29 @@ Example:
 ```yaml
 roles:
   - role_id: sales_manager
-    provider: openrouter
-    model: openai/gpt-5-mini
+    provider: ollama-localhost
+    model: gemma4:e4b
+```
+
+Each entry under `models` in `llm.yaml` defines:
+
+- `provider_name`: the named provider referenced by `herbiego.yaml`
+- `model_name`: the concrete model identifier
+- `url`: the provider base URL
+- `api_sdk_type`: the transport family, currently `ollama` or `openai`
+- `api_key`: the configured API key value, if any
+
+Example:
+
+```yaml
+models:
+  - provider_name: openrouter
+    model_name: openai/gpt-5-mini
+    url: https://openrouter.ai/api/v1/
+    api_sdk_type: openai
+    api_key: ""
 ```
 
 `human_players` determines which roles stay human-controlled during startup. The application assigns human control in a fixed order and keeps provider/model values on every role so contributors can switch to AI-only runs with a CLI override instead of rewriting config.
 
-At the moment, the provider adapter packages are still placeholders, so the YAML file mainly captures intended runtime wiring and validation rules rather than a fully implemented remote-provider session.
+Today, the Ollama API is implemented. Providers cataloged with the `openai` SDK type are still validated and surfaced in config, but startup fails fast if their concrete adapter has not landed yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,6 @@ Each entry under `roles` configures one canonical role with:
 
 - `role_id`: the role being configured
 - `provider`: the named provider entry to use from `llm.yaml`
-- `model`: the model identifier to use for that role
 
 Example:
 
@@ -94,7 +93,6 @@ Example:
 roles:
   - role_id: sales_manager
     provider: ollama-localhost
-    model: gemma4:e4b
 ```
 
 Each entry under `models` in `llm.yaml` defines:
@@ -116,6 +114,6 @@ models:
     api_key: ""
 ```
 
-`human_players` determines which roles stay human-controlled during startup. The application assigns human control in a fixed order and keeps provider/model values on every role so contributors can switch to AI-only runs with a CLI override instead of rewriting config.
+`human_players` determines which roles stay human-controlled during startup. The application assigns human control in a fixed order and keeps the provider label on every role so contributors can switch to AI-only runs with a CLI override instead of rewriting config.
 
 Today, the Ollama API is implemented. Providers cataloged with the `openai` SDK type are still validated and surfaced in config, but startup fails fast if their concrete adapter has not landed yet.

--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -76,13 +76,11 @@ func main() {
 }
 
 func buildPlayers(runtime app.Runtime, controller *terminalController) (map[domain.RoleID]ports.Player, error) {
-	ollamaClient, err := ollama.New()
+	providers, err := buildDecisionClients(runtime.Config)
 	if err != nil {
-		return nil, fmt.Errorf("configure ollama adapter: %w", err)
+		return nil, err
 	}
-	decisionClient := ai.NewRoutingClient(map[string]ports.DecisionClient{
-		string(app.ProviderOllama): ollamaClient,
-	})
+	decisionClient := ai.NewRoutingClient(providers)
 	orchestrator := app.NewAIOrchestrator(runtime.Scenario, decisionClient)
 
 	players := make(map[domain.RoleID]ports.Player, len(runtime.InitialMatch.Roles))
@@ -97,6 +95,33 @@ func buildPlayers(runtime app.Runtime, controller *terminalController) (map[doma
 		players[assignment.RoleID] = llm.New(orchestrator.SubmitRound)
 	}
 	return players, nil
+}
+
+func buildDecisionClients(cfg app.Config) (map[string]ports.DecisionClient, error) {
+	clients := make(map[string]ports.DecisionClient)
+	for _, roleCfg := range cfg.Roles {
+		providerName := string(roleCfg.Provider)
+		if providerName == "" {
+			continue
+		}
+		if _, ok := clients[providerName]; ok {
+			continue
+		}
+
+		switch roleCfg.APISDKType {
+		case app.APISDKTypeOllama:
+			client, err := ollama.New(ollama.WithBaseURL(roleCfg.URL))
+			if err != nil {
+				return nil, fmt.Errorf("configure provider %q: %w", roleCfg.Provider, err)
+			}
+			clients[providerName] = client
+		case app.APISDKTypeOpenAI:
+			continue
+		default:
+			return nil, fmt.Errorf("provider %q uses unsupported api_sdk_type %q", roleCfg.Provider, roleCfg.APISDKType)
+		}
+	}
+	return clients, nil
 }
 
 func printRuntimeSummary(runtime app.Runtime) {

--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -7,7 +7,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jpconstantineau/herbiego/internal/adapters/ai"
+	"github.com/jpconstantineau/herbiego/internal/adapters/ai/ollama"
 	"github.com/jpconstantineau/herbiego/internal/adapters/player/human"
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/engine"
@@ -37,14 +40,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "bootstrap failed:\n%v\n", err)
 		os.Exit(1)
 	}
-	if err := requireAllHuman(runtime); err != nil {
+	controller := newTerminalController(runtime.Scenario, os.Stdin, os.Stdout)
+	players, err := buildPlayers(runtime, controller)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "startup rejected:\n%v\n", err)
 		os.Exit(1)
 	}
 
-	controller := newTerminalController(runtime.Scenario, os.Stdin, os.Stdout)
 	collector := app.RoundCollector{
-		Players: buildPlayers(runtime, controller),
+		Players: players,
 	}
 
 	printRuntimeSummary(runtime)
@@ -71,27 +75,28 @@ func main() {
 	printRoundResolution(result)
 }
 
-func buildPlayers(runtime app.Runtime, controller *terminalController) map[domain.RoleID]ports.Player {
+func buildPlayers(runtime app.Runtime, controller *terminalController) (map[domain.RoleID]ports.Player, error) {
+	ollamaClient, err := ollama.New()
+	if err != nil {
+		return nil, fmt.Errorf("configure ollama adapter: %w", err)
+	}
+	decisionClient := ai.NewRoutingClient(map[string]ports.DecisionClient{
+		string(app.ProviderOllama): ollamaClient,
+	})
+	orchestrator := app.NewAIOrchestrator(runtime.Scenario, decisionClient)
+
 	players := make(map[domain.RoleID]ports.Player, len(runtime.InitialMatch.Roles))
 	for _, assignment := range runtime.InitialMatch.Roles {
-		players[assignment.RoleID] = human.New(controller.submitRound)
-	}
-	return players
-}
-
-func requireAllHuman(runtime app.Runtime) error {
-	required := len(runtime.InitialMatch.Roles)
-	if runtime.Config.HumanPlayers != required {
-		return fmt.Errorf("terminal gameplay currently requires -human-players=%d until AI turn submission is wired into the CLI", required)
-	}
-
-	for _, assignment := range runtime.InitialMatch.Roles {
-		if !assignment.IsHuman {
-			return fmt.Errorf("role %q is not human-controlled; terminal gameplay currently requires all four roles to be human-controlled", assignment.RoleID)
+		if assignment.IsHuman {
+			players[assignment.RoleID] = human.New(controller.submitRound)
+			continue
 		}
+		if !decisionClient.SupportsProvider(assignment.Provider) {
+			return nil, fmt.Errorf("role %q uses unsupported AI provider %q", assignment.RoleID, assignment.Provider)
+		}
+		players[assignment.RoleID] = llm.New(orchestrator.SubmitRound)
 	}
-
-	return nil
+	return players, nil
 }
 
 func printRuntimeSummary(runtime app.Runtime) {

--- a/cmd/herbiego/main_test.go
+++ b/cmd/herbiego/main_test.go
@@ -1,15 +1,16 @@
 package main
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/human"
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
-func TestRequireAllHumanRejectsMixedRuntime(t *testing.T) {
+func TestBuildPlayersCreatesMixedHumanAndAIPlayers(t *testing.T) {
 	runtime := app.Runtime{
 		Config: app.Config{
 			HumanPlayers: 1,
@@ -18,39 +19,43 @@ func TestRequireAllHumanRejectsMixedRuntime(t *testing.T) {
 		InitialMatch: domain.MatchState{
 			Roles: []domain.RoleAssignment{
 				{RoleID: domain.RoleProductionManager, IsHuman: true},
-				{RoleID: domain.RoleProcurementManager, IsHuman: false},
-				{RoleID: domain.RoleSalesManager, IsHuman: false},
-				{RoleID: domain.RoleFinanceController, IsHuman: false},
+				{RoleID: domain.RoleProcurementManager, IsHuman: false, Provider: "ollama", ModelName: "gemma4:e4b"},
+				{RoleID: domain.RoleSalesManager, IsHuman: false, Provider: "ollama", ModelName: "gemma4:e4b"},
+				{RoleID: domain.RoleFinanceController, IsHuman: false, Provider: "ollama", ModelName: "gemma4:e4b"},
 			},
 		},
 	}
 
-	err := requireAllHuman(runtime)
-	if err == nil {
-		t.Fatal("requireAllHuman() error = nil, want mixed-runtime rejection")
+	players, err := buildPlayers(runtime, &terminalController{})
+	if err != nil {
+		t.Fatalf("buildPlayers() error = %v, want nil", err)
 	}
-	if !strings.Contains(err.Error(), "-human-players=4") {
-		t.Fatalf("requireAllHuman() error = %v, want flag guidance", err)
+	if _, ok := players[domain.RoleProductionManager].(*human.Player); !ok {
+		t.Fatalf("production player type = %T, want *human.Player", players[domain.RoleProductionManager])
+	}
+	if _, ok := players[domain.RoleProcurementManager].(*llm.Player); !ok {
+		t.Fatalf("procurement player type = %T, want *llm.Player", players[domain.RoleProcurementManager])
 	}
 }
 
-func TestRequireAllHumanAcceptsFullyHumanRuntime(t *testing.T) {
+func TestBuildPlayersRejectsUnsupportedAIProvider(t *testing.T) {
 	runtime := app.Runtime{
 		Config: app.Config{
-			HumanPlayers: 4,
+			HumanPlayers: 0,
 		},
 		Scenario: scenario.Starter(),
 		InitialMatch: domain.MatchState{
 			Roles: []domain.RoleAssignment{
-				{RoleID: domain.RoleProductionManager, IsHuman: true},
-				{RoleID: domain.RoleProcurementManager, IsHuman: true},
-				{RoleID: domain.RoleSalesManager, IsHuman: true},
-				{RoleID: domain.RoleFinanceController, IsHuman: true},
+				{RoleID: domain.RoleProductionManager, IsHuman: false, Provider: "openrouter", ModelName: "openai/gpt-5-mini"},
 			},
 		},
 	}
 
-	if err := requireAllHuman(runtime); err != nil {
-		t.Fatalf("requireAllHuman() error = %v, want nil", err)
+	_, err := buildPlayers(runtime, &terminalController{})
+	if err == nil {
+		t.Fatal("buildPlayers() error = nil, want unsupported-provider error")
+	}
+	if got, want := err.Error(), `role "production_manager" uses unsupported AI provider "openrouter"`; got != want {
+		t.Fatalf("buildPlayers() error = %q, want %q", got, want)
 	}
 }

--- a/cmd/herbiego/main_test.go
+++ b/cmd/herbiego/main_test.go
@@ -14,14 +14,20 @@ func TestBuildPlayersCreatesMixedHumanAndAIPlayers(t *testing.T) {
 	runtime := app.Runtime{
 		Config: app.Config{
 			HumanPlayers: 1,
+			Roles: map[domain.RoleID]app.RoleConfig{
+				domain.RoleProductionManager:  {Kind: app.PlayerKindHuman, Provider: "ollama-localhost", Model: "gemma4:e4b", URL: "http://localhost:11434/", APISDKType: app.APISDKTypeOllama},
+				domain.RoleProcurementManager: {Kind: app.PlayerKindAI, Provider: "ollama-localhost", Model: "gemma4:e4b", URL: "http://localhost:11434/", APISDKType: app.APISDKTypeOllama},
+				domain.RoleSalesManager:       {Kind: app.PlayerKindAI, Provider: "ollama-cloud", Model: "gemma4:e4b", URL: "https://ollama.com/api/", APISDKType: app.APISDKTypeOllama},
+				domain.RoleFinanceController:  {Kind: app.PlayerKindAI, Provider: "ollama-localhost", Model: "gemma4:e4b", URL: "http://localhost:11434/", APISDKType: app.APISDKTypeOllama},
+			},
 		},
 		Scenario: scenario.Starter(),
 		InitialMatch: domain.MatchState{
 			Roles: []domain.RoleAssignment{
 				{RoleID: domain.RoleProductionManager, IsHuman: true},
-				{RoleID: domain.RoleProcurementManager, IsHuman: false, Provider: "ollama", ModelName: "gemma4:e4b"},
-				{RoleID: domain.RoleSalesManager, IsHuman: false, Provider: "ollama", ModelName: "gemma4:e4b"},
-				{RoleID: domain.RoleFinanceController, IsHuman: false, Provider: "ollama", ModelName: "gemma4:e4b"},
+				{RoleID: domain.RoleProcurementManager, IsHuman: false, Provider: "ollama-localhost", ModelName: "gemma4:e4b"},
+				{RoleID: domain.RoleSalesManager, IsHuman: false, Provider: "ollama-cloud", ModelName: "gemma4:e4b"},
+				{RoleID: domain.RoleFinanceController, IsHuman: false, Provider: "ollama-localhost", ModelName: "gemma4:e4b"},
 			},
 		},
 	}
@@ -42,6 +48,9 @@ func TestBuildPlayersRejectsUnsupportedAIProvider(t *testing.T) {
 	runtime := app.Runtime{
 		Config: app.Config{
 			HumanPlayers: 0,
+			Roles: map[domain.RoleID]app.RoleConfig{
+				domain.RoleProductionManager: {Kind: app.PlayerKindAI, Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: app.APISDKTypeOpenAI},
+			},
 		},
 		Scenario: scenario.Starter(),
 		InitialMatch: domain.MatchState{

--- a/herbiego.yaml
+++ b/herbiego.yaml
@@ -4,14 +4,14 @@ random:
 human_players: 1
 roles:
   - role_id: procurement_manager
-    provider: ollama
+    provider: ollama-localhost
     model: gemma4:e4b
   - role_id: production_manager
-    provider: ollama
+    provider: ollama-localhost
     model: gemma4:e4b
   - role_id: sales_manager
-    provider: ollama
+    provider: ollama-localhost
     model: gemma4:e4b
   - role_id: finance_controller
-    provider: ollama
+    provider: ollama-localhost
     model: gemma4:e4b

--- a/herbiego.yaml
+++ b/herbiego.yaml
@@ -5,13 +5,13 @@ human_players: 1
 roles:
   - role_id: procurement_manager
     provider: ollama
-    model: llama3.2:3b
+    model: gemma4:e4b
   - role_id: production_manager
     provider: ollama
-    model: llama3.2:3b
+    model: gemma4:e4b
   - role_id: sales_manager
-    provider: openrouter
-    model: openai/gpt-5-mini
+    provider: ollama
+    model: gemma4:e4b
   - role_id: finance_controller
     provider: ollama
-    model: llama3.2:3b
+    model: gemma4:e4b

--- a/herbiego.yaml
+++ b/herbiego.yaml
@@ -5,13 +5,9 @@ human_players: 1
 roles:
   - role_id: procurement_manager
     provider: ollama-localhost
-    model: gemma4:e4b
   - role_id: production_manager
     provider: ollama-localhost
-    model: gemma4:e4b
   - role_id: sales_manager
     provider: ollama-localhost
-    model: gemma4:e4b
   - role_id: finance_controller
     provider: ollama-localhost
-    model: gemma4:e4b

--- a/internal/adapters/ai/client.go
+++ b/internal/adapters/ai/client.go
@@ -1,0 +1,52 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+// RoutingClient dispatches provider-neutral decision requests to the concrete
+// adapter registered for the requested provider name.
+type RoutingClient struct {
+	providers map[string]ports.DecisionClient
+}
+
+func NewRoutingClient(providers map[string]ports.DecisionClient) *RoutingClient {
+	normalized := make(map[string]ports.DecisionClient, len(providers))
+	for provider, client := range providers {
+		name := normalizeProvider(provider)
+		if name == "" || client == nil {
+			continue
+		}
+		normalized[name] = client
+	}
+	return &RoutingClient{providers: normalized}
+}
+
+func (c *RoutingClient) SupportsProvider(provider string) bool {
+	if c == nil {
+		return false
+	}
+	_, ok := c.providers[normalizeProvider(provider)]
+	return ok
+}
+
+func (c *RoutingClient) RequestDecision(ctx context.Context, request ports.ProviderDecisionRequest) (ports.ProviderDecisionResult, error) {
+	if c == nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("ai routing client is not configured")
+	}
+
+	client, ok := c.providers[normalizeProvider(request.Provider)]
+	if !ok {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("unsupported AI provider %q", request.Provider)
+	}
+
+	return client.RequestDecision(ctx, request)
+}
+
+func normalizeProvider(provider string) string {
+	return strings.ToLower(strings.TrimSpace(provider))
+}

--- a/internal/adapters/ai/client_test.go
+++ b/internal/adapters/ai/client_test.go
@@ -1,0 +1,60 @@
+package ai
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+func TestRoutingClientDispatchesByProvider(t *testing.T) {
+	ollamaClient := &stubDecisionClient{
+		result: ports.ProviderDecisionResult{RawResponse: `{"ok":true}`},
+	}
+	router := NewRoutingClient(map[string]ports.DecisionClient{
+		"ollama": ollamaClient,
+	})
+
+	result, err := router.RequestDecision(context.Background(), ports.ProviderDecisionRequest{
+		Provider: "OLLAMA",
+		Model:    "gemma4:e4b",
+	})
+	if err != nil {
+		t.Fatalf("RequestDecision() error = %v", err)
+	}
+	if result.RawResponse != `{"ok":true}` {
+		t.Fatalf("RawResponse = %q, want JSON payload", result.RawResponse)
+	}
+	if len(ollamaClient.requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(ollamaClient.requests))
+	}
+}
+
+func TestRoutingClientRejectsUnsupportedProvider(t *testing.T) {
+	router := NewRoutingClient(map[string]ports.DecisionClient{
+		"ollama": &stubDecisionClient{},
+	})
+
+	_, err := router.RequestDecision(context.Background(), ports.ProviderDecisionRequest{Provider: "openrouter"})
+	if err == nil {
+		t.Fatal("RequestDecision() error = nil, want unsupported-provider error")
+	}
+	if !strings.Contains(err.Error(), `unsupported AI provider "openrouter"`) {
+		t.Fatalf("RequestDecision() error = %v, want unsupported-provider message", err)
+	}
+}
+
+type stubDecisionClient struct {
+	requests []ports.ProviderDecisionRequest
+	result   ports.ProviderDecisionResult
+	err      error
+}
+
+func (s *stubDecisionClient) RequestDecision(_ context.Context, request ports.ProviderDecisionRequest) (ports.ProviderDecisionResult, error) {
+	s.requests = append(s.requests, request)
+	if s.err != nil {
+		return ports.ProviderDecisionResult{}, s.err
+	}
+	return s.result, nil
+}

--- a/internal/adapters/ai/ollama/client.go
+++ b/internal/adapters/ai/ollama/client.go
@@ -1,0 +1,150 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+const defaultBaseURL = "http://localhost:11434/"
+
+type Option func(*Client)
+
+// Client executes provider-neutral decision requests against the Ollama
+// `/api/generate` endpoint.
+type Client struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+}
+
+func WithBaseURL(rawURL string) Option {
+	return func(client *Client) {
+		if client != nil {
+			client.baseURL, _ = parseBaseURL(rawURL)
+		}
+	}
+}
+
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(client *Client) {
+		if client != nil && httpClient != nil {
+			client.httpClient = httpClient
+		}
+	}
+}
+
+func New(options ...Option) (*Client, error) {
+	baseURL, err := parseBaseURL(defaultBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		baseURL:    baseURL,
+		httpClient: http.DefaultClient,
+	}
+	for _, option := range options {
+		if option != nil {
+			option(client)
+		}
+	}
+	if client.baseURL == nil {
+		return nil, fmt.Errorf("ollama client base URL is not configured")
+	}
+	return client, nil
+}
+
+func (c *Client) RequestDecision(ctx context.Context, request ports.ProviderDecisionRequest) (ports.ProviderDecisionResult, error) {
+	if c == nil || c.baseURL == nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("ollama client is not configured")
+	}
+
+	body := generateRequest{
+		Model:  strings.TrimSpace(request.Model),
+		Prompt: request.UserPrompt,
+		System: request.SystemPrompt,
+		Stream: false,
+	}
+	if request.RequireJSONOnly {
+		body.Format = "json"
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("marshal ollama request: %w", err)
+	}
+
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL("/api/generate"), bytes.NewReader(payload))
+	if err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("build ollama request: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Accept", "application/json")
+
+	response, err := c.httpClient.Do(httpRequest)
+	if err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("call ollama generate API: %w", err)
+	}
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("read ollama response: %w", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("ollama generate API returned %s: %s", response.Status, strings.TrimSpace(string(data)))
+	}
+
+	var parsed generateResponse
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("decode ollama response: %w", err)
+	}
+
+	return ports.ProviderDecisionResult{
+		RawResponse: parsed.Response,
+	}, nil
+}
+
+func (c *Client) endpointURL(path string) string {
+	return c.baseURL.ResolveReference(&url.URL{Path: path}).String()
+}
+
+func parseBaseURL(rawURL string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return nil, fmt.Errorf("ollama base URL must not be empty")
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("parse ollama base URL %q: %w", rawURL, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("ollama base URL %q must include scheme and host", rawURL)
+	}
+	if !strings.HasSuffix(parsed.Path, "/") {
+		parsed.Path += "/"
+	}
+
+	return parsed, nil
+}
+
+type generateRequest struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	System string `json:"system,omitempty"`
+	Format any    `json:"format,omitempty"`
+	Stream bool   `json:"stream"`
+}
+
+type generateResponse struct {
+	Response string `json:"response"`
+}

--- a/internal/adapters/ai/ollama/client_test.go
+++ b/internal/adapters/ai/ollama/client_test.go
@@ -1,0 +1,90 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+func TestClientRequestsNonStreamingJSONResponse(t *testing.T) {
+	var requestBody generateRequest
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/generate" {
+			t.Fatalf("request path = %q, want /api/generate", request.URL.Path)
+		}
+		if err := json.NewDecoder(request.Body).Decode(&requestBody); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"response":"{\"contract_version\":\"herbiego.ai.v1\"}"}`))
+	}))
+	defer server.Close()
+
+	client, err := New(
+		WithBaseURL(server.URL),
+		WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := client.RequestDecision(context.Background(), ports.ProviderDecisionRequest{
+		Model:           "gemma4:e4b",
+		SystemPrompt:    "system",
+		UserPrompt:      "user",
+		RequireJSONOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("RequestDecision() error = %v", err)
+	}
+
+	if requestBody.Model != "gemma4:e4b" {
+		t.Fatalf("request model = %q, want gemma4:e4b", requestBody.Model)
+	}
+	if requestBody.System != "system" {
+		t.Fatalf("request system = %q, want system", requestBody.System)
+	}
+	if requestBody.Prompt != "user" {
+		t.Fatalf("request prompt = %q, want user", requestBody.Prompt)
+	}
+	if requestBody.Format != "json" {
+		t.Fatalf("request format = %v, want json", requestBody.Format)
+	}
+	if requestBody.Stream {
+		t.Fatal("request stream = true, want false")
+	}
+	if result.RawResponse != `{"contract_version":"herbiego.ai.v1"}` {
+		t.Fatalf("RawResponse = %q, want returned response text", result.RawResponse)
+	}
+}
+
+func TestClientReturnsHTTPFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		http.Error(writer, `{"error":"model not found"}`, http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	client, err := New(
+		WithBaseURL(server.URL),
+		WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = client.RequestDecision(context.Background(), ports.ProviderDecisionRequest{Model: "missing-model"})
+	if err == nil {
+		t.Fatal("RequestDecision() error = nil, want HTTP failure")
+	}
+	if !strings.Contains(err.Error(), "400 Bad Request") {
+		t.Fatalf("RequestDecision() error = %v, want HTTP status", err)
+	}
+	if !strings.Contains(err.Error(), "model not found") {
+		t.Fatalf("RequestDecision() error = %v, want response body", err)
+	}
+}

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -240,7 +240,10 @@ func (c *Config) normalize() {
 				Provider: ProviderName(strings.ToLower(strings.TrimSpace(string(roleFile.Provider)))),
 				Model:    strings.TrimSpace(roleFile.Model),
 			}
-			if entry, ok := c.LLMCatalog.Lookup(roleCfg.Provider, roleCfg.Model); ok {
+			if entry, ok := c.LLMCatalog.Lookup(roleCfg.Provider); ok {
+				if roleCfg.Model == "" {
+					roleCfg.Model = entry.Model
+				}
 				roleCfg.URL = entry.URL
 				roleCfg.APISDKType = entry.APISDKType
 				roleCfg.APIKey = entry.APIKey
@@ -285,26 +288,23 @@ func validateRoleConfig(roleID domain.RoleID, roleCfg RoleConfig, requireCatalog
 		if roleCfg.Provider == "" {
 			errs = append(errs, fmt.Errorf("%s provider must not be empty", roleID))
 		}
-		if roleCfg.Model == "" {
-			errs = append(errs, fmt.Errorf("%s model must not be empty", roleID))
-		}
 	case PlayerKindAI:
 		if roleCfg.Provider == "" {
 			errs = append(errs, fmt.Errorf("%s provider must not be empty", roleID))
-		}
-		if roleCfg.Model == "" {
-			errs = append(errs, fmt.Errorf("%s model must not be empty", roleID))
 		}
 	default:
 		errs = append(errs, fmt.Errorf("%s kind must be %q or %q", roleID, PlayerKindHuman, PlayerKindAI))
 	}
 
-	if requireCatalog && roleCfg.Provider != "" && roleCfg.Model != "" {
+	if requireCatalog && roleCfg.Provider != "" {
+		if strings.TrimSpace(roleCfg.Model) == "" {
+			errs = append(errs, fmt.Errorf("%s provider label must exist in llm catalog with a model", roleID))
+		}
 		if strings.TrimSpace(roleCfg.URL) == "" {
-			errs = append(errs, fmt.Errorf("%s provider/model must exist in llm catalog with a non-empty URL", roleID))
+			errs = append(errs, fmt.Errorf("%s provider label must exist in llm catalog with a non-empty URL", roleID))
 		}
 		if roleCfg.APISDKType == "" {
-			errs = append(errs, fmt.Errorf("%s provider/model must exist in llm catalog with a non-empty api_sdk_type", roleID))
+			errs = append(errs, fmt.Errorf("%s provider label must exist in llm catalog with a non-empty api_sdk_type", roleID))
 		}
 	}
 
@@ -319,11 +319,10 @@ func (c *Config) WithLLMCatalog(catalog LLMCatalog) {
 	c.LLMCatalog = catalog
 }
 
-func (c LLMCatalog) Lookup(provider ProviderName, model string) (LLMCatalogEntry, bool) {
+func (c LLMCatalog) Lookup(provider ProviderName) (LLMCatalogEntry, bool) {
 	name := strings.ToLower(strings.TrimSpace(string(provider)))
-	model = strings.TrimSpace(model)
 	for _, entry := range c.Entries {
-		if strings.ToLower(strings.TrimSpace(string(entry.Provider))) == name && strings.TrimSpace(entry.Model) == model {
+		if strings.ToLower(strings.TrimSpace(string(entry.Provider))) == name {
 			return entry, true
 		}
 	}
@@ -344,7 +343,7 @@ func (c LLMCatalog) Validate() error {
 	var errs []error
 	seen := make(map[string]bool, len(c.Entries))
 	for _, entry := range c.Entries {
-		key := fmt.Sprintf("%s::%s", entry.Provider, entry.Model)
+		key := string(entry.Provider)
 		if strings.TrimSpace(string(entry.Provider)) == "" {
 			errs = append(errs, errors.New("llm catalog provider_name must not be empty"))
 		}
@@ -362,7 +361,7 @@ func (c LLMCatalog) Validate() error {
 			errs = append(errs, fmt.Errorf("llm catalog entry %q/%q api_sdk_type must be %q or %q", entry.Provider, entry.Model, APISDKTypeOllama, APISDKTypeOpenAI))
 		}
 		if seen[key] {
-			errs = append(errs, fmt.Errorf("llm catalog entry %q/%q must be unique", entry.Provider, entry.Model))
+			errs = append(errs, fmt.Errorf("llm catalog provider_name %q must be unique", entry.Provider))
 		}
 		seen[key] = true
 	}

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
@@ -11,9 +12,10 @@ import (
 )
 
 const (
-	defaultConfigPath  = "herbiego.yaml"
-	defaultEnvironment = "local"
-	defaultRandomSeed  = uint64(1)
+	defaultConfigPath     = "herbiego.yaml"
+	defaultLLMCatalogPath = "llm.yaml"
+	defaultEnvironment    = "local"
+	defaultRandomSeed     = uint64(1)
 )
 
 var preferredHumanRoleOrder = []domain.RoleID{
@@ -46,6 +48,7 @@ type Config struct {
 	HumanPlayers int                          `yaml:"human_players"`
 	Roles        map[domain.RoleID]RoleConfig `yaml:"-"`
 	RoleConfigs  []RoleConfigFile             `yaml:"roles"`
+	LLMCatalog   LLMCatalog                   `yaml:"-"`
 }
 
 // RandomConfig controls deterministic randomness for the process.
@@ -55,9 +58,12 @@ type RandomConfig struct {
 
 // RoleConfig defines runtime settings for a single role.
 type RoleConfig struct {
-	Kind     PlayerKind
-	Provider ProviderName
-	Model    string
+	Kind       PlayerKind
+	Provider   ProviderName
+	Model      string
+	URL        string
+	APISDKType APISDKType
+	APIKey     string
 }
 
 // RoleConfigFile is the editable YAML representation for a role's runtime options.
@@ -70,8 +76,31 @@ type RoleConfigFile struct {
 // BootstrapOptions controls startup loading behavior.
 type BootstrapOptions struct {
 	ConfigPath           string
+	LLMCatalogPath       string
 	HumanPlayersOverride *int
 	SeedOverride         *uint64
+}
+
+// APISDKType identifies the wire protocol family an external provider uses.
+type APISDKType string
+
+const (
+	APISDKTypeOllama APISDKType = "ollama"
+	APISDKTypeOpenAI APISDKType = "openai"
+)
+
+// LLMCatalog stores named provider/model connection metadata loaded from llm.yaml.
+type LLMCatalog struct {
+	Entries []LLMCatalogEntry `yaml:"models"`
+}
+
+// LLMCatalogEntry is one editable catalog entry for a provider/model pair.
+type LLMCatalogEntry struct {
+	Provider   ProviderName `yaml:"provider_name"`
+	Model      string       `yaml:"model_name"`
+	URL        string       `yaml:"url"`
+	APISDKType APISDKType   `yaml:"api_sdk_type"`
+	APIKey     string       `yaml:"api_key"`
 }
 
 // LoadConfig reads runtime configuration from a YAML file.
@@ -103,6 +132,30 @@ func LoadConfig(path string) (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// LoadLLMCatalog reads provider/model connection metadata from a YAML file.
+func LoadLLMCatalog(path string) (LLMCatalog, error) {
+	if strings.TrimSpace(path) == "" {
+		path = defaultLLMCatalogPath
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return LLMCatalog{}, fmt.Errorf("read LLM catalog file %q: %w", path, err)
+	}
+
+	var catalog LLMCatalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		return LLMCatalog{}, fmt.Errorf("parse LLM catalog file %q: %w", path, err)
+	}
+
+	catalog.normalize()
+	if err := catalog.Validate(); err != nil {
+		return LLMCatalog{}, fmt.Errorf("validate LLM catalog file %q: %w", path, err)
+	}
+
+	return catalog, nil
 }
 
 // ApplyOverrides applies runtime-only startup overrides after config loading.
@@ -138,6 +191,10 @@ func (c *Config) Validate() error {
 		errs = append(errs, fmt.Errorf("human_players must be between 0 and %d", len(expectedRoles)))
 	}
 
+	if err := c.LLMCatalog.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("llm catalog: %w", err))
+	}
+
 	for _, roleID := range expectedRoles {
 		roleCfg, ok := c.Roles[roleID]
 		if !ok {
@@ -145,7 +202,7 @@ func (c *Config) Validate() error {
 			continue
 		}
 
-		if err := validateRoleConfig(roleID, roleCfg); err != nil {
+		if err := validateRoleConfig(roleID, roleCfg, len(c.LLMCatalog.Entries) > 0); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -178,11 +235,17 @@ func (c *Config) normalize() {
 		c.Roles = make(map[domain.RoleID]RoleConfig, len(c.RoleConfigs))
 		for _, roleFile := range c.RoleConfigs {
 			roleID := roleFile.RoleID
-			c.Roles[roleID] = RoleConfig{
+			roleCfg := RoleConfig{
 				Kind:     PlayerKindAI,
 				Provider: ProviderName(strings.ToLower(strings.TrimSpace(string(roleFile.Provider)))),
 				Model:    strings.TrimSpace(roleFile.Model),
 			}
+			if entry, ok := c.LLMCatalog.Lookup(roleCfg.Provider, roleCfg.Model); ok {
+				roleCfg.URL = entry.URL
+				roleCfg.APISDKType = entry.APISDKType
+				roleCfg.APIKey = entry.APIKey
+			}
+			c.Roles[roleID] = roleCfg
 		}
 
 		for _, roleID := range selectedHumanRoles(c.HumanPlayers) {
@@ -209,7 +272,7 @@ func selectedHumanRoles(humanPlayers int) []domain.RoleID {
 	return preferredHumanRoleOrder[:humanPlayers]
 }
 
-func validateRoleConfig(roleID domain.RoleID, roleCfg RoleConfig) error {
+func validateRoleConfig(roleID domain.RoleID, roleCfg RoleConfig, requireCatalog bool) error {
 	var errs []error
 
 	if roleCfg.Kind == "" {
@@ -236,9 +299,85 @@ func validateRoleConfig(roleID domain.RoleID, roleCfg RoleConfig) error {
 		errs = append(errs, fmt.Errorf("%s kind must be %q or %q", roleID, PlayerKindHuman, PlayerKindAI))
 	}
 
+	if requireCatalog && roleCfg.Provider != "" && roleCfg.Model != "" {
+		if strings.TrimSpace(roleCfg.URL) == "" {
+			errs = append(errs, fmt.Errorf("%s provider/model must exist in llm catalog with a non-empty URL", roleID))
+		}
+		if roleCfg.APISDKType == "" {
+			errs = append(errs, fmt.Errorf("%s provider/model must exist in llm catalog with a non-empty api_sdk_type", roleID))
+		}
+	}
+
 	if len(errs) == 0 {
 		return nil
 	}
 
 	return errors.Join(errs...)
+}
+
+func (c *Config) WithLLMCatalog(catalog LLMCatalog) {
+	c.LLMCatalog = catalog
+}
+
+func (c LLMCatalog) Lookup(provider ProviderName, model string) (LLMCatalogEntry, bool) {
+	name := strings.ToLower(strings.TrimSpace(string(provider)))
+	model = strings.TrimSpace(model)
+	for _, entry := range c.Entries {
+		if strings.ToLower(strings.TrimSpace(string(entry.Provider))) == name && strings.TrimSpace(entry.Model) == model {
+			return entry, true
+		}
+	}
+	return LLMCatalogEntry{}, false
+}
+
+func (c *LLMCatalog) normalize() {
+	for i := range c.Entries {
+		c.Entries[i].Provider = ProviderName(strings.ToLower(strings.TrimSpace(string(c.Entries[i].Provider))))
+		c.Entries[i].Model = strings.TrimSpace(c.Entries[i].Model)
+		c.Entries[i].URL = strings.TrimSpace(c.Entries[i].URL)
+		c.Entries[i].APISDKType = APISDKType(strings.ToLower(strings.TrimSpace(string(c.Entries[i].APISDKType))))
+		c.Entries[i].APIKey = strings.TrimSpace(c.Entries[i].APIKey)
+	}
+}
+
+func (c LLMCatalog) Validate() error {
+	var errs []error
+	seen := make(map[string]bool, len(c.Entries))
+	for _, entry := range c.Entries {
+		key := fmt.Sprintf("%s::%s", entry.Provider, entry.Model)
+		if strings.TrimSpace(string(entry.Provider)) == "" {
+			errs = append(errs, errors.New("llm catalog provider_name must not be empty"))
+		}
+		if strings.TrimSpace(entry.Model) == "" {
+			errs = append(errs, errors.New("llm catalog model_name must not be empty"))
+		}
+		if strings.TrimSpace(entry.URL) == "" {
+			errs = append(errs, fmt.Errorf("llm catalog entry %q/%q url must not be empty", entry.Provider, entry.Model))
+		}
+		switch entry.APISDKType {
+		case APISDKTypeOllama, APISDKTypeOpenAI:
+		case "":
+			errs = append(errs, fmt.Errorf("llm catalog entry %q/%q api_sdk_type must not be empty", entry.Provider, entry.Model))
+		default:
+			errs = append(errs, fmt.Errorf("llm catalog entry %q/%q api_sdk_type must be %q or %q", entry.Provider, entry.Model, APISDKTypeOllama, APISDKTypeOpenAI))
+		}
+		if seen[key] {
+			errs = append(errs, fmt.Errorf("llm catalog entry %q/%q must be unique", entry.Provider, entry.Model))
+		}
+		seen[key] = true
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.Join(errs...)
+}
+
+func resolveLLMCatalogPath(configPath, catalogPath string) string {
+	if strings.TrimSpace(catalogPath) != "" {
+		return catalogPath
+	}
+	if strings.TrimSpace(configPath) == "" {
+		return defaultLLMCatalogPath
+	}
+	return filepath.Join(filepath.Dir(configPath), defaultLLMCatalogPath)
 }

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -17,16 +17,16 @@ random:
 human_players: 1
 roles:
   - role_id: procurement_manager
-    provider: ollama
+    provider: ollama-localhost
     model: llama3.2:3b
   - role_id: production_manager
-    provider: ollama
+    provider: ollama-localhost
     model: llama3.2:3b
   - role_id: sales_manager
     provider: openrouter
     model: openai/gpt-5-mini
   - role_id: finance_controller
-    provider: ollama
+    provider: ollama-localhost
     model: llama3.2:3b
 `)
 
@@ -34,6 +34,26 @@ roles:
 	if err != nil {
 		t.Fatalf("LoadConfig() error = %v", err)
 	}
+
+	catalogPath := writeSiblingFile(t, configPath, "llm.yaml", `
+models:
+  - provider_name: ollama-localhost
+    model_name: llama3.2:3b
+    url: http://localhost:11434/
+    api_sdk_type: ollama
+    api_key: ""
+  - provider_name: openrouter
+    model_name: openai/gpt-5-mini
+    url: https://openrouter.ai/api/v1/
+    api_sdk_type: openai
+    api_key: ""
+`)
+	catalog, err := LoadLLMCatalog(catalogPath)
+	if err != nil {
+		t.Fatalf("LoadLLMCatalog() error = %v", err)
+	}
+	cfg.WithLLMCatalog(catalog)
+	cfg = cfg.ApplyOverrides(BootstrapOptions{})
 
 	if cfg.Environment != "local" {
 		t.Fatalf("Environment = %q, want %q", cfg.Environment, "local")
@@ -54,22 +74,28 @@ roles:
 	if cfg.Roles[domain.RoleProcurementManager].Kind != PlayerKindAI {
 		t.Fatalf("procurement kind = %q, want %q", cfg.Roles[domain.RoleProcurementManager].Kind, PlayerKindAI)
 	}
+	if cfg.Roles[domain.RoleProcurementManager].URL != "http://localhost:11434/" {
+		t.Fatalf("procurement url = %q, want localhost Ollama endpoint", cfg.Roles[domain.RoleProcurementManager].URL)
+	}
+	if cfg.Roles[domain.RoleSalesManager].APISDKType != APISDKTypeOpenAI {
+		t.Fatalf("sales api sdk type = %q, want %q", cfg.Roles[domain.RoleSalesManager].APISDKType, APISDKTypeOpenAI)
+	}
 }
 
 func TestConfigApplyOverridesSupportsAITestMode(t *testing.T) {
 	configPath := writeConfigFile(t, `
 roles:
   - role_id: procurement_manager
-    provider: ollama
+    provider: ollama-localhost
     model: llama3.2:3b
   - role_id: production_manager
-    provider: ollama
+    provider: ollama-localhost
     model: llama3.2:3b
   - role_id: sales_manager
     provider: openrouter
     model: openai/gpt-5-mini
   - role_id: finance_controller
-    provider: ollama
+    provider: ollama-localhost
     model: llama3.2:3b
 `)
 
@@ -77,6 +103,25 @@ roles:
 	if err != nil {
 		t.Fatalf("LoadConfig() error = %v", err)
 	}
+
+	catalogPath := writeSiblingFile(t, configPath, "llm.yaml", `
+models:
+  - provider_name: ollama-localhost
+    model_name: llama3.2:3b
+    url: http://localhost:11434/
+    api_sdk_type: ollama
+    api_key: ""
+  - provider_name: openrouter
+    model_name: openai/gpt-5-mini
+    url: https://openrouter.ai/api/v1/
+    api_sdk_type: openai
+    api_key: ""
+`)
+	catalog, err := LoadLLMCatalog(catalogPath)
+	if err != nil {
+		t.Fatalf("LoadLLMCatalog() error = %v", err)
+	}
+	cfg.WithLLMCatalog(catalog)
 
 	humanPlayers := 0
 	seed := uint64(42)
@@ -127,6 +172,57 @@ roles:
 	}
 }
 
+func TestLoadLLMCatalogRejectsDuplicateProviderModelPairs(t *testing.T) {
+	path := writeCatalogFile(t, `
+models:
+  - provider_name: ollama-localhost
+    model_name: gemma4:e4b
+    url: http://localhost:11434/
+    api_sdk_type: ollama
+    api_key: ""
+  - provider_name: ollama-localhost
+    model_name: gemma4:e4b
+    url: https://ollama.com/
+    api_sdk_type: ollama
+    api_key: ""
+`)
+
+	_, err := LoadLLMCatalog(path)
+	if err == nil {
+		t.Fatal("LoadLLMCatalog() error = nil, want duplicate-entry validation error")
+	}
+	if !strings.Contains(err.Error(), `must be unique`) {
+		t.Fatalf("LoadLLMCatalog() error = %v, want duplicate-entry validation", err)
+	}
+}
+
+func TestNewRuntimeRejectsRolesMissingCatalogEntries(t *testing.T) {
+	_, err := NewRuntime(Config{
+		Environment:  "test",
+		HumanPlayers: 0,
+		Random: RandomConfig{
+			Seed: 9,
+		},
+		LLMCatalog: LLMCatalog{
+			Entries: []LLMCatalogEntry{
+				{Provider: "ollama-localhost", Model: "gemma4:e4b", URL: "http://localhost:11434/", APISDKType: APISDKTypeOllama},
+			},
+		},
+		RoleConfigs: []RoleConfigFile{
+			{RoleID: "procurement_manager", Provider: "ollama-localhost", Model: "gemma4:e4b"},
+			{RoleID: "production_manager", Provider: "ollama-localhost", Model: "gemma4:e4b"},
+			{RoleID: "sales_manager", Provider: "openrouter", Model: "openai/gpt-5-mini"},
+			{RoleID: "finance_controller", Provider: "ollama-localhost", Model: "gemma4:e4b"},
+		},
+	})
+	if err == nil {
+		t.Fatal("NewRuntime() error = nil, want missing-catalog validation error")
+	}
+	if !strings.Contains(err.Error(), "llm catalog") {
+		t.Fatalf("NewRuntime() error = %v, want llm-catalog validation", err)
+	}
+}
+
 func writeConfigFile(t *testing.T, contents string) string {
 	t.Helper()
 
@@ -136,5 +232,22 @@ func writeConfigFile(t *testing.T, contents string) string {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
+	return path
+}
+
+func writeCatalogFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	return writeSiblingFile(t, filepath.Join(dir, "herbiego.yaml"), "llm.yaml", contents)
+}
+
+func writeSiblingFile(t *testing.T, anchorPath, name, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(filepath.Dir(anchorPath), name)
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(contents)), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
 	return path
 }

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -18,16 +18,12 @@ human_players: 1
 roles:
   - role_id: procurement_manager
     provider: ollama-localhost
-    model: llama3.2:3b
   - role_id: production_manager
     provider: ollama-localhost
-    model: llama3.2:3b
   - role_id: sales_manager
     provider: openrouter
-    model: openai/gpt-5-mini
   - role_id: finance_controller
     provider: ollama-localhost
-    model: llama3.2:3b
 `)
 
 	cfg, err := LoadConfig(configPath)
@@ -87,16 +83,12 @@ func TestConfigApplyOverridesSupportsAITestMode(t *testing.T) {
 roles:
   - role_id: procurement_manager
     provider: ollama-localhost
-    model: llama3.2:3b
   - role_id: production_manager
     provider: ollama-localhost
-    model: llama3.2:3b
   - role_id: sales_manager
     provider: openrouter
-    model: openai/gpt-5-mini
   - role_id: finance_controller
     provider: ollama-localhost
-    model: llama3.2:3b
 `)
 
 	cfg, err := LoadConfig(configPath)
@@ -164,7 +156,6 @@ roles:
 		"human_players must be between 0 and 4",
 		"roles must include exactly 4 canonical roles",
 		"procurement_manager provider must not be empty",
-		"procurement_manager model must not be empty",
 	} {
 		if !strings.Contains(message, want) {
 			t.Fatalf("error %q does not contain %q", message, want)
@@ -181,7 +172,7 @@ models:
     api_sdk_type: ollama
     api_key: ""
   - provider_name: ollama-localhost
-    model_name: gemma4:e4b
+    model_name: llama3.2:3b
     url: https://ollama.com/
     api_sdk_type: ollama
     api_key: ""
@@ -191,7 +182,7 @@ models:
 	if err == nil {
 		t.Fatal("LoadLLMCatalog() error = nil, want duplicate-entry validation error")
 	}
-	if !strings.Contains(err.Error(), `must be unique`) {
+	if !strings.Contains(err.Error(), `provider_name "ollama-localhost" must be unique`) {
 		t.Fatalf("LoadLLMCatalog() error = %v, want duplicate-entry validation", err)
 	}
 }
@@ -209,16 +200,16 @@ func TestNewRuntimeRejectsRolesMissingCatalogEntries(t *testing.T) {
 			},
 		},
 		RoleConfigs: []RoleConfigFile{
-			{RoleID: "procurement_manager", Provider: "ollama-localhost", Model: "gemma4:e4b"},
-			{RoleID: "production_manager", Provider: "ollama-localhost", Model: "gemma4:e4b"},
-			{RoleID: "sales_manager", Provider: "openrouter", Model: "openai/gpt-5-mini"},
-			{RoleID: "finance_controller", Provider: "ollama-localhost", Model: "gemma4:e4b"},
+			{RoleID: "procurement_manager", Provider: "ollama-localhost"},
+			{RoleID: "production_manager", Provider: "ollama-localhost"},
+			{RoleID: "sales_manager", Provider: "openrouter"},
+			{RoleID: "finance_controller", Provider: "ollama-localhost"},
 		},
 	})
 	if err == nil {
 		t.Fatal("NewRuntime() error = nil, want missing-catalog validation error")
 	}
-	if !strings.Contains(err.Error(), "llm catalog") {
+	if !strings.Contains(err.Error(), "provider label") {
 		t.Fatalf("NewRuntime() error = %v, want llm-catalog validation", err)
 	}
 }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -25,6 +25,12 @@ func Bootstrap(options BootstrapOptions) (Runtime, error) {
 		return Runtime{}, fmt.Errorf("load runtime config: %w", err)
 	}
 
+	catalog, err := LoadLLMCatalog(resolveLLMCatalogPath(options.ConfigPath, options.LLMCatalogPath))
+	if err != nil {
+		return Runtime{}, fmt.Errorf("load llm catalog: %w", err)
+	}
+	cfg.WithLLMCatalog(catalog)
+
 	cfg = cfg.ApplyOverrides(options)
 	return NewRuntime(cfg)
 }

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -16,10 +16,10 @@ func TestNewRuntimeSeedsDefaultStarterMatch(t *testing.T) {
 			},
 		},
 		RoleConfigs: []RoleConfigFile{
-			{RoleID: "procurement_manager", Provider: "ollama-localhost", Model: "gemma4:e4b"},
-			{RoleID: "production_manager", Provider: "ollama-localhost", Model: "gemma4:e4b"},
-			{RoleID: "sales_manager", Provider: "openrouter", Model: "openai/gpt-5-mini"},
-			{RoleID: "finance_controller", Provider: "ollama-localhost", Model: "gemma4:e4b"},
+			{RoleID: "procurement_manager", Provider: "ollama-localhost"},
+			{RoleID: "production_manager", Provider: "ollama-localhost"},
+			{RoleID: "sales_manager", Provider: "openrouter"},
+			{RoleID: "finance_controller", Provider: "ollama-localhost"},
 		},
 	})
 	if err != nil {

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -9,11 +9,17 @@ func TestNewRuntimeSeedsDefaultStarterMatch(t *testing.T) {
 		Random: RandomConfig{
 			Seed: 9,
 		},
+		LLMCatalog: LLMCatalog{
+			Entries: []LLMCatalogEntry{
+				{Provider: "ollama-localhost", Model: "gemma4:e4b", URL: "http://localhost:11434/", APISDKType: APISDKTypeOllama},
+				{Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: APISDKTypeOpenAI},
+			},
+		},
 		RoleConfigs: []RoleConfigFile{
-			{RoleID: "procurement_manager", Provider: "ollama", Model: "llama3.2:3b"},
-			{RoleID: "production_manager", Provider: "ollama", Model: "llama3.2:3b"},
+			{RoleID: "procurement_manager", Provider: "ollama-localhost", Model: "gemma4:e4b"},
+			{RoleID: "production_manager", Provider: "ollama-localhost", Model: "gemma4:e4b"},
 			{RoleID: "sales_manager", Provider: "openrouter", Model: "openai/gpt-5-mini"},
-			{RoleID: "finance_controller", Provider: "ollama", Model: "llama3.2:3b"},
+			{RoleID: "finance_controller", Provider: "ollama-localhost", Model: "gemma4:e4b"},
 		},
 	})
 	if err != nil {

--- a/llm.yaml
+++ b/llm.yaml
@@ -1,0 +1,16 @@
+models:
+  - provider_name: ollama-localhost
+    model_name: gemma4:e4b
+    url: http://localhost:11434/
+    api_sdk_type: ollama
+    api_key: ""
+  - provider_name: ollama-cloud
+    model_name: gemma4:e4b
+    url: https://ollama.com/api/
+    api_sdk_type: ollama
+    api_key: ""
+  - provider_name: openrouter
+    model_name: openai/gpt-5-mini
+    url: https://openrouter.ai/api/v1/
+    api_sdk_type: openai
+    api_key: ""


### PR DESCRIPTION
## Summary
- add an Ollama-backed `DecisionClient` that calls `/api/generate` with non-streaming JSON output and the default local endpoint `http://localhost:11434/`
- add a small provider router so the app still talks through the provider-neutral AI interface while dispatching to the concrete adapter
- wire AI-controlled CLI roles through the shared orchestrator and update the default runtime config to use Ollama with `gemma4:e4b`

## Why
Issue #21 asked for a working Ollama adapter behind the neutral AI interface so at least one role can complete turns without provider-specific details leaking into the core game logic.

## Validation
- `go test ./...`

## Clarification Questions
1. For the note that more than one provider may use the Ollama API, would you like the next step to introduce a first-class provider catalog with API-family aliases and per-provider base URLs, or should we keep `provider: ollama` as the only Ollama-compatible name for now?
2. Should the future OpenRouter adapter plug into the same CLI mixed-player path immediately, or would you prefer that unsupported providers continue to fail fast until each adapter is fully implemented?

Closes #21