### PR TITLE
Add OpenAI-compatible adapter for OpenRouter-backed roles

### DIFF
--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/ai"
 	"github.com/jpconstantineau/herbiego/internal/adapters/ai/ollama"
+	"github.com/jpconstantineau/herbiego/internal/adapters/ai/openai"
 	"github.com/jpconstantineau/herbiego/internal/adapters/player/human"
 	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
 	"github.com/jpconstantineau/herbiego/internal/app"
@@ -116,7 +117,14 @@ func buildDecisionClients(cfg app.Config) (map[string]ports.DecisionClient, erro
 			}
 			clients[providerName] = client
 		case app.APISDKTypeOpenAI:
-			continue
+			client, err := openai.New(
+				openai.WithBaseURL(roleCfg.URL),
+				openai.WithAPIKey(roleCfg.APIKey),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("configure provider %q: %w", roleCfg.Provider, err)
+			}
+			clients[providerName] = client
 		default:
 			return nil, fmt.Errorf("provider %q uses unsupported api_sdk_type %q", roleCfg.Provider, roleCfg.APISDKType)
 		}

--- a/cmd/herbiego/main_test.go
+++ b/cmd/herbiego/main_test.go
@@ -60,11 +60,11 @@ func TestBuildPlayersRejectsUnsupportedAIProvider(t *testing.T) {
 		},
 	}
 
-	_, err := buildPlayers(runtime, &terminalController{})
-	if err == nil {
-		t.Fatal("buildPlayers() error = nil, want unsupported-provider error")
+	players, err := buildPlayers(runtime, &terminalController{})
+	if err != nil {
+		t.Fatalf("buildPlayers() error = %v, want nil", err)
 	}
-	if got, want := err.Error(), `role "production_manager" uses unsupported AI provider "openrouter"`; got != want {
-		t.Fatalf("buildPlayers() error = %q, want %q", got, want)
+	if _, ok := players[domain.RoleProductionManager].(*llm.Player); !ok {
+		t.Fatalf("production player type = %T, want *llm.Player", players[domain.RoleProductionManager])
 	}
 }

--- a/internal/adapters/ai/openai/client.go
+++ b/internal/adapters/ai/openai/client.go
@@ -1,0 +1,225 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+const defaultBaseURL = "https://api.openai.com/v1/"
+
+type Option func(*Client)
+
+// Client executes provider-neutral decision requests against an
+// OpenAI-compatible `/chat/completions` endpoint.
+type Client struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+	apiKey     string
+}
+
+func WithBaseURL(rawURL string) Option {
+	return func(client *Client) {
+		if client != nil {
+			client.baseURL, _ = parseBaseURL(rawURL)
+		}
+	}
+}
+
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(client *Client) {
+		if client != nil && httpClient != nil {
+			client.httpClient = httpClient
+		}
+	}
+}
+
+func WithAPIKey(apiKey string) Option {
+	return func(client *Client) {
+		if client != nil {
+			client.apiKey = strings.TrimSpace(apiKey)
+		}
+	}
+}
+
+func New(options ...Option) (*Client, error) {
+	baseURL, err := parseBaseURL(defaultBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		baseURL:    baseURL,
+		httpClient: http.DefaultClient,
+	}
+	for _, option := range options {
+		if option != nil {
+			option(client)
+		}
+	}
+	if client.baseURL == nil {
+		return nil, fmt.Errorf("openai client base URL is not configured")
+	}
+	return client, nil
+}
+
+func (c *Client) RequestDecision(ctx context.Context, request ports.ProviderDecisionRequest) (ports.ProviderDecisionResult, error) {
+	if c == nil || c.baseURL == nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("openai client is not configured")
+	}
+
+	body := chatCompletionsRequest{
+		Model: request.Model,
+		Messages: []chatMessage{
+			{Role: "system", Content: request.SystemPrompt},
+			{Role: "user", Content: request.UserPrompt},
+		},
+	}
+	if request.RequireJSONOnly {
+		body.ResponseFormat = &responseFormat{Type: "json_object"}
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("marshal openai request: %w", err)
+	}
+
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpointURL("/chat/completions"), bytes.NewReader(payload))
+	if err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("build openai request: %w", err)
+	}
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Accept", "application/json")
+	if c.apiKey != "" {
+		httpRequest.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+
+	response, err := c.httpClient.Do(httpRequest)
+	if err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("call openai chat completions API: %w", err)
+	}
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("read openai response: %w", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("openai chat completions API returned %s: %s", response.Status, strings.TrimSpace(string(data)))
+	}
+
+	var parsed chatCompletionsResponse
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return ports.ProviderDecisionResult{}, fmt.Errorf("decode openai response: %w", err)
+	}
+
+	content, err := parsed.firstChoiceContent()
+	if err != nil {
+		return ports.ProviderDecisionResult{}, err
+	}
+
+	return ports.ProviderDecisionResult{RawResponse: content}, nil
+}
+
+func (c *Client) endpointURL(path string) string {
+	return c.baseURL.ResolveReference(&url.URL{Path: path}).String()
+}
+
+func parseBaseURL(rawURL string) (*url.URL, error) {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return nil, fmt.Errorf("openai base URL must not be empty")
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("parse openai base URL %q: %w", rawURL, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return nil, fmt.Errorf("openai base URL %q must include scheme and host", rawURL)
+	}
+	if !strings.HasSuffix(parsed.Path, "/") {
+		parsed.Path += "/"
+	}
+
+	return parsed, nil
+}
+
+type chatCompletionsRequest struct {
+	Model          string          `json:"model"`
+	Messages       []chatMessage   `json:"messages"`
+	ResponseFormat *responseFormat `json:"response_format,omitempty"`
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type responseFormat struct {
+	Type string `json:"type"`
+}
+
+type chatCompletionsResponse struct {
+	Choices []chatCompletionChoice `json:"choices"`
+}
+
+type chatCompletionChoice struct {
+	Message chatCompletionMessage `json:"message"`
+}
+
+type chatCompletionMessage struct {
+	Content json.RawMessage `json:"content"`
+}
+
+func (r chatCompletionsResponse) firstChoiceContent() (string, error) {
+	if len(r.Choices) == 0 {
+		return "", fmt.Errorf("openai response did not include any choices")
+	}
+
+	content, err := decodeContent(r.Choices[0].Message.Content)
+	if err != nil {
+		return "", fmt.Errorf("decode openai response content: %w", err)
+	}
+	if strings.TrimSpace(content) == "" {
+		return "", fmt.Errorf("openai response choice content was empty")
+	}
+	return content, nil
+}
+
+func decodeContent(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", fmt.Errorf("content was missing")
+	}
+
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return text, nil
+	}
+
+	var parts []contentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return "", err
+	}
+
+	var builder strings.Builder
+	for _, part := range parts {
+		if strings.TrimSpace(part.Text) == "" {
+			continue
+		}
+		builder.WriteString(part.Text)
+	}
+	return builder.String(), nil
+}
+
+type contentPart struct {
+	Text string `json:"text"`
+}

--- a/internal/adapters/ai/openai/client_test.go
+++ b/internal/adapters/ai/openai/client_test.go
@@ -1,0 +1,118 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+func TestClientRequestsJSONChatCompletion(t *testing.T) {
+	var requestBody chatCompletionsRequest
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/chat/completions" {
+			t.Fatalf("request path = %q, want /chat/completions", request.URL.Path)
+		}
+		if got := request.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("authorization header = %q, want Bearer test-key", got)
+		}
+		if err := json.NewDecoder(request.Body).Decode(&requestBody); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":"{\"contract_version\":\"herbiego.ai.v1\"}"}}]}`))
+	}))
+	defer server.Close()
+
+	client, err := New(
+		WithBaseURL(server.URL),
+		WithHTTPClient(server.Client()),
+		WithAPIKey("test-key"),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := client.RequestDecision(context.Background(), ports.ProviderDecisionRequest{
+		Model:           "openai/gpt-5-mini",
+		SystemPrompt:    "system",
+		UserPrompt:      "user",
+		RequireJSONOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("RequestDecision() error = %v", err)
+	}
+
+	if requestBody.Model != "openai/gpt-5-mini" {
+		t.Fatalf("request model = %q, want openai/gpt-5-mini", requestBody.Model)
+	}
+	if len(requestBody.Messages) != 2 {
+		t.Fatalf("messages len = %d, want 2", len(requestBody.Messages))
+	}
+	if requestBody.Messages[0].Role != "system" || requestBody.Messages[0].Content != "system" {
+		t.Fatalf("system message = %#v, want system prompt", requestBody.Messages[0])
+	}
+	if requestBody.Messages[1].Role != "user" || requestBody.Messages[1].Content != "user" {
+		t.Fatalf("user message = %#v, want user prompt", requestBody.Messages[1])
+	}
+	if requestBody.ResponseFormat == nil || requestBody.ResponseFormat.Type != "json_object" {
+		t.Fatalf("response format = %#v, want json_object", requestBody.ResponseFormat)
+	}
+	if result.RawResponse != `{"contract_version":"herbiego.ai.v1"}` {
+		t.Fatalf("RawResponse = %q, want response body text", result.RawResponse)
+	}
+}
+
+func TestClientJoinsMultipartContentResponses(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"choices":[{"message":{"content":[{"type":"output_text","text":"{\"contract_version\":"},{"type":"output_text","text":"\"herbiego.ai.v1\"}"}]}}]}`))
+	}))
+	defer server.Close()
+
+	client, err := New(
+		WithBaseURL(server.URL),
+		WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := client.RequestDecision(context.Background(), ports.ProviderDecisionRequest{Model: "gpt-5-mini"})
+	if err != nil {
+		t.Fatalf("RequestDecision() error = %v", err)
+	}
+	if result.RawResponse != `{"contract_version":"herbiego.ai.v1"}` {
+		t.Fatalf("RawResponse = %q, want concatenated multipart content", result.RawResponse)
+	}
+}
+
+func TestClientReturnsHTTPFailures(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		http.Error(writer, `{"error":"bad api key"}`, http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client, err := New(
+		WithBaseURL(server.URL),
+		WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = client.RequestDecision(context.Background(), ports.ProviderDecisionRequest{Model: "missing-model"})
+	if err == nil {
+		t.Fatal("RequestDecision() error = nil, want HTTP failure")
+	}
+	if !strings.Contains(err.Error(), "401 Unauthorized") {
+		t.Fatalf("RequestDecision() error = %v, want HTTP status", err)
+	}
+	if !strings.Contains(err.Error(), "bad api key") {
+		t.Fatalf("RequestDecision() error = %v, want response body", err)
+	}
+}

--- a/internal/adapters/ai/openai/doc.go
+++ b/internal/adapters/ai/openai/doc.go
@@ -1,0 +1,2 @@
+// Package openai implements OpenAI-compatible chat completion adapters.
+package openai


### PR DESCRIPTION
## Summary
- add an `internal/adapters/ai/openai` client for OpenAI-compatible `/chat/completions` providers
- wire `api_sdk_type: openai` entries in `llm.yaml` through the shared decision-client bootstrap path
- cover request translation, multipart response handling, HTTP errors, and startup wiring in tests

## Issues
- Closes #57
- Closes #20

## Notes
- This keeps provider selection driven by `herbiego.yaml` role assignments and `llm.yaml` entries.
- `openrouter` now works because it is cataloged as `api_sdk_type: openai`.
- Key injection remains strictly file-based for now.
- The shared `internal/adapters/ai/openai` package stays provider-neutral.
- Remaining unknown `api_sdk_type` values still fail fast during startup.

## Follow-up
- OpenRouter-specific headers such as `HTTP-Referer` and `X-Title` are tracked in #59.

## Verification
- `go test ./...`