### PR TITLE
[codex] Implement hidden simultaneous turn flow state

### DIFF
--- a/herbiego.yaml
+++ b/herbiego.yaml
@@ -2,6 +2,8 @@ environment: local
 random:
   seed: 1
 human_players: 1
+ui:
+  ai_reveal_delay_seconds: 15
 roles:
   - role_id: procurement_manager
     provider: ollama-localhost

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -251,10 +251,12 @@ func (m Model) renderRoundFeedWorkspace(width int) []string {
 
 	lines := []string{
 		fmt.Sprintf("Round %d for %s", view.Round, m.roleTitle()),
-		"View: current round feed",
+		fmt.Sprintf("View: %s", roundPhaseLabel(view.RoundFlow.Phase)),
 	}
+	lines = append(lines, roundFlowSummary(view.RoundFlow, m.state.Roles)...)
+
 	if len(view.RecentRounds) == 0 {
-		lines = append(lines, "No prior rounds recorded yet.", "Resolved events and role commentary will appear here after round one.")
+		lines = append(lines, "", "No prior rounds recorded yet.", "Resolved events and role commentary will appear here after round one.")
 	} else {
 		lines = append(lines, "")
 	}
@@ -312,16 +314,17 @@ func (m Model) renderActionEntryWorkspace(width int) []string {
 	assignment := m.selectedAssignment()
 	lines := []string{
 		fmt.Sprintf("Decision workspace for %s", m.roleTitle()),
-		"View: future round action entry surface",
+		fmt.Sprintf("View: %s", roundPhaseLabel(m.state.RoundFlow.Phase)),
 	}
 	if assignment.IsHuman {
-		lines = append(lines, "This role is human-controlled, so round decisions will land in this workspace.")
+		lines = append(lines, "This role is human-controlled, so simultaneous turn entry will land in this workspace.")
 	} else {
 		lines = append(lines, "This role is AI-controlled right now. Human decision entry will appear here when a human role is selected.")
 	}
 	lines = append(lines,
 		"",
-		wrapLine("Action entry is intentionally deferred from issue #23 so the four-pane shell can stabilize first.", width-4),
+		wrapLine("Current-turn decisions stay hidden from the shared round feed until the round resolves.", width-4),
+		wrapLine("Action entry is still deferred while the shell stabilizes, so this workspace currently serves as the dedicated collection surface placeholder.", width-4),
 		wrapLine("Use the workspace navigation keys to switch back to reports or the round feed.", width-4),
 	)
 	return lines
@@ -361,6 +364,7 @@ func (m Model) renderStatsPane(width, height int) string {
 
 func (m Model) renderCommandBar(width, height int) string {
 	status := fmt.Sprintf("Mode: inspect | Focus: %s | Role: %s | Round: %d", paneName(m.focusedPane), m.roleTitle(), m.state.CurrentRound)
+	status += " | Phase: " + roundPhaseShortLabel(m.state.RoundFlow.Phase)
 	if detail := strings.TrimSpace(m.statusLine()); detail != "" {
 		status += " | " + detail
 	}
@@ -544,6 +548,111 @@ func workstationSummary(workstations []domain.WorkstationState) string {
 		return "Workstations: waiting for first telemetry"
 	}
 	return fmt.Sprintf("Workstations: %d online", len(workstations))
+}
+
+func roundFlowSummary(flow domain.RoundFlowState, assignments []domain.RoleAssignment) []string {
+	phase := flow.Phase
+	if phase == "" {
+		phase = domain.RoundPhaseCollecting
+	}
+
+	lines := []string{
+		roundPhaseDescription(phase),
+	}
+
+	switch phase {
+	case domain.RoundPhaseCollecting:
+		submitted := len(flow.SubmittedRoles)
+		waiting := len(flow.WaitingOnRoles)
+		total := submitted + waiting
+		if total == 0 {
+			total = len(assignments)
+		}
+		lines = append(lines,
+			fmt.Sprintf("Submissions received: %d/%d", submitted, total),
+			waitingOnSummary(flow.WaitingOnRoles),
+			"Current-turn actions remain hidden until every role is collected and the round resolves.",
+		)
+	case domain.RoundPhaseResolving:
+		lines = append(lines,
+			"All current-turn actions are locked in.",
+			"The plant is resolving simultaneous decisions before reveal.",
+		)
+	case domain.RoundPhaseRevealed:
+		lines = append(lines,
+			"Round results are now visible in the resolved history below.",
+			revealDelaySummary(flow, assignments),
+		)
+	default:
+		lines = append(lines, "Round flow is waiting for the next engine update.")
+	}
+
+	return lines
+}
+
+func waitingOnSummary(roleIDs []domain.RoleID) string {
+	if len(roleIDs) == 0 {
+		return "Waiting on: none"
+	}
+
+	names := make([]string, 0, len(roleIDs))
+	for _, roleID := range roleIDs {
+		names = append(names, displayRoleName(roleID))
+	}
+	return "Waiting on: " + strings.Join(names, ", ")
+}
+
+func revealDelaySummary(flow domain.RoundFlowState, assignments []domain.RoleAssignment) string {
+	if humanRoleCount(assignments) > 0 {
+		return "Reveal remains visible until the next collection phase begins."
+	}
+	if flow.AIRevealDelaySeconds <= 0 {
+		return "AI-only reveal pause is not configured."
+	}
+	return fmt.Sprintf("AI-only rounds hold the reveal for %d seconds before advancing.", flow.AIRevealDelaySeconds)
+}
+
+func humanRoleCount(assignments []domain.RoleAssignment) int {
+	count := 0
+	for _, assignment := range assignments {
+		if assignment.IsHuman {
+			count++
+		}
+	}
+	return count
+}
+
+func roundPhaseLabel(phase domain.RoundPhase) string {
+	switch phase {
+	case domain.RoundPhaseResolving:
+		return "resolving simultaneous turn"
+	case domain.RoundPhaseRevealed:
+		return "revealed round results"
+	default:
+		return "hidden simultaneous turn collection"
+	}
+}
+
+func roundPhaseShortLabel(phase domain.RoundPhase) string {
+	switch phase {
+	case domain.RoundPhaseResolving:
+		return "resolving"
+	case domain.RoundPhaseRevealed:
+		return "revealed"
+	default:
+		return "collecting"
+	}
+}
+
+func roundPhaseDescription(phase domain.RoundPhase) string {
+	switch phase {
+	case domain.RoundPhaseResolving:
+		return "The round is resolving."
+	case domain.RoundPhaseRevealed:
+		return "The round has been revealed."
+	default:
+		return "The round is waiting for simultaneous submissions."
+	}
 }
 
 func paneName(index int) string {

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -24,6 +24,12 @@ func (s testStateSource) Updates() <-chan domain.MatchState {
 
 func TestModelLoadsInitialSnapshotAndRendersShell(t *testing.T) {
 	initial := scenario.Starter().InitialState("starter-match", starterAssignments())
+	initial.RoundFlow.SubmittedRoles = []domain.RoleID{domain.RoleProcurementManager}
+	initial.RoundFlow.WaitingOnRoles = []domain.RoleID{
+		domain.RoleProductionManager,
+		domain.RoleSalesManager,
+		domain.RoleFinanceController,
+	}
 	initial.History.RecentRounds = []domain.RoundRecord{
 		{
 			Round: 1,
@@ -54,6 +60,10 @@ func TestModelLoadsInitialSnapshotAndRendersShell(t *testing.T) {
 		"Departments [focus]",
 		"Center Workspace",
 		"Mode: round feed",
+		"The round is waiting for simultaneous submissions.",
+		"Submissions received: 1/4",
+		"Current-turn actions remain hidden until every role is",
+		"collected and the round resolves.",
 		"Plant Stats",
 		"Command Bar",
 		"Procurement Manager",
@@ -61,6 +71,7 @@ func TestModelLoadsInitialSnapshotAndRendersShell(t *testing.T) {
 		"Event: Assembly shipped one pump.",
 		"Sales Manager: Demand stayed healthy.",
 		"Inspect mode",
+		"Phase: collecting",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("View() missing %q\n%s", want, view)
@@ -175,9 +186,11 @@ func TestModelUsesCompactLayoutAndEmptyStatesOnSmallerTerminal(t *testing.T) {
 		"Departments [focus]",
 		"Plant Stats",
 		"Center Workspace",
-		"No prior rounds recorded yet.",
+		"The round is waiting for simultaneous submissions.",
+		"Current-turn actions remain hidden until every role is",
 		"Workstations: waiting for first telemetry",
-		"Mode: inspect | Focus: departments | Role: Procurement Manager | Round: 1",
+		"Mode: inspect | Focus: departments | Role: Procurement Manager | Round: 1 | Phase:",
+		"collecting | Round 1 loaded for Procurement Manager",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("compact View() missing %q\n%s", want, view)
@@ -200,10 +213,60 @@ func TestModelActionWorkspaceExplainsDeferredEntrySurface(t *testing.T) {
 	for _, want := range []string{
 		"Mode: action entry",
 		"Decision workspace for Procurement Manager",
-		"Action entry is intentionally deferred from issue #23",
+		"Current-turn decisions stay hidden from the shared round",
+		"feed until the round resolves.",
+		"Action entry is still deferred while the shell",
+		"stabilizes, so this workspace currently serves as the",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("action workspace missing %q\n%s", want, view)
+		}
+	}
+}
+
+func TestModelRoundFeedExplainsResolvingAndRevealedStates(t *testing.T) {
+	model := NewModel("Prairie Pump Starter Plant", testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.width = 120
+	shell.height = 30
+
+	shell.state.RoundFlow.Phase = domain.RoundPhaseResolving
+	resolvingView := shell.View()
+	for _, want := range []string{
+		"View: resolving simultaneous turn",
+		"The round is resolving.",
+		"All current-turn actions are locked in.",
+		"The plant is resolving simultaneous decisions before",
+		"reveal.",
+	} {
+		if !strings.Contains(resolvingView, want) {
+			t.Fatalf("resolving view missing %q\n%s", want, resolvingView)
+		}
+	}
+
+	shell.state.RoundFlow.Phase = domain.RoundPhaseRevealed
+	shell.state.RoundFlow.AIRevealDelaySeconds = 15
+	shell.state.Roles = []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: false},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", IsHuman: false},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", IsHuman: false},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", IsHuman: false},
+	}
+	revealedView := shell.View()
+	for _, want := range []string{
+		"View: revealed round results",
+		"The round has been revealed.",
+		"Round results are now visible in the resolved history",
+		"below.",
+		"AI-only rounds hold the reveal for 15 seconds before",
+		"advancing.",
+	} {
+		if !strings.Contains(revealedView, want) {
+			t.Fatalf("revealed view missing %q\n%s", want, revealedView)
 		}
 	}
 }

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -16,6 +16,7 @@ const (
 	defaultLLMCatalogPath = "llm.yaml"
 	defaultEnvironment    = "local"
 	defaultRandomSeed     = uint64(1)
+	defaultAIRevealDelay  = 15
 )
 
 var preferredHumanRoleOrder = []domain.RoleID{
@@ -46,6 +47,7 @@ type Config struct {
 	Environment  string                       `yaml:"environment"`
 	Random       RandomConfig                 `yaml:"random"`
 	HumanPlayers int                          `yaml:"human_players"`
+	UI           UIConfig                     `yaml:"ui"`
 	Roles        map[domain.RoleID]RoleConfig `yaml:"-"`
 	RoleConfigs  []RoleConfigFile             `yaml:"roles"`
 	LLMCatalog   LLMCatalog                   `yaml:"-"`
@@ -54,6 +56,11 @@ type Config struct {
 // RandomConfig controls deterministic randomness for the process.
 type RandomConfig struct {
 	Seed uint64 `yaml:"seed"`
+}
+
+// UIConfig controls player-facing round-flow timing.
+type UIConfig struct {
+	AIRevealDelaySeconds int `yaml:"ai_reveal_delay_seconds"`
 }
 
 // RoleConfig defines runtime settings for a single role.
@@ -120,6 +127,9 @@ func LoadConfig(path string) (Config, error) {
 			Seed: defaultRandomSeed,
 		},
 		HumanPlayers: 1,
+		UI: UIConfig{
+			AIRevealDelaySeconds: defaultAIRevealDelay,
+		},
 	}
 
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
@@ -190,6 +200,9 @@ func (c *Config) Validate() error {
 	if c.HumanPlayers < 0 || c.HumanPlayers > len(expectedRoles) {
 		errs = append(errs, fmt.Errorf("human_players must be between 0 and %d", len(expectedRoles)))
 	}
+	if c.UI.AIRevealDelaySeconds <= 0 {
+		errs = append(errs, errors.New("ui.ai_reveal_delay_seconds must be greater than 0"))
+	}
 
 	if err := c.LLMCatalog.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("llm catalog: %w", err))
@@ -225,6 +238,9 @@ func (c *Config) normalize() {
 
 	if c.HumanPlayers == 0 && len(c.RoleConfigs) == 0 && len(c.Roles) == 0 {
 		c.HumanPlayers = 1
+	}
+	if c.UI.AIRevealDelaySeconds <= 0 {
+		c.UI.AIRevealDelaySeconds = defaultAIRevealDelay
 	}
 
 	if c.Roles == nil {

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -15,6 +15,8 @@ environment: local
 random:
   seed: 7
 human_players: 1
+ui:
+  ai_reveal_delay_seconds: 9
 roles:
   - role_id: procurement_manager
     provider: ollama-localhost
@@ -61,6 +63,9 @@ models:
 
 	if cfg.HumanPlayers != 1 {
 		t.Fatalf("HumanPlayers = %d, want 1", cfg.HumanPlayers)
+	}
+	if cfg.UI.AIRevealDelaySeconds != 9 {
+		t.Fatalf("UI.AIRevealDelaySeconds = %d, want 9", cfg.UI.AIRevealDelaySeconds)
 	}
 
 	if cfg.Roles[domain.RoleProductionManager].Kind != PlayerKindHuman {
@@ -140,6 +145,8 @@ models:
 func TestLoadConfigReportsValidationErrors(t *testing.T) {
 	configPath := writeConfigFile(t, `
 human_players: 5
+ui:
+  ai_reveal_delay_seconds: 15
 roles:
   - role_id: procurement_manager
     provider: ""

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -42,11 +42,14 @@ func NewRuntime(cfg Config) (Runtime, error) {
 	}
 
 	starter := scenario.Default()
+	initialMatch := starter.InitialState("starter-match", runtimeRoles(cfg))
+	initialMatch.RoundFlow.AIRevealDelaySeconds = cfg.UI.AIRevealDelaySeconds
+
 	return Runtime{
 		Config:       cfg,
 		Random:       seeded.New(cfg.Random.Seed),
 		Scenario:     starter,
-		InitialMatch: starter.InitialState("starter-match", runtimeRoles(cfg)),
+		InitialMatch: initialMatch,
 	}, nil
 }
 

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -6,6 +6,9 @@ func TestNewRuntimeSeedsDefaultStarterMatch(t *testing.T) {
 	runtime, err := NewRuntime(Config{
 		Environment:  "test",
 		HumanPlayers: 1,
+		UI: UIConfig{
+			AIRevealDelaySeconds: 12,
+		},
 		Random: RandomConfig{
 			Seed: 9,
 		},
@@ -46,5 +49,14 @@ func TestNewRuntimeSeedsDefaultStarterMatch(t *testing.T) {
 	}
 	if got := len(runtime.InitialMatch.Plant.Backlog); got != 2 {
 		t.Fatalf("InitialMatch.Plant.Backlog len = %d, want 2", got)
+	}
+	if got := runtime.InitialMatch.RoundFlow.Phase; got != "collecting" {
+		t.Fatalf("InitialMatch.RoundFlow.Phase = %q, want collecting", got)
+	}
+	if got := runtime.InitialMatch.RoundFlow.AIRevealDelaySeconds; got != 12 {
+		t.Fatalf("InitialMatch.RoundFlow.AIRevealDelaySeconds = %d, want 12", got)
+	}
+	if got := len(runtime.InitialMatch.RoundFlow.WaitingOnRoles); got != 4 {
+		t.Fatalf("InitialMatch.RoundFlow.WaitingOnRoles len = %d, want 4", got)
 	}
 }

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -35,6 +35,7 @@ type MatchState struct {
 	ScenarioID    ScenarioID
 	CurrentRound  RoundNumber
 	Roles         []RoleAssignment
+	RoundFlow     RoundFlowState
 	Plant         PlantState
 	Customers     []CustomerState
 	ActiveTargets BudgetTargets
@@ -48,6 +49,21 @@ type RoleAssignment struct {
 	IsHuman   bool
 	Provider  string
 	ModelName string
+}
+
+type RoundPhase string
+
+const (
+	RoundPhaseCollecting RoundPhase = "collecting"
+	RoundPhaseResolving  RoundPhase = "resolving"
+	RoundPhaseRevealed   RoundPhase = "revealed"
+)
+
+type RoundFlowState struct {
+	Phase                RoundPhase
+	SubmittedRoles       []RoleID
+	WaitingOnRoles       []RoleID
+	AIRevealDelaySeconds int
 }
 
 type PlantState struct {
@@ -298,6 +314,7 @@ type RoundView struct {
 	MatchID          MatchID
 	Round            RoundNumber
 	ViewerRoleID     RoleID
+	RoundFlow        RoundFlowState
 	Plant            PlantState
 	Customers        []CustomerState
 	ActiveTargets    BudgetTargets
@@ -327,6 +344,7 @@ func (s MatchState) Clone() MatchState {
 		ScenarioID:    s.ScenarioID,
 		CurrentRound:  s.CurrentRound,
 		Roles:         slices.Clone(s.Roles),
+		RoundFlow:     s.RoundFlow.Clone(),
 		Plant:         s.Plant.Clone(),
 		Customers:     cloneSlice(s.Customers, CustomerState.Clone),
 		ActiveTargets: s.ActiveTargets,
@@ -429,6 +447,15 @@ func (r CommentaryRecord) Clone() CommentaryRecord {
 	return r
 }
 
+func (f RoundFlowState) Clone() RoundFlowState {
+	return RoundFlowState{
+		Phase:                f.Phase,
+		SubmittedRoles:       slices.Clone(f.SubmittedRoles),
+		WaitingOnRoles:       slices.Clone(f.WaitingOnRoles),
+		AIRevealDelaySeconds: f.AIRevealDelaySeconds,
+	}
+}
+
 func (e RoundEvent) Clone() RoundEvent {
 	return RoundEvent{
 		EventID: e.EventID,
@@ -446,6 +473,7 @@ func (v RoundView) Clone() RoundView {
 		MatchID:          v.MatchID,
 		Round:            v.Round,
 		ViewerRoleID:     v.ViewerRoleID,
+		RoundFlow:        v.RoundFlow.Clone(),
 		Plant:            v.Plant.Clone(),
 		Customers:        cloneSlice(v.Customers, CustomerState.Clone),
 		ActiveTargets:    v.ActiveTargets,

--- a/internal/projection/round_view.go
+++ b/internal/projection/round_view.go
@@ -18,6 +18,7 @@ func BuildRoundView(state domain.MatchState, viewerRoleID domain.RoleID) domain.
 		MatchID:          state.MatchID,
 		Round:            state.CurrentRound,
 		ViewerRoleID:     viewerRoleID,
+		RoundFlow:        state.RoundFlow.Clone(),
 		Plant:            state.Plant.Clone(),
 		Customers:        cloneCustomers(state.Customers),
 		ActiveTargets:    state.ActiveTargets,

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -130,10 +130,14 @@ func (d Definition) InitialState(matchID domain.MatchID, roles []domain.RoleAssi
 	}
 
 	return domain.MatchState{
-		MatchID:       matchID,
-		ScenarioID:    d.ID,
-		CurrentRound:  1,
-		Roles:         slices.Clone(roles),
+		MatchID:      matchID,
+		ScenarioID:   d.ID,
+		CurrentRound: 1,
+		Roles:        slices.Clone(roles),
+		RoundFlow: domain.RoundFlowState{
+			Phase:          domain.RoundPhaseCollecting,
+			WaitingOnRoles: roleIDs(roles),
+		},
 		Plant:         plant,
 		Customers:     customers,
 		ActiveTargets: d.StartingConditions.StartingTargets,
@@ -357,4 +361,12 @@ func roleNames(roleIDs []domain.RoleID) []string {
 		names = append(names, string(roleID))
 	}
 	return names
+}
+
+func roleIDs(assignments []domain.RoleAssignment) []domain.RoleID {
+	ids := make([]domain.RoleID, 0, len(assignments))
+	for _, assignment := range assignments {
+		ids = append(ids, assignment.RoleID)
+	}
+	return ids
 }


### PR DESCRIPTION
## Summary
- add first-class round lifecycle state to the domain and round projections so the UI can distinguish collecting, resolving, and revealed phases without exposing current-turn actions
- show hidden simultaneous-turn messaging in the TUI center workspace, including safe submission status and the configurable AI-only reveal delay
- add config/runtime coverage for `ui.ai_reveal_delay_seconds` and extend tests around the new round-flow behavior

## Testing
- `go test ./...`

## Follow-up
- Human action entry in the Bubble Tea workspace is tracked in follow-up issue #66.
- Center-workspace navigation remains tracked in #63.
- Submitted human turns should lock immediately on submit, and that decision is now reflected in #66.

Closes #24
