### PR TITLE
Preserve canonical intra-round chronology in TUI history feed

### DIFF
--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -753,17 +753,12 @@ func historyFeedEntries(rounds []domain.RoundHistoryEntry) []string {
 	lines := make([]string, 0, len(rounds)*2)
 	for _, round := range rounds {
 		lines = append(lines, fmt.Sprintf("[R%d] %d events | %d commentary", round.Round, len(round.Events), len(round.Commentary)))
-		if len(round.Events) == 0 && len(round.Commentary) == 0 {
+		timeline := historyEntryTimeline(round)
+		if len(timeline) == 0 {
 			lines = append(lines, "  No visible history.")
 			continue
 		}
-
-		for _, event := range round.Events {
-			lines = append(lines, fmt.Sprintf("  Event: %s", event.Summary))
-		}
-		for _, commentary := range round.Commentary {
-			lines = append(lines, fmt.Sprintf("  %s: %s", displayRoleName(commentary.RoleID), commentary.Body))
-		}
+		lines = append(lines, roundTimelineLines(timeline)...)
 	}
 
 	return lines
@@ -786,18 +781,77 @@ func archiveEntries(rounds []domain.RoundRecord) []string {
 				round.Metrics.NetCashChange,
 			),
 		)
-		for _, event := range round.Events {
-			lines = append(lines, fmt.Sprintf("  Event: %s", event.Summary))
-		}
-		for _, commentary := range round.Commentary {
-			lines = append(lines, fmt.Sprintf("  %s: %s", displayRoleName(commentary.RoleID), commentary.Body))
-		}
-		if len(round.Events) == 0 && len(round.Commentary) == 0 {
+		timeline := round.CanonicalTimeline()
+		if len(timeline) == 0 {
 			lines = append(lines, "  No visible history.")
+			continue
+		}
+		lines = append(lines, roundTimelineLines(timeline)...)
+	}
+
+	return lines
+}
+
+func roundTimelineLines(entries []domain.RoundTimelineEntry) []string {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	lines := make([]string, 0, len(entries))
+	var phase domain.RoundTimelinePhase
+	for _, entry := range entries {
+		if entry.Phase != phase {
+			phase = entry.Phase
+			lines = append(lines, fmt.Sprintf("  %s", timelinePhaseLabel(entry.Phase)))
+		}
+
+		switch entry.Kind {
+		case domain.RoundTimelineKindCommentary:
+			if entry.Commentary == nil {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("    %d. %s: %s", entry.Sequence, displayRoleName(entry.Commentary.RoleID), entry.Commentary.Body))
+		case domain.RoundTimelineKindEvent:
+			if entry.Event == nil {
+				continue
+			}
+			lines = append(lines, fmt.Sprintf("    %d. Event: %s", entry.Sequence, entry.Event.Summary))
 		}
 	}
 
 	return lines
+}
+
+func historyEntryTimeline(entry domain.RoundHistoryEntry) []domain.RoundTimelineEntry {
+	if len(entry.Timeline) > 0 {
+		return cloneTimelineEntries(entry.Timeline)
+	}
+
+	round := domain.RoundRecord{
+		Round:      entry.Round,
+		Events:     entry.Events,
+		Commentary: entry.Commentary,
+	}
+	return round.CanonicalTimeline()
+}
+
+func cloneTimelineEntries(entries []domain.RoundTimelineEntry) []domain.RoundTimelineEntry {
+	cloned := make([]domain.RoundTimelineEntry, len(entries))
+	for i := range entries {
+		cloned[i] = entries[i].Clone()
+	}
+	return cloned
+}
+
+func timelinePhaseLabel(phase domain.RoundTimelinePhase) string {
+	switch phase {
+	case domain.RoundTimelinePhaseIntake:
+		return "Player action intake"
+	case domain.RoundTimelinePhaseSummary:
+		return "Round summary"
+	default:
+		return "Round simulation"
+	}
 }
 
 func companywideReportLines(report domain.CompanywidePerformanceReport) []string {

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -70,8 +70,10 @@ func TestModelLoadsInitialSnapshotAndRendersShell(t *testing.T) {
 		"Command Bar",
 		"Procurement Manager",
 		"[R1] 1 events | 1 commentary",
-		"Event: Assembly shipped one pump.",
-		"Sales Manager: Demand stayed healthy.",
+		"Player action intake",
+		"1. Sales Manager: Demand stayed healthy.",
+		"Round simulation",
+		"1. Event: Assembly shipped one pump.",
 		"Inspect mode",
 		"Workspace: round feed",
 	} {
@@ -102,10 +104,13 @@ func TestHistoryFeedEntriesMergesRoundsIntoSingleChronologicalFeed(t *testing.T)
 
 	want := []string{
 		"[R2] 1 events | 1 commentary",
-		"  Event: Shipped two valves.",
-		"  Finance Controller: Margins improved.",
+		"  Player action intake",
+		"    1. Finance Controller: Margins improved.",
+		"  Round simulation",
+		"    1. Event: Shipped two valves.",
 		"[R3] 0 events | 1 commentary",
-		"  Production Manager: Assembly stayed constrained.",
+		"  Player action intake",
+		"    1. Production Manager: Assembly stayed constrained.",
 	}
 	if len(entries) != len(want) {
 		t.Fatalf("len(entries) = %d, want %d (%v)", len(entries), len(want), entries)
@@ -326,8 +331,10 @@ func TestModelArchiveShowsRetainedHistorySummaries(t *testing.T) {
 		"rather than the current feed.",
 		"[R1] 1 actions | 1 events | 1 commentary | profit 18 |",
 		"net cash 7",
-		"Event: Assembly shipped one pump.",
-		"Sales Manager: Demand stayed healthy.",
+		"Player action intake",
+		"1. Sales Manager: Demand stayed healthy.",
+		"Round simulation",
+		"1. Event: Assembly shipped one pump.",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("archive view missing %q\n%s", want, view)

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"cmp"
 	"maps"
 	"slices"
 	"time"
@@ -259,11 +260,35 @@ type RoundRecord struct {
 	Actions    []ActionSubmission
 	Events     []RoundEvent
 	Commentary []CommentaryRecord
+	Timeline   []RoundTimelineEntry
 	Metrics    PlantMetrics
 }
 
 type RoundHistory struct {
 	RecentRounds []RoundRecord
+}
+
+type RoundTimelinePhase string
+
+const (
+	RoundTimelinePhaseIntake     RoundTimelinePhase = "player_action_intake"
+	RoundTimelinePhaseSimulation RoundTimelinePhase = "round_simulation"
+	RoundTimelinePhaseSummary    RoundTimelinePhase = "round_summary"
+)
+
+type RoundTimelineKind string
+
+const (
+	RoundTimelineKindCommentary RoundTimelineKind = "commentary"
+	RoundTimelineKindEvent      RoundTimelineKind = "event"
+)
+
+type RoundTimelineEntry struct {
+	Phase      RoundTimelinePhase
+	Sequence   int
+	Kind       RoundTimelineKind
+	Event      *RoundEvent
+	Commentary *CommentaryRecord
 }
 
 type CommentaryRecord struct {
@@ -320,6 +345,7 @@ type RoundView struct {
 	ActiveTargets    BudgetTargets
 	Metrics          PlantMetrics
 	RecentRounds     []RoundHistoryEntry
+	RecentTimeline   []RoundTimelineEntry
 	RecentEvents     []RoundEvent
 	RecentCommentary []CommentaryRecord
 }
@@ -328,6 +354,7 @@ type RoundHistoryEntry struct {
 	Round      RoundNumber
 	Events     []RoundEvent
 	Commentary []CommentaryRecord
+	Timeline   []RoundTimelineEntry
 	Summary    RoundSummary
 }
 
@@ -399,8 +426,70 @@ func (r RoundRecord) Clone() RoundRecord {
 		Actions:    cloneSlice(r.Actions, ActionSubmission.Clone),
 		Events:     cloneSlice(r.Events, RoundEvent.Clone),
 		Commentary: cloneSlice(r.Commentary, CommentaryRecord.Clone),
+		Timeline:   cloneSlice(r.CanonicalTimeline(), RoundTimelineEntry.Clone),
 		Metrics:    r.Metrics,
 	}
+}
+
+func (r RoundRecord) CanonicalTimeline() []RoundTimelineEntry {
+	if len(r.Timeline) > 0 {
+		return cloneSlice(r.Timeline, RoundTimelineEntry.Clone)
+	}
+
+	var timeline []RoundTimelineEntry
+
+	commentaryByID := make(map[CommentaryID]CommentaryRecord, len(r.Commentary))
+	for _, commentary := range r.Commentary {
+		commentaryByID[commentary.CommentaryID] = commentary
+	}
+
+	type orderedCommentary struct {
+		record CommentaryRecord
+		action ActionSubmission
+	}
+
+	ordered := make([]orderedCommentary, 0, len(r.Commentary))
+	used := make(map[CommentaryID]bool, len(r.Commentary))
+	for _, action := range r.orderedActionsForTimeline() {
+		record, ok := commentaryByID[action.Commentary.CommentaryID]
+		if !ok {
+			continue
+		}
+		ordered = append(ordered, orderedCommentary{record: record, action: action})
+		used[record.CommentaryID] = true
+	}
+
+	for _, commentary := range r.Commentary {
+		if used[commentary.CommentaryID] {
+			continue
+		}
+		ordered = append(ordered, orderedCommentary{record: commentary})
+	}
+
+	for index, item := range ordered {
+		commentary := item.record.Clone()
+		timeline = append(timeline, RoundTimelineEntry{
+			Phase:      RoundTimelinePhaseIntake,
+			Sequence:   index + 1,
+			Kind:       RoundTimelineKindCommentary,
+			Commentary: &commentary,
+		})
+	}
+
+	phaseSequence := map[RoundTimelinePhase]int{}
+	for _, event := range r.Events {
+		phase := phaseForRoundEvent(event)
+		phaseSequence[phase]++
+		eventClone := event.Clone()
+		timeline = append(timeline, RoundTimelineEntry{
+			Phase:    phase,
+			Sequence: phaseSequence[phase],
+			Kind:     RoundTimelineKindEvent,
+			Event:    &eventClone,
+		})
+	}
+
+	return timeline
 }
 
 func (s ActionSubmission) Clone() ActionSubmission {
@@ -447,6 +536,16 @@ func (r CommentaryRecord) Clone() CommentaryRecord {
 	return r
 }
 
+func (e RoundTimelineEntry) Clone() RoundTimelineEntry {
+	return RoundTimelineEntry{
+		Phase:      e.Phase,
+		Sequence:   e.Sequence,
+		Kind:       e.Kind,
+		Event:      clonePtr(e.Event, RoundEvent.Clone),
+		Commentary: clonePtr(e.Commentary, CommentaryRecord.Clone),
+	}
+}
+
 func (f RoundFlowState) Clone() RoundFlowState {
 	return RoundFlowState{
 		Phase:                f.Phase,
@@ -479,6 +578,7 @@ func (v RoundView) Clone() RoundView {
 		ActiveTargets:    v.ActiveTargets,
 		Metrics:          v.Metrics,
 		RecentRounds:     cloneSlice(v.RecentRounds, RoundHistoryEntry.Clone),
+		RecentTimeline:   cloneSlice(v.RecentTimeline, RoundTimelineEntry.Clone),
 		RecentEvents:     cloneSlice(v.RecentEvents, RoundEvent.Clone),
 		RecentCommentary: cloneSlice(v.RecentCommentary, CommentaryRecord.Clone),
 	}
@@ -489,6 +589,7 @@ func (e RoundHistoryEntry) Clone() RoundHistoryEntry {
 		Round:      e.Round,
 		Events:     cloneSlice(e.Events, RoundEvent.Clone),
 		Commentary: cloneSlice(e.Commentary, CommentaryRecord.Clone),
+		Timeline:   cloneSlice(e.Timeline, RoundTimelineEntry.Clone),
 		Summary:    e.Summary.Clone(),
 	}
 }
@@ -550,4 +651,40 @@ func clonePtr[T any](item *T, clone func(T) T) *T {
 
 	cloned := clone(*item)
 	return &cloned
+}
+
+func (r RoundRecord) orderedActionsForTimeline() []ActionSubmission {
+	if len(r.Actions) == 0 {
+		return nil
+	}
+
+	ordered := cloneSlice(r.Actions, ActionSubmission.Clone)
+	slices.SortFunc(ordered, func(left, right ActionSubmission) int {
+		if compare := left.SubmittedAt.Compare(right.SubmittedAt); compare != 0 {
+			return compare
+		}
+		if compare := cmp.Compare(roleTimelineRank(left.RoleID), roleTimelineRank(right.RoleID)); compare != 0 {
+			return compare
+		}
+		return cmp.Compare(string(left.ActionID), string(right.ActionID))
+	})
+	return ordered
+}
+
+func roleTimelineRank(roleID RoleID) int {
+	for index, canonical := range CanonicalRoles() {
+		if canonical == roleID {
+			return index
+		}
+	}
+	return len(CanonicalRoles())
+}
+
+func phaseForRoundEvent(event RoundEvent) RoundTimelinePhase {
+	switch event.Type {
+	case EventMetricSnapshot:
+		return RoundTimelinePhaseSummary
+	default:
+		return RoundTimelinePhaseSimulation
+	}
 }

--- a/internal/domain/model_test.go
+++ b/internal/domain/model_test.go
@@ -1,0 +1,78 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRoundRecordCanonicalTimelinePreservesPhaseChronology(t *testing.T) {
+	round := RoundRecord{
+		Round: 4,
+		Actions: []ActionSubmission{
+			{
+				ActionID:    "sales-4",
+				RoleID:      RoleSalesManager,
+				SubmittedAt: time.Date(2026, time.April, 21, 10, 0, 5, 0, time.UTC),
+				Commentary:  CommentaryRecord{CommentaryID: "sales-commentary", RoleID: RoleSalesManager, Body: "Demand still looks strong."},
+			},
+			{
+				ActionID:    "proc-4",
+				RoleID:      RoleProcurementManager,
+				SubmittedAt: time.Date(2026, time.April, 21, 10, 0, 1, 0, time.UTC),
+				Commentary:  CommentaryRecord{CommentaryID: "proc-commentary", RoleID: RoleProcurementManager, Body: "Restocking the housings."},
+			},
+		},
+		Commentary: []CommentaryRecord{
+			{CommentaryID: "sales-commentary", RoleID: RoleSalesManager, Body: "Demand still looks strong."},
+			{CommentaryID: "proc-commentary", RoleID: RoleProcurementManager, Body: "Restocking the housings."},
+		},
+		Events: []RoundEvent{
+			{EventID: "event-1", Type: EventSupplyArrived, Summary: "Received 4 housings."},
+			{EventID: "event-2", Type: EventMetricSnapshot, Summary: "Recorded round metrics."},
+		},
+	}
+
+	timeline := round.CanonicalTimeline()
+	if len(timeline) != 4 {
+		t.Fatalf("len(timeline) = %d, want 4", len(timeline))
+	}
+	if got := timeline[0].Phase; got != RoundTimelinePhaseIntake {
+		t.Fatalf("timeline[0].Phase = %q, want %q", got, RoundTimelinePhaseIntake)
+	}
+	if got := timeline[0].Commentary.RoleID; got != RoleProcurementManager {
+		t.Fatalf("timeline[0].Commentary.RoleID = %q, want %q", got, RoleProcurementManager)
+	}
+	if got := timeline[1].Commentary.RoleID; got != RoleSalesManager {
+		t.Fatalf("timeline[1].Commentary.RoleID = %q, want %q", got, RoleSalesManager)
+	}
+	if got := timeline[2].Phase; got != RoundTimelinePhaseSimulation {
+		t.Fatalf("timeline[2].Phase = %q, want %q", got, RoundTimelinePhaseSimulation)
+	}
+	if got := timeline[2].Sequence; got != 1 {
+		t.Fatalf("timeline[2].Sequence = %d, want 1", got)
+	}
+	if got := timeline[3].Phase; got != RoundTimelinePhaseSummary {
+		t.Fatalf("timeline[3].Phase = %q, want %q", got, RoundTimelinePhaseSummary)
+	}
+}
+
+func TestRoundRecordCloneDeepCopiesTimeline(t *testing.T) {
+	round := RoundRecord{
+		Round: 2,
+		Timeline: []RoundTimelineEntry{
+			{
+				Phase:      RoundTimelinePhaseSummary,
+				Sequence:   1,
+				Kind:       RoundTimelineKindCommentary,
+				Commentary: &CommentaryRecord{CommentaryID: "commentary-1", Body: "Original"},
+			},
+		},
+	}
+
+	cloned := round.Clone()
+	cloned.Timeline[0].Commentary.Body = "Changed"
+
+	if got := round.Timeline[0].Commentary.Body; got != "Original" {
+		t.Fatalf("round timeline commentary body = %q, want %q", got, "Original")
+	}
+}

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -205,6 +205,7 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 	}
 
 	phase.finalizeRound(actionForRole(orderedActions, domain.RoleFinanceController))
+	round.Timeline = round.CanonicalTimeline()
 
 	nextState.Metrics = round.Metrics
 	nextState.CurrentRound++
@@ -983,8 +984,19 @@ func validateFinanceAction(action domain.ActionSubmission) error {
 }
 
 func collectCommentary(state domain.MatchState, actions []domain.ActionSubmission) []domain.CommentaryRecord {
-	commentary := make([]domain.CommentaryRecord, 0, len(actions))
-	for _, action := range actions {
+	ordered := cloneActions(actions)
+	slices.SortFunc(ordered, func(left, right domain.ActionSubmission) int {
+		if compare := left.SubmittedAt.Compare(right.SubmittedAt); compare != 0 {
+			return compare
+		}
+		if compare := cmp.Compare(actionTimelineRoleRank(left.RoleID), actionTimelineRoleRank(right.RoleID)); compare != 0 {
+			return compare
+		}
+		return cmp.Compare(string(left.ActionID), string(right.ActionID))
+	})
+
+	commentary := make([]domain.CommentaryRecord, 0, len(ordered))
+	for _, action := range ordered {
 		if strings.TrimSpace(action.Commentary.Body) == "" {
 			continue
 		}
@@ -1018,6 +1030,15 @@ func cloneActions(actions []domain.ActionSubmission) []domain.ActionSubmission {
 		cloned[i] = actions[i].Clone()
 	}
 	return cloned
+}
+
+func actionTimelineRoleRank(roleID domain.RoleID) int {
+	for index, canonical := range domain.CanonicalRoles() {
+		if canonical == roleID {
+			return index
+		}
+	}
+	return len(domain.CanonicalRoles())
 }
 
 func actionForRole(actions []domain.ActionSubmission, roleID domain.RoleID) *domain.ActionSubmission {

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
 	"github.com/jpconstantineau/herbiego/internal/domain"
@@ -131,6 +132,52 @@ func TestResolverExecutesRoundPhasesAndSchedulesNextTargets(t *testing.T) {
 	} {
 		if !slices.Contains(eventTypes, want) {
 			t.Fatalf("Round.Events missing %q in %#v", want, eventTypes)
+		}
+	}
+
+	if len(result.Round.Timeline) == 0 {
+		t.Fatal("Round.Timeline is empty, want canonical round chronology")
+	}
+	if got := result.Round.Timeline[0].Phase; got != domain.RoundTimelinePhaseIntake {
+		t.Fatalf("Round.Timeline[0].Phase = %q, want %q", got, domain.RoundTimelinePhaseIntake)
+	}
+	if got := result.Round.Timeline[len(result.Round.Timeline)-1].Phase; got != domain.RoundTimelinePhaseSummary {
+		t.Fatalf("Round.Timeline[last].Phase = %q, want %q", got, domain.RoundTimelinePhaseSummary)
+	}
+}
+
+func TestResolverOrdersCommentaryBySubmissionTimeWithinIntakePhase(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+	actions := fixtureActions()
+	actions[0].SubmittedAt = time.Date(2026, time.April, 21, 12, 0, 3, 0, time.UTC)
+	actions[1].Commentary = domain.CommentaryRecord{Body: "Assembly is the bottleneck."}
+	actions[1].SubmittedAt = time.Date(2026, time.April, 21, 12, 0, 1, 0, time.UTC)
+	actions[2].Commentary = domain.CommentaryRecord{Body: "Demand is steady."}
+	actions[2].SubmittedAt = time.Date(2026, time.April, 21, 12, 0, 2, 0, time.UTC)
+	actions[3].SubmittedAt = time.Date(2026, time.April, 21, 12, 0, 4, 0, time.UTC)
+
+	result, err := resolver.ResolveRound(fixtureState(), actions, seeded.New(7))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	want := []domain.RoleID{
+		domain.RoleProductionManager,
+		domain.RoleSalesManager,
+		domain.RoleProcurementManager,
+	}
+	if len(result.Round.Commentary) != len(want) {
+		t.Fatalf("len(Round.Commentary) = %d, want %d", len(result.Round.Commentary), len(want))
+	}
+	for index, roleID := range want {
+		if got := result.Round.Commentary[index].RoleID; got != roleID {
+			t.Fatalf("Round.Commentary[%d].RoleID = %q, want %q", index, got, roleID)
+		}
+		if got := result.Round.Timeline[index].Commentary.RoleID; got != roleID {
+			t.Fatalf("Round.Timeline[%d].Commentary.RoleID = %q, want %q", index, got, roleID)
+		}
+		if got := result.Round.Timeline[index].Sequence; got != index+1 {
+			t.Fatalf("Round.Timeline[%d].Sequence = %d, want %d", index, got, index+1)
 		}
 	}
 }

--- a/internal/projection/round_view.go
+++ b/internal/projection/round_view.go
@@ -7,9 +7,11 @@ import (
 // BuildRoundView projects the canonical state and recent append-only history into a player-facing view.
 func BuildRoundView(state domain.MatchState, viewerRoleID domain.RoleID) domain.RoundView {
 	recentRounds := buildRecentRounds(state.History.Recent(10))
+	recentTimeline := make([]domain.RoundTimelineEntry, 0)
 	recentEvents := make([]domain.RoundEvent, 0)
 	recentCommentary := make([]domain.CommentaryRecord, 0)
 	for _, round := range recentRounds {
+		recentTimeline = append(recentTimeline, cloneTimeline(round.Timeline)...)
 		recentEvents = append(recentEvents, cloneEvents(round.Events)...)
 		recentCommentary = append(recentCommentary, cloneCommentary(round.Commentary)...)
 	}
@@ -24,6 +26,7 @@ func BuildRoundView(state domain.MatchState, viewerRoleID domain.RoleID) domain.
 		ActiveTargets:    state.ActiveTargets,
 		Metrics:          state.Metrics,
 		RecentRounds:     recentRounds,
+		RecentTimeline:   recentTimeline,
 		RecentEvents:     recentEvents,
 		RecentCommentary: recentCommentary,
 	}
@@ -40,6 +43,7 @@ func buildRecentRounds(history domain.RoundHistory) []domain.RoundHistoryEntry {
 			Round:      round.Round,
 			Events:     cloneEvents(round.Events),
 			Commentary: cloneCommentary(round.Commentary),
+			Timeline:   cloneTimeline(round.CanonicalTimeline()),
 			Summary: domain.RoundSummary{
 				Metrics:         round.Metrics,
 				EventCount:      len(round.Events),
@@ -60,6 +64,19 @@ func cloneEvents(events []domain.RoundEvent) []domain.RoundEvent {
 	cloned := make([]domain.RoundEvent, len(events))
 	for i := range events {
 		cloned[i] = events[i].Clone()
+	}
+
+	return cloned
+}
+
+func cloneTimeline(entries []domain.RoundTimelineEntry) []domain.RoundTimelineEntry {
+	if entries == nil {
+		return nil
+	}
+
+	cloned := make([]domain.RoundTimelineEntry, len(entries))
+	for i := range entries {
+		cloned[i] = entries[i].Clone()
 	}
 
 	return cloned

--- a/internal/projection/round_view_test.go
+++ b/internal/projection/round_view_test.go
@@ -87,6 +87,9 @@ func TestBuildRoundViewIncludesRecentHistoryWindow(t *testing.T) {
 	if len(view.RecentCommentary) != 1 {
 		t.Fatalf("RecentCommentary len = %d, want 1", len(view.RecentCommentary))
 	}
+	if len(view.RecentTimeline) != 3 {
+		t.Fatalf("RecentTimeline len = %d, want 3", len(view.RecentTimeline))
+	}
 	if got := view.RecentRounds[1].Round; got != 3 {
 		t.Fatalf("RecentRounds[1].Round = %d, want 3", got)
 	}
@@ -98,6 +101,15 @@ func TestBuildRoundViewIncludesRecentHistoryWindow(t *testing.T) {
 	}
 	if got := view.RecentRounds[1].Summary.ActionCount; got != 1 {
 		t.Fatalf("RecentRounds[1].Summary.ActionCount = %d, want 1", got)
+	}
+	if got := view.RecentRounds[1].Timeline[0].Phase; got != domain.RoundTimelinePhaseIntake {
+		t.Fatalf("RecentRounds[1].Timeline[0].Phase = %q, want %q", got, domain.RoundTimelinePhaseIntake)
+	}
+	if got := view.RecentRounds[1].Timeline[0].Commentary.Body; got != "Demand stayed strong." {
+		t.Fatalf("RecentRounds[1].Timeline[0].Commentary.Body = %q, want %q", got, "Demand stayed strong.")
+	}
+	if got := view.RecentRounds[1].Timeline[1].Phase; got != domain.RoundTimelinePhaseSimulation {
+		t.Fatalf("RecentRounds[1].Timeline[1].Phase = %q, want %q", got, domain.RoundTimelinePhaseSimulation)
 	}
 	if got := view.RecentRounds[1].Summary.Metrics.RoundProfit; got != 12 {
 		t.Fatalf("RecentRounds[1].Summary.Metrics.RoundProfit = %d, want 12", got)
@@ -173,11 +185,15 @@ func TestBuildRoundViewClonesStructuredHistory(t *testing.T) {
 	view := projection.BuildRoundView(state, domain.RoleProcurementManager)
 	view.RecentRounds[0].Events[0].Payload["quantity"] = 99
 	view.RecentRounds[0].Commentary[0].Body = "Changed"
+	view.RecentRounds[0].Timeline[0].Commentary.Body = "Timeline Changed"
 
 	if got := state.History.RecentRounds[0].Events[0].Payload["quantity"]; got != 2 {
 		t.Fatalf("state payload quantity = %#v, want 2", got)
 	}
 	if got := state.History.RecentRounds[0].Commentary[0].Body; got != "Original" {
 		t.Fatalf("state commentary body = %q, want %q", got, "Original")
+	}
+	if len(state.History.RecentRounds[0].Timeline) != 0 {
+		t.Fatalf("state timeline len = %d, want 0", len(state.History.RecentRounds[0].Timeline))
 	}
 }


### PR DESCRIPTION
## Summary
- add a canonical round timeline with explicit intake, simulation, and summary phases
- order intake commentary by submission time with deterministic tie-breakers
- project and render the TUI history/archive views from the canonical timeline instead of stitching events and commentary separately

## Decision
- keep `round_summary` reserved for system-authored summary items
- keep revealed role-authored commentary in `player_action_intake` unless we later add a distinct post-resolution reflection concept

## Testing
- `go test ./...`

Closes #61.