### PR TITLE
[codex] Add TUI-native human action entry workflow

### DIFF
--- a/internal/adapters/tui/action_entry.go
+++ b/internal/adapters/tui/action_entry.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/projection"
 )
 
 type draftStage int
@@ -132,7 +133,7 @@ func (m *Model) handleActionEntryKey(msg tea.KeyMsg) bool {
 			draft.status = "Submission locked for this round"
 			draft.errorText = ""
 			m.drafts[assignment.RoleID] = draft
-			m.status = fmt.Sprintf("%s submitted and locked for round %d", m.roleTitle(), m.state.CurrentRound)
+			m.advanceAfterSubmission(assignment.RoleID)
 			return true
 		}
 	case "b":
@@ -219,6 +220,16 @@ func (m Model) renderActionEntryWorkspace(width int) []string {
 	}
 
 	if draft.stage == draftStageSubmitted {
+		if m.hideSubmittedHumanDetails(assignment.RoleID) {
+			lines = append(lines,
+				"",
+				"Submission locked for this round.",
+				waitingOnSummary(m.effectiveRoundFlow().WaitingOnRoles),
+				"Locked human entries stay private in multi-human games.",
+			)
+			return append(lines, m.renderDraftStatus(width, draft)...)
+		}
+
 		lines = append(lines,
 			"",
 			"Submission locked for this round.",
@@ -303,22 +314,19 @@ func (m Model) actionFields() []fieldSpec {
 }
 
 func (m Model) currentDraft() actionDraft {
-	roleID := m.selectedAssignment().RoleID
-	draft, ok := m.drafts[roleID]
-	if ok {
-		return draft
+	return m.currentDraftForRole(m.selectedAssignment().RoleID)
+}
+
+func (m *Model) advanceAfterSubmission(roleID domain.RoleID) {
+	if nextIndex, ok := m.nextPendingHumanRole(roleID); ok {
+		m.selectedRole = nextIndex
+		m.workspace = workspaceActionEntry
+		m.status = fmt.Sprintf("%s submitted. Moved to %s for entry.", displayRoleName(roleID), m.roleTitle())
+		return
 	}
 
-	draft = actionDraft{}
-	if m.selectedAssignment().RoleID == domain.RoleFinanceController {
-		targets := m.selectedRoleView().ActiveTargets
-		draft.financeProcurement = strconv.Itoa(int(targets.ProcurementBudget))
-		draft.financeProduction = strconv.Itoa(int(targets.ProductionSpendBudget))
-		draft.financeRevenue = strconv.Itoa(int(targets.RevenueTarget))
-		draft.financeCashFloor = strconv.Itoa(int(targets.CashFloorTarget))
-		draft.financeDebtCeiling = strconv.Itoa(int(targets.DebtCeilingTarget))
-	}
-	return draft
+	m.workspace = workspaceRoundFeed
+	m.status = fmt.Sprintf("%s submitted. All human entries are locked; switched to the round feed.", displayRoleName(roleID))
 }
 
 func (m *Model) setDraftField(draft *actionDraft, field draftField, value string) {
@@ -562,6 +570,51 @@ func (m Model) effectiveRoundFlow() domain.RoundFlowState {
 		flow.Phase = domain.RoundPhaseResolving
 	}
 	return flow
+}
+
+func (m Model) nextPendingHumanRole(submittedRoleID domain.RoleID) (int, bool) {
+	if len(m.state.Roles) == 0 {
+		return 0, false
+	}
+
+	start := clampRoleIndex(m.selectedRole, len(m.state.Roles))
+	for step := 1; step <= len(m.state.Roles); step++ {
+		index := (start + step) % len(m.state.Roles)
+		assignment := m.state.Roles[index]
+		if !assignment.IsHuman || assignment.RoleID == submittedRoleID {
+			continue
+		}
+		if m.currentDraftForRole(assignment.RoleID).stage == draftStageSubmitted {
+			continue
+		}
+		return index, true
+	}
+	return 0, false
+}
+
+func (m Model) currentDraftForRole(roleID domain.RoleID) actionDraft {
+	draft, ok := m.drafts[roleID]
+	if ok {
+		return draft
+	}
+
+	draft = actionDraft{}
+	if roleID != domain.RoleFinanceController {
+		return draft
+	}
+
+	view := projection.BuildRoundView(m.state, roleID)
+	targets := view.ActiveTargets
+	draft.financeProcurement = strconv.Itoa(int(targets.ProcurementBudget))
+	draft.financeProduction = strconv.Itoa(int(targets.ProductionSpendBudget))
+	draft.financeRevenue = strconv.Itoa(int(targets.RevenueTarget))
+	draft.financeCashFloor = strconv.Itoa(int(targets.CashFloorTarget))
+	draft.financeDebtCeiling = strconv.Itoa(int(targets.DebtCeilingTarget))
+	return draft
+}
+
+func (m Model) hideSubmittedHumanDetails(roleID domain.RoleID) bool {
+	return m.selectedAssignment().IsHuman && humanRoleCount(m.state.Roles) > 1 && m.currentDraftForRole(roleID).stage == draftStageSubmitted
 }
 
 func (m Model) previousAcceptedAction(roleID domain.RoleID) *domain.ActionSubmission {

--- a/internal/adapters/tui/action_entry.go
+++ b/internal/adapters/tui/action_entry.go
@@ -1,0 +1,698 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+type draftStage int
+
+const (
+	draftStageEditing draftStage = iota
+	draftStageReview
+	draftStageSubmitted
+)
+
+type draftField int
+
+const (
+	fieldProcurementOrders draftField = iota
+	fieldProductionReleases
+	fieldProductionAllocations
+	fieldSalesOffers
+	fieldFinanceProcurementBudget
+	fieldFinanceProductionBudget
+	fieldFinanceRevenueTarget
+	fieldFinanceCashFloor
+	fieldFinanceDebtCeiling
+	fieldCommentary
+)
+
+type actionDraft struct {
+	stage         draftStage
+	selectedField int
+	editing       bool
+	inputBuffer   string
+	status        string
+	errorText     string
+
+	procurementOrders     string
+	productionReleases    string
+	productionAllocations string
+	salesOffers           string
+	financeProcurement    string
+	financeProduction     string
+	financeRevenue        string
+	financeCashFloor      string
+	financeDebtCeiling    string
+	commentary            string
+
+	submission *domain.ActionSubmission
+}
+
+type fieldSpec struct {
+	id          draftField
+	label       string
+	value       string
+	placeholder string
+	help        string
+}
+
+func (m *Model) handleActionEntryKey(msg tea.KeyMsg) bool {
+	if m.workspace != workspaceActionEntry {
+		return false
+	}
+
+	assignment := m.selectedAssignment()
+	if !assignment.IsHuman {
+		return false
+	}
+
+	draft := m.currentDraft()
+	if draft.stage == draftStageSubmitted {
+		return false
+	}
+
+	if draft.editing {
+		return m.handleEditingKey(msg, assignment.RoleID)
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if draft.selectedField > 0 {
+			draft.selectedField--
+			draft.status = fmt.Sprintf("Focused %s", m.actionFields()[draft.selectedField].label)
+		}
+		m.drafts[assignment.RoleID] = draft
+		return true
+	case "down", "j":
+		if draft.selectedField < len(m.actionFields())-1 {
+			draft.selectedField++
+			draft.status = fmt.Sprintf("Focused %s", m.actionFields()[draft.selectedField].label)
+		}
+		m.drafts[assignment.RoleID] = draft
+		return true
+	case "enter", "e":
+		draft.editing = true
+		draft.inputBuffer = m.actionFields()[draft.selectedField].value
+		draft.errorText = ""
+		draft.status = fmt.Sprintf("Editing %s", m.actionFields()[draft.selectedField].label)
+		m.drafts[assignment.RoleID] = draft
+		return true
+	case "r":
+		submission, err := m.buildSubmissionDraft(draft)
+		if err != nil {
+			draft.errorText = err.Error()
+			draft.status = "Review blocked until the draft is valid"
+			m.drafts[assignment.RoleID] = draft
+			return true
+		}
+		draft.stage = draftStageReview
+		draft.errorText = ""
+		draft.status = "Draft ready for review"
+		draft.submission = &submission
+		m.drafts[assignment.RoleID] = draft
+		return true
+	case "s":
+		if draft.stage == draftStageReview {
+			submission, err := m.buildSubmissionDraft(draft)
+			if err != nil {
+				draft.errorText = err.Error()
+				draft.status = "Submit blocked until the draft is valid"
+				m.drafts[assignment.RoleID] = draft
+				return true
+			}
+			draft.stage = draftStageSubmitted
+			draft.submission = &submission
+			draft.status = "Submission locked for this round"
+			draft.errorText = ""
+			m.drafts[assignment.RoleID] = draft
+			m.status = fmt.Sprintf("%s submitted and locked for round %d", m.roleTitle(), m.state.CurrentRound)
+			return true
+		}
+	case "b":
+		if draft.stage == draftStageReview {
+			draft.stage = draftStageEditing
+			draft.status = "Returned to editing"
+			m.drafts[assignment.RoleID] = draft
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *Model) handleEditingKey(msg tea.KeyMsg, roleID domain.RoleID) bool {
+	draft := m.currentDraft()
+	switch msg.Type {
+	case tea.KeyEsc:
+		draft.editing = false
+		draft.inputBuffer = ""
+		draft.status = "Edit cancelled"
+		m.drafts[roleID] = draft
+		return true
+	case tea.KeyEnter:
+		spec := m.actionFields()[draft.selectedField]
+		m.setDraftField(&draft, spec.id, draft.inputBuffer)
+		draft.editing = false
+		draft.inputBuffer = ""
+		draft.status = fmt.Sprintf("Saved %s", spec.label)
+		draft.errorText = ""
+		m.drafts[roleID] = draft
+		return true
+	case tea.KeyBackspace:
+		if len(draft.inputBuffer) > 0 {
+			draft.inputBuffer = draft.inputBuffer[:len(draft.inputBuffer)-1]
+			m.drafts[roleID] = draft
+		}
+		return true
+	case tea.KeySpace:
+		draft.inputBuffer += " "
+		m.drafts[roleID] = draft
+		return true
+	case tea.KeyRunes:
+		for _, r := range msg.Runes {
+			if unicode.IsPrint(r) {
+				draft.inputBuffer += string(r)
+			}
+		}
+		m.drafts[roleID] = draft
+		return true
+	default:
+		return true
+	}
+}
+
+func (m Model) renderActionEntryWorkspace(width int) []string {
+	assignment := m.selectedAssignment()
+	lines := []string{
+		fmt.Sprintf("Action entry for %s", m.roleTitle()),
+		"View: draft, review, and submit a private turn without leaving the center workspace",
+	}
+
+	if !assignment.IsHuman {
+		return append(lines,
+			"",
+			"This role is AI-controlled in the current match configuration.",
+			"Use report/feed/archive views to inspect plant context while the AI submits through the shared player interface.",
+		)
+	}
+
+	draft := m.currentDraft()
+	if previous := m.previousAcceptedAction(assignment.RoleID); previous != nil {
+		lines = append(lines, "", "Previous accepted commentary", wrapLine(previous.Commentary.Body, width-4))
+	}
+
+	if draft.stage == draftStageReview {
+		lines = append(lines, "", "Review draft", "Press s to submit and lock, or b to return to editing.")
+		if draft.submission != nil {
+			for _, line := range summarizeSubmission(*draft.submission) {
+				lines = append(lines, wrapLine("- "+line, width-4))
+			}
+		}
+		return append(lines, m.renderDraftStatus(width, draft)...)
+	}
+
+	if draft.stage == draftStageSubmitted {
+		lines = append(lines,
+			"",
+			"Submission locked for this round.",
+			waitingOnSummary(m.effectiveRoundFlow().WaitingOnRoles),
+			"Current-turn details stay out of the shared round feed until reveal.",
+		)
+		if draft.submission != nil {
+			lines = append(lines, "")
+			for _, line := range summarizeSubmission(*draft.submission) {
+				lines = append(lines, wrapLine("- "+line, width-4))
+			}
+		}
+		return append(lines, m.renderDraftStatus(width, draft)...)
+	}
+
+	lines = append(lines,
+		"",
+		"Editing flow",
+		"Use up/down to move fields, enter to edit/save, esc to cancel a field edit, and r to review.",
+	)
+	for index, field := range m.actionFields() {
+		cursor := " "
+		value := field.value
+		if index == draft.selectedField {
+			cursor = ">"
+			if draft.editing {
+				value = draft.inputBuffer
+			}
+		}
+		if strings.TrimSpace(value) == "" {
+			value = field.placeholder
+		}
+		lines = append(lines, fmt.Sprintf("%s %s: %s", cursor, field.label, value))
+		lines = append(lines, wrapLine("  "+field.help, width-4))
+	}
+
+	return append(lines, m.renderDraftStatus(width, draft)...)
+}
+
+func (m Model) renderDraftStatus(width int, draft actionDraft) []string {
+	var lines []string
+	if strings.TrimSpace(draft.status) != "" {
+		lines = append(lines, "", wrapLine("Status: "+draft.status, width-4))
+	}
+	if strings.TrimSpace(draft.errorText) != "" {
+		lines = append(lines, wrapLine("Validation: "+draft.errorText, width-4))
+	}
+	return lines
+}
+
+func (m Model) actionFields() []fieldSpec {
+	draft := m.currentDraft()
+	switch m.selectedAssignment().RoleID {
+	case domain.RoleProcurementManager:
+		return []fieldSpec{
+			{id: fieldProcurementOrders, label: "Orders", value: draft.procurementOrders, placeholder: "housing=2, seal_kit=1", help: "Comma-separated part=quantity entries. Leave blank for no orders."},
+			{id: fieldCommentary, label: "Commentary", value: draft.commentary, placeholder: "Explain your reasoning for this round.", help: "Required public commentary shown after the round is revealed."},
+		}
+	case domain.RoleProductionManager:
+		return []fieldSpec{
+			{id: fieldProductionReleases, label: "Releases", value: draft.productionReleases, placeholder: "pump=2, valve=1", help: "Comma-separated product=quantity entries. Leave blank for no releases."},
+			{id: fieldProductionAllocations, label: "Capacity", value: draft.productionAllocations, placeholder: "fabrication:pump=2, assembly:pump=2", help: "Comma-separated workstation:product=capacity entries. Leave blank for no allocations."},
+			{id: fieldCommentary, label: "Commentary", value: draft.commentary, placeholder: "Explain your reasoning for this round.", help: "Required public commentary shown after the round is revealed."},
+		}
+	case domain.RoleSalesManager:
+		return []fieldSpec{
+			{id: fieldSalesOffers, label: "Offers", value: draft.salesOffers, placeholder: "pump=14, valve=9", help: "Comma-separated product=unit_price entries. Leave blank for no offers."},
+			{id: fieldCommentary, label: "Commentary", value: draft.commentary, placeholder: "Explain your reasoning for this round.", help: "Required public commentary shown after the round is revealed."},
+		}
+	case domain.RoleFinanceController:
+		return []fieldSpec{
+			{id: fieldFinanceProcurementBudget, label: "Procurement budget", value: draft.financeProcurement, placeholder: "0", help: "Whole number budget for the next round."},
+			{id: fieldFinanceProductionBudget, label: "Production budget", value: draft.financeProduction, placeholder: "0", help: "Whole number budget for the next round."},
+			{id: fieldFinanceRevenueTarget, label: "Revenue target", value: draft.financeRevenue, placeholder: "0", help: "Whole number revenue target for the next round."},
+			{id: fieldFinanceCashFloor, label: "Cash floor", value: draft.financeCashFloor, placeholder: "0", help: "Whole number cash floor target for the next round."},
+			{id: fieldFinanceDebtCeiling, label: "Debt ceiling", value: draft.financeDebtCeiling, placeholder: "0", help: "Whole number debt ceiling target for the next round."},
+			{id: fieldCommentary, label: "Commentary", value: draft.commentary, placeholder: "Explain your reasoning for this round.", help: "Required public commentary shown after the round is revealed."},
+		}
+	default:
+		return []fieldSpec{{id: fieldCommentary, label: "Commentary", value: draft.commentary, placeholder: "Explain your reasoning for this round.", help: "Required public commentary shown after the round is revealed."}}
+	}
+}
+
+func (m Model) currentDraft() actionDraft {
+	roleID := m.selectedAssignment().RoleID
+	draft, ok := m.drafts[roleID]
+	if ok {
+		return draft
+	}
+
+	draft = actionDraft{}
+	if m.selectedAssignment().RoleID == domain.RoleFinanceController {
+		targets := m.selectedRoleView().ActiveTargets
+		draft.financeProcurement = strconv.Itoa(int(targets.ProcurementBudget))
+		draft.financeProduction = strconv.Itoa(int(targets.ProductionSpendBudget))
+		draft.financeRevenue = strconv.Itoa(int(targets.RevenueTarget))
+		draft.financeCashFloor = strconv.Itoa(int(targets.CashFloorTarget))
+		draft.financeDebtCeiling = strconv.Itoa(int(targets.DebtCeilingTarget))
+	}
+	return draft
+}
+
+func (m *Model) setDraftField(draft *actionDraft, field draftField, value string) {
+	switch field {
+	case fieldProcurementOrders:
+		draft.procurementOrders = strings.TrimSpace(value)
+	case fieldProductionReleases:
+		draft.productionReleases = strings.TrimSpace(value)
+	case fieldProductionAllocations:
+		draft.productionAllocations = strings.TrimSpace(value)
+	case fieldSalesOffers:
+		draft.salesOffers = strings.TrimSpace(value)
+	case fieldFinanceProcurementBudget:
+		draft.financeProcurement = strings.TrimSpace(value)
+	case fieldFinanceProductionBudget:
+		draft.financeProduction = strings.TrimSpace(value)
+	case fieldFinanceRevenueTarget:
+		draft.financeRevenue = strings.TrimSpace(value)
+	case fieldFinanceCashFloor:
+		draft.financeCashFloor = strings.TrimSpace(value)
+	case fieldFinanceDebtCeiling:
+		draft.financeDebtCeiling = strings.TrimSpace(value)
+	case fieldCommentary:
+		draft.commentary = strings.TrimSpace(value)
+	}
+}
+
+func (m Model) buildSubmissionDraft(draft actionDraft) (domain.ActionSubmission, error) {
+	assignment := m.selectedAssignment()
+	action, err := m.parseRoleAction(assignment.RoleID, draft)
+	if err != nil {
+		return domain.ActionSubmission{}, err
+	}
+	commentary := strings.TrimSpace(draft.commentary)
+	if commentary == "" {
+		return domain.ActionSubmission{}, fmt.Errorf("commentary is required before review or submit")
+	}
+
+	return domain.ActionSubmission{
+		Action: action,
+		Commentary: domain.CommentaryRecord{
+			ActorID:    domain.ActorID(assignment.PlayerID),
+			Visibility: domain.CommentaryPublic,
+			Body:       commentary,
+		},
+	}, nil
+}
+
+func (m Model) parseRoleAction(roleID domain.RoleID, draft actionDraft) (domain.RoleAction, error) {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		orders, err := m.parseOrders(draft.procurementOrders)
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		return domain.RoleAction{Procurement: &domain.ProcurementAction{Orders: orders}}, nil
+	case domain.RoleProductionManager:
+		releases, err := m.parseReleases(draft.productionReleases)
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		allocations, err := m.parseAllocations(draft.productionAllocations)
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		return domain.RoleAction{Production: &domain.ProductionAction{
+			Releases:           releases,
+			CapacityAllocation: allocations,
+		}}, nil
+	case domain.RoleSalesManager:
+		offers, err := m.parseOffers(draft.salesOffers)
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		return domain.RoleAction{Sales: &domain.SalesAction{ProductOffers: offers}}, nil
+	case domain.RoleFinanceController:
+		targets, err := m.parseFinanceTargets(draft)
+		if err != nil {
+			return domain.RoleAction{}, err
+		}
+		return domain.RoleAction{Finance: &domain.FinanceAction{NextRoundTargets: targets}}, nil
+	default:
+		return domain.RoleAction{}, fmt.Errorf("unsupported role %q", roleID)
+	}
+}
+
+func (m Model) parseOrders(raw string) ([]domain.PurchaseOrderIntent, error) {
+	pairs, err := parseKeyValueList(raw)
+	if err != nil {
+		return nil, err
+	}
+	orders := make([]domain.PurchaseOrderIntent, 0, len(pairs))
+	for _, pair := range pairs {
+		partID := domain.PartID(pair.key)
+		supplierID, ok := m.supplierForPart(partID)
+		if !ok {
+			return nil, fmt.Errorf("unknown part %q", pair.key)
+		}
+		quantity := domain.Units(pair.value)
+		orders = append(orders, domain.PurchaseOrderIntent{
+			PartID:     partID,
+			SupplierID: supplierID,
+			Quantity:   quantity,
+		})
+	}
+	return orders, nil
+}
+
+func (m Model) parseReleases(raw string) ([]domain.ProductionRelease, error) {
+	pairs, err := parseKeyValueList(raw)
+	if err != nil {
+		return nil, err
+	}
+	releases := make([]domain.ProductionRelease, 0, len(pairs))
+	for _, pair := range pairs {
+		if !m.validProduct(domain.ProductID(pair.key)) {
+			return nil, fmt.Errorf("unknown product %q", pair.key)
+		}
+		releases = append(releases, domain.ProductionRelease{
+			ProductID: domain.ProductID(pair.key),
+			Quantity:  domain.Units(pair.value),
+		})
+	}
+	return releases, nil
+}
+
+func (m Model) parseAllocations(raw string) ([]domain.CapacityAllocation, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	entries := strings.Split(raw, ",")
+	allocations := make([]domain.CapacityAllocation, 0, len(entries))
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		workstationAndProduct, capacityText, ok := strings.Cut(entry, "=")
+		if !ok {
+			return nil, fmt.Errorf("capacity entry %q must use workstation:product=capacity", entry)
+		}
+		workstationText, productText, ok := strings.Cut(strings.TrimSpace(workstationAndProduct), ":")
+		if !ok {
+			return nil, fmt.Errorf("capacity entry %q must include workstation:product", entry)
+		}
+		if !m.validWorkstation(domain.WorkstationID(strings.TrimSpace(workstationText))) {
+			return nil, fmt.Errorf("unknown workstation %q", strings.TrimSpace(workstationText))
+		}
+		productID := domain.ProductID(strings.TrimSpace(productText))
+		if !m.validProduct(productID) {
+			return nil, fmt.Errorf("unknown product %q", productText)
+		}
+		capacity, err := parseNonNegativeInt(capacityText)
+		if err != nil {
+			return nil, fmt.Errorf("capacity entry %q: %w", entry, err)
+		}
+		allocations = append(allocations, domain.CapacityAllocation{
+			WorkstationID: domain.WorkstationID(strings.TrimSpace(workstationText)),
+			ProductID:     productID,
+			Capacity:      domain.CapacityUnits(capacity),
+		})
+	}
+	return allocations, nil
+}
+
+func (m Model) parseOffers(raw string) ([]domain.ProductOffer, error) {
+	pairs, err := parseKeyValueList(raw)
+	if err != nil {
+		return nil, err
+	}
+	offers := make([]domain.ProductOffer, 0, len(pairs))
+	for _, pair := range pairs {
+		productID := domain.ProductID(pair.key)
+		if !m.validProduct(productID) {
+			return nil, fmt.Errorf("unknown product %q", pair.key)
+		}
+		offers = append(offers, domain.ProductOffer{
+			ProductID: productID,
+			UnitPrice: domain.Money(pair.value),
+		})
+	}
+	return offers, nil
+}
+
+func (m Model) parseFinanceTargets(draft actionDraft) (domain.BudgetTargets, error) {
+	procurement, err := parseNonNegativeInt(draft.financeProcurement)
+	if err != nil {
+		return domain.BudgetTargets{}, fmt.Errorf("procurement budget: %w", err)
+	}
+	production, err := parseNonNegativeInt(draft.financeProduction)
+	if err != nil {
+		return domain.BudgetTargets{}, fmt.Errorf("production budget: %w", err)
+	}
+	revenue, err := parseNonNegativeInt(draft.financeRevenue)
+	if err != nil {
+		return domain.BudgetTargets{}, fmt.Errorf("revenue target: %w", err)
+	}
+	cashFloor, err := parseNonNegativeInt(draft.financeCashFloor)
+	if err != nil {
+		return domain.BudgetTargets{}, fmt.Errorf("cash floor: %w", err)
+	}
+	debtCeiling, err := parseNonNegativeInt(draft.financeDebtCeiling)
+	if err != nil {
+		return domain.BudgetTargets{}, fmt.Errorf("debt ceiling: %w", err)
+	}
+
+	return domain.BudgetTargets{
+		EffectiveRound:        m.selectedRoleView().ActiveTargets.EffectiveRound + 1,
+		ProcurementBudget:     domain.Money(procurement),
+		ProductionSpendBudget: domain.Money(production),
+		RevenueTarget:         domain.Money(revenue),
+		CashFloorTarget:       domain.Money(cashFloor),
+		DebtCeilingTarget:     domain.Money(debtCeiling),
+	}, nil
+}
+
+func (m Model) effectiveRoundFlow() domain.RoundFlowState {
+	flow := m.state.RoundFlow.Clone()
+	submittedSet := make(map[domain.RoleID]bool, len(flow.SubmittedRoles))
+	for _, roleID := range flow.SubmittedRoles {
+		submittedSet[roleID] = true
+	}
+	for roleID, draft := range m.drafts {
+		if draft.stage == draftStageSubmitted {
+			submittedSet[roleID] = true
+		}
+	}
+
+	var submitted []domain.RoleID
+	var waiting []domain.RoleID
+	for _, assignment := range m.state.Roles {
+		if submittedSet[assignment.RoleID] {
+			submitted = append(submitted, assignment.RoleID)
+			continue
+		}
+		waiting = append(waiting, assignment.RoleID)
+	}
+	flow.SubmittedRoles = submitted
+	flow.WaitingOnRoles = waiting
+	if flow.Phase == "" {
+		flow.Phase = domain.RoundPhaseCollecting
+	}
+	if flow.Phase == domain.RoundPhaseCollecting && len(waiting) == 0 && len(submitted) > 0 {
+		flow.Phase = domain.RoundPhaseResolving
+	}
+	return flow
+}
+
+func (m Model) previousAcceptedAction(roleID domain.RoleID) *domain.ActionSubmission {
+	for i := len(m.state.History.RecentRounds) - 1; i >= 0; i-- {
+		round := m.state.History.RecentRounds[i]
+		for _, action := range round.Actions {
+			if action.RoleID != roleID {
+				continue
+			}
+			cloned := action.Clone()
+			return &cloned
+		}
+	}
+	return nil
+}
+
+func summarizeSubmission(submission domain.ActionSubmission) []string {
+	lines := summarizeAction(submission.Action)
+	return append(lines, "Commentary: "+submission.Commentary.Body)
+}
+
+type kvPair struct {
+	key   string
+	value int
+}
+
+func parseKeyValueList(raw string) ([]kvPair, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	entries := strings.Split(raw, ",")
+	pairs := make([]kvPair, 0, len(entries))
+	for _, entry := range entries {
+		keyText, valueText, ok := strings.Cut(entry, "=")
+		if !ok {
+			return nil, fmt.Errorf("entry %q must use name=value", strings.TrimSpace(entry))
+		}
+		key := strings.TrimSpace(keyText)
+		if key == "" {
+			return nil, fmt.Errorf("entry %q needs a name before =", strings.TrimSpace(entry))
+		}
+		value, err := parseNonNegativeInt(valueText)
+		if err != nil {
+			return nil, fmt.Errorf("entry %q: %w", strings.TrimSpace(entry), err)
+		}
+		pairs = append(pairs, kvPair{key: key, value: value})
+	}
+	return pairs, nil
+}
+
+func parseNonNegativeInt(raw string) (int, error) {
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || value < 0 {
+		return 0, fmt.Errorf("enter a whole number that is 0 or greater")
+	}
+	return value, nil
+}
+
+func (m Model) validProduct(productID domain.ProductID) bool {
+	for _, product := range m.scenario.ProductionModel.Products {
+		if product.ID == productID {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Model) validWorkstation(workstationID domain.WorkstationID) bool {
+	for _, workstation := range m.scenario.ProductionModel.Workstations {
+		if workstation.ID == workstationID {
+			return true
+		}
+	}
+	return false
+}
+
+func (m Model) supplierForPart(partID domain.PartID) (domain.SupplierID, bool) {
+	for _, part := range m.scenario.ProductionModel.Parts {
+		if part.ID == partID {
+			return part.SupplierID, true
+		}
+	}
+	return "", false
+}
+
+func summarizeAction(action domain.RoleAction) []string {
+	switch {
+	case action.Procurement != nil:
+		if len(action.Procurement.Orders) == 0 {
+			return []string{"No purchase orders"}
+		}
+		lines := make([]string, 0, len(action.Procurement.Orders))
+		for _, order := range action.Procurement.Orders {
+			lines = append(lines, fmt.Sprintf("Order %d of %s from %s", order.Quantity, order.PartID, order.SupplierID))
+		}
+		return lines
+	case action.Production != nil:
+		lines := make([]string, 0, len(action.Production.Releases)+len(action.Production.CapacityAllocation))
+		if len(action.Production.Releases) == 0 {
+			lines = append(lines, "No production releases")
+		}
+		for _, release := range action.Production.Releases {
+			lines = append(lines, fmt.Sprintf("Release %d of %s", release.Quantity, release.ProductID))
+		}
+		if len(action.Production.CapacityAllocation) == 0 {
+			lines = append(lines, "No capacity allocations")
+		}
+		for _, allocation := range action.Production.CapacityAllocation {
+			lines = append(lines, fmt.Sprintf("Allocate %d capacity at %s for %s", allocation.Capacity, allocation.WorkstationID, allocation.ProductID))
+		}
+		return lines
+	case action.Sales != nil:
+		if len(action.Sales.ProductOffers) == 0 {
+			return []string{"No product offers"}
+		}
+		lines := make([]string, 0, len(action.Sales.ProductOffers))
+		for _, offer := range action.Sales.ProductOffers {
+			lines = append(lines, fmt.Sprintf("Offer %s at %d", offer.ProductID, offer.UnitPrice))
+		}
+		return lines
+	case action.Finance != nil:
+		targets := action.Finance.NextRoundTargets
+		return []string{
+			fmt.Sprintf("Effective round %d", targets.EffectiveRound),
+			fmt.Sprintf("Procurement budget %d", targets.ProcurementBudget),
+			fmt.Sprintf("Production budget %d", targets.ProductionSpendBudget),
+			fmt.Sprintf("Revenue target %d", targets.RevenueTarget),
+			fmt.Sprintf("Cash floor %d", targets.CashFloorTarget),
+			fmt.Sprintf("Debt ceiling %d", targets.DebtCeilingTarget),
+		}
+	default:
+		return []string{"No action payload"}
+	}
+}

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/projection"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
 const (
@@ -27,7 +28,8 @@ const (
 type layoutMode int
 
 const (
-	workspaceRoleReport workspaceMode = iota
+	workspaceActionEntry workspaceMode = iota
+	workspaceRoleReport
 	workspaceRoundFeed
 	workspaceHistoryArchive
 )
@@ -42,7 +44,7 @@ type stateStreamClosedMsg struct{}
 
 // Model is the Bubble Tea shell for the round-based gameplay UI.
 type Model struct {
-	scenarioName string
+	scenario     scenario.Definition
 	source       StateSource
 	updates      <-chan domain.MatchState
 	state        domain.MatchState
@@ -53,16 +55,18 @@ type Model struct {
 	height       int
 	status       string
 	streamClosed bool
+	drafts       map[domain.RoleID]actionDraft
 }
 
 // NewModel constructs the main gameplay shell model.
-func NewModel(scenarioName string, source StateSource) Model {
+func NewModel(definition scenario.Definition, source StateSource) Model {
 	return Model{
-		scenarioName: scenarioName,
-		source:       source,
-		updates:      source.Updates(),
-		workspace:    workspaceRoundFeed,
-		status:       "Loading round state...",
+		scenario:  definition,
+		source:    source,
+		updates:   source.Updates(),
+		workspace: workspaceActionEntry,
+		status:    "Loading round state...",
+		drafts:    make(map[domain.RoleID]actionDraft),
 	}
 }
 
@@ -79,6 +83,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = typed.Height
 		return m, nil
 	case tea.KeyMsg:
+		if m.handleActionEntryKey(typed) {
+			return m, nil
+		}
 		switch typed.String() {
 		case "ctrl+c", "q":
 			return m, tea.Quit
@@ -93,10 +100,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "[":
 			m.moveWorkspace(-1)
 		case "1":
-			m.setWorkspace(workspaceRoleReport)
+			m.setWorkspace(workspaceActionEntry)
 		case "2":
-			m.setWorkspace(workspaceRoundFeed)
+			m.setWorkspace(workspaceRoleReport)
 		case "3":
+			m.setWorkspace(workspaceRoundFeed)
+		case "4":
 			m.setWorkspace(workspaceHistoryArchive)
 		case "left", "h", "p":
 			m.moveRole(-1)
@@ -105,6 +114,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case stateLoadedMsg:
+		if typed.state.CurrentRound != m.state.CurrentRound {
+			clear(m.drafts)
+		}
 		m.state = typed.state.Clone()
 		m.selectedRole = clampRoleIndex(m.selectedRole, len(m.state.Roles))
 		m.status = fmt.Sprintf("Round %d loaded for %s", m.state.CurrentRound, m.roleTitle())
@@ -201,7 +213,9 @@ func (m Model) selectedAssignment() domain.RoleAssignment {
 
 func (m Model) selectedRoleView() domain.RoundView {
 	assignment := m.selectedAssignment()
-	return projection.BuildRoundView(m.state, assignment.RoleID)
+	view := projection.BuildRoundView(m.state, assignment.RoleID)
+	view.RoundFlow = m.effectiveRoundFlow()
+	return view
 }
 
 func (m Model) selectedRoleReport() domain.RoleRoundReport {
@@ -213,7 +227,7 @@ func (m Model) renderDepartmentsPane(width, height int) string {
 	report := m.selectedRoleReport()
 
 	lines := []string{
-		fmt.Sprintf("Scenario: %s", m.scenarioName),
+		fmt.Sprintf("Scenario: %s", m.scenario.DisplayName),
 		fmt.Sprintf("Match: %s", m.state.MatchID),
 		fmt.Sprintf("Mode: %s", modeLabel(m.focusedPane)),
 		"",
@@ -252,6 +266,8 @@ func (m Model) renderHistoryPane(width, height int) string {
 	switch m.workspace {
 	case workspaceRoleReport:
 		lines = append(lines, m.renderRoleReportWorkspace(width)...)
+	case workspaceActionEntry:
+		lines = append(lines, m.renderActionEntryWorkspace(width)...)
 	case workspaceHistoryArchive:
 		lines = append(lines, m.renderHistoryArchiveWorkspace(width)...)
 	default:
@@ -371,8 +387,9 @@ func (m Model) renderStatsPane(width, height int) string {
 }
 
 func (m Model) renderCommandBar(width, height int) string {
+	flow := m.effectiveRoundFlow()
 	status := fmt.Sprintf("Mode: inspect | Focus: %s | Workspace: %s | Role: %s | Round: %d", paneName(m.focusedPane), m.workspace.label(), m.roleTitle(), m.state.CurrentRound)
-	status += " | Phase: " + roundPhaseShortLabel(m.state.RoundFlow.Phase)
+	status += " | Phase: " + roundPhaseShortLabel(flow.Phase)
 	if detail := strings.TrimSpace(m.statusLine()); detail != "" {
 		status += " | " + detail
 	}
@@ -684,6 +701,8 @@ func workspacePaneTitle() string {
 
 func (mode workspaceMode) label() string {
 	switch mode {
+	case workspaceActionEntry:
+		return "action entry"
 	case workspaceRoleReport:
 		return "role report"
 	case workspaceHistoryArchive:
@@ -694,7 +713,7 @@ func (mode workspaceMode) label() string {
 }
 
 func workspaceNavigationLine(active workspaceMode) string {
-	items := []workspaceMode{workspaceRoleReport, workspaceRoundFeed, workspaceHistoryArchive}
+	items := []workspaceMode{workspaceActionEntry, workspaceRoleReport, workspaceRoundFeed, workspaceHistoryArchive}
 	labels := make([]string, 0, len(items))
 	for index, mode := range items {
 		label := fmt.Sprintf("%d %s", index+1, mode.shortLabel())
@@ -707,9 +726,11 @@ func workspaceNavigationLine(active workspaceMode) string {
 }
 
 func workspaceCommandHints(active workspaceMode) string {
-	base := "Inspect mode | tab/shift+tab focus panes | left/right cycle roles | 1/2/3 switch workspace | [/] cycle | q quit"
+	base := "Inspect mode | tab/shift+tab focus panes | left/right cycle roles | 1/2/3/4 switch workspace | [/] cycle | q quit"
 
 	switch active {
+	case workspaceActionEntry:
+		return base + " | action entry uses up/down to move fields, enter to edit, r review, s submit"
 	case workspaceRoleReport:
 		return base + " | report shows briefing, company snapshot, and role metrics"
 	case workspaceHistoryArchive:
@@ -721,6 +742,8 @@ func workspaceCommandHints(active workspaceMode) string {
 
 func (mode workspaceMode) shortLabel() string {
 	switch mode {
+	case workspaceActionEntry:
+		return "action"
 	case workspaceRoleReport:
 		return "report"
 	case workspaceHistoryArchive:

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -199,21 +199,140 @@ func TestModelSupportsHumanActionDraftReviewAndSubmit(t *testing.T) {
 	if got := len(shell.effectiveRoundFlow().SubmittedRoles); got != 1 {
 		t.Fatalf("submitted roles = %d, want 1", got)
 	}
+	if shell.workspace != workspaceRoundFeed {
+		t.Fatalf("workspace = %v, want %v", shell.workspace, workspaceRoundFeed)
+	}
 
 	shell.width = 120
 	shell.height = 32
 	view := shell.View()
 	for _, want := range []string{
-		"Submission locked for this round.",
+		"Mode: round feed",
+		"Submissions received: 1/4",
 		"Waiting on: Production Manager, Sales Manager, Finance",
 		"Controller",
-		"Current-turn details stay out of the shared round feed",
-		"until reveal.",
-		"Order 2 of housing from forgeco",
-		"Commentary: Ordering only what assembly can absorb.",
+		"Current-turn actions remain hidden until every role is",
+		"collected and the round resolves.",
 	} {
 		if !strings.Contains(view, want) {
-			t.Fatalf("submitted action-entry view missing %q\n%s", want, view)
+			t.Fatalf("submitted round-feed view missing %q\n%s", want, view)
+		}
+	}
+	for _, unwanted := range []string{
+		"Order 2 of housing from forgeco",
+		"Ordering only what assembly can absorb.",
+	} {
+		if strings.Contains(view, unwanted) {
+			t.Fatalf("round feed leaked %q\n%s", unwanted, view)
+		}
+	}
+}
+
+func TestModelAdvancesAcrossHumanRolesAndHidesLockedDrafts(t *testing.T) {
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", multiHumanAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("housing=2")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyDown},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("Buying only what we can use.")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune{'r'}},
+		{Type: tea.KeyRunes, Runes: []rune{'s'}},
+	} {
+		next, _ := shell.Update(key)
+		shell = next.(Model)
+	}
+
+	if got := shell.selectedAssignment().RoleID; got != domain.RoleSalesManager {
+		t.Fatalf("selected role = %q, want sales_manager", got)
+	}
+	if shell.workspace != workspaceActionEntry {
+		t.Fatalf("workspace = %v, want %v", shell.workspace, workspaceActionEntry)
+	}
+
+	shell.width = 120
+	shell.height = 32
+	view := shell.View()
+	for _, want := range []string{
+		"Action entry for Sales Manager",
+		"Procurement Manager submitted. Moved to Sales Manager",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("multi-human view missing %q\n%s", want, view)
+		}
+	}
+
+	shell.selectedRole = 0
+	privateView := shell.View()
+	for _, want := range []string{
+		"Submission locked for this round.",
+		"Locked human entries stay private in multi-human games.",
+	} {
+		if !strings.Contains(privateView, want) {
+			t.Fatalf("private locked view missing %q\n%s", want, privateView)
+		}
+	}
+	for _, unwanted := range []string{
+		"Order 2 of housing from forgeco",
+		"Buying only what we can use.",
+	} {
+		if strings.Contains(privateView, unwanted) {
+			t.Fatalf("private locked view leaked %q\n%s", unwanted, privateView)
+		}
+	}
+}
+
+func TestModelSwitchesToRoundFeedAfterFinalHumanSubmission(t *testing.T) {
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", multiHumanAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.drafts[domain.RoleProcurementManager] = actionDraft{
+		stage: draftStageSubmitted,
+		submission: &domain.ActionSubmission{
+			Action:     domain.RoleAction{Procurement: &domain.ProcurementAction{}},
+			Commentary: domain.CommentaryRecord{Body: "Already locked."},
+		},
+	}
+	shell.selectedRole = 2
+
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("pump=14")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyDown},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("Holding price steady.")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune{'r'}},
+		{Type: tea.KeyRunes, Runes: []rune{'s'}},
+	} {
+		next, _ := shell.Update(key)
+		shell = next.(Model)
+	}
+
+	if shell.workspace != workspaceRoundFeed {
+		t.Fatalf("workspace = %v, want %v", shell.workspace, workspaceRoundFeed)
+	}
+	view := shell.View()
+	for _, want := range []string{
+		"Mode: round feed",
+		"Submissions received: 2/4",
+		"Waiting on: Production Manager, Finance Controller",
+		"All human entries are locked; switched to the round feed.",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("final human submission view missing %q\n%s", want, view)
 		}
 	}
 }
@@ -476,6 +595,15 @@ func starterAssignments() []domain.RoleAssignment {
 		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
 		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", IsHuman: false, Provider: "ollama"},
 		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", IsHuman: false, Provider: "openrouter"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", IsHuman: false, Provider: "openai"},
+	}
+}
+
+func multiHumanAssignments() []domain.RoleAssignment {
+	return []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", IsHuman: false, Provider: "ollama"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", IsHuman: true},
 		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", IsHuman: false, Provider: "openai"},
 	}
 }

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -42,7 +42,7 @@ func TestModelLoadsInitialSnapshotAndRendersShell(t *testing.T) {
 		},
 	}
 
-	model := NewModel("Prairie Pump Starter Plant", testStateSource{snapshot: initial})
+	model := NewModel(scenario.Starter(), testStateSource{snapshot: initial})
 	cmd := model.Init()
 	msg := cmd()
 
@@ -59,23 +59,19 @@ func TestModelLoadsInitialSnapshotAndRendersShell(t *testing.T) {
 	for _, want := range []string{
 		"Departments [focus]",
 		"Center Workspace",
-		"Mode: round feed",
-		"Navigate: 1 report | [2 feed] | 3 archive | [/] cycle",
-		"The round is waiting for simultaneous submissions.",
-		"Submissions received: 1/4",
-		"Current-turn actions remain hidden until every role is",
-		"collected and the round resolves.",
-		"Recent resolved rounds (1 shown)",
+		"Mode: action entry",
+		"Navigate: [1 action] | 2 report | 3 feed | 4 archive | [/]",
+		"cycle",
+		"Action entry for Procurement Manager",
+		"View: draft, review, and submit a private turn without",
+		"leaving the center workspace",
+		"Editing flow",
+		"Orders: housing=2, seal_kit=1",
 		"Plant Stats",
 		"Command Bar",
 		"Procurement Manager",
-		"[R1] 1 events | 1 commentary",
-		"Player action intake",
-		"1. Sales Manager: Demand stayed healthy.",
-		"Round simulation",
-		"1. Event: Assembly shipped one pump.",
 		"Inspect mode",
-		"Workspace: round feed",
+		"Workspace: action entry",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("View() missing %q\n%s", want, view)
@@ -123,7 +119,7 @@ func TestHistoryFeedEntriesMergesRoundsIntoSingleChronologicalFeed(t *testing.T)
 }
 
 func TestModelCyclesRoleSelectionAndPaneFocus(t *testing.T) {
-	model := NewModel("Prairie Pump Starter Plant", testStateSource{
+	model := NewModel(scenario.Starter(), testStateSource{
 		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
 	})
 
@@ -144,32 +140,162 @@ func TestModelCyclesRoleSelectionAndPaneFocus(t *testing.T) {
 
 	switched, _ := focusedShell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{']'}})
 	switchedShell := switched.(Model)
-	if switchedShell.workspace != workspaceHistoryArchive {
-		t.Fatalf("workspace = %v, want %v", switchedShell.workspace, workspaceHistoryArchive)
+	if switchedShell.workspace != workspaceRoleReport {
+		t.Fatalf("workspace = %v, want %v", switchedShell.workspace, workspaceRoleReport)
 	}
 
 	reset, _ := switchedShell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
 	resetShell := reset.(Model)
-	if resetShell.workspace != workspaceRoleReport {
-		t.Fatalf("workspace = %v, want %v", resetShell.workspace, workspaceRoleReport)
+	if resetShell.workspace != workspaceActionEntry {
+		t.Fatalf("workspace = %v, want %v", resetShell.workspace, workspaceActionEntry)
 	}
 
 	feed, _ := resetShell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
 	feedShell := feed.(Model)
-	if feedShell.workspace != workspaceRoundFeed {
-		t.Fatalf("workspace = %v, want %v", feedShell.workspace, workspaceRoundFeed)
+	if feedShell.workspace != workspaceRoleReport {
+		t.Fatalf("workspace = %v, want %v", feedShell.workspace, workspaceRoleReport)
 	}
 
 	archive, _ := feedShell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
 	archiveShell := archive.(Model)
-	if archiveShell.workspace != workspaceHistoryArchive {
-		t.Fatalf("workspace = %v, want %v", archiveShell.workspace, workspaceHistoryArchive)
+	if archiveShell.workspace != workspaceRoundFeed {
+		t.Fatalf("workspace = %v, want %v", archiveShell.workspace, workspaceRoundFeed)
+	}
+
+	history, _ := archiveShell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+	historyShell := history.(Model)
+	if historyShell.workspace != workspaceHistoryArchive {
+		t.Fatalf("workspace = %v, want %v", historyShell.workspace, workspaceHistoryArchive)
+	}
+}
+
+func TestModelSupportsHumanActionDraftReviewAndSubmit(t *testing.T) {
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("housing=2")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyDown},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune("Ordering only what assembly can absorb.")},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune{'r'}},
+		{Type: tea.KeyRunes, Runes: []rune{'s'}},
+	} {
+		next, _ := shell.Update(key)
+		shell = next.(Model)
+	}
+
+	draft := shell.currentDraft()
+	if draft.stage != draftStageSubmitted {
+		t.Fatalf("draft.stage = %v, want %v", draft.stage, draftStageSubmitted)
+	}
+	if got := len(shell.effectiveRoundFlow().SubmittedRoles); got != 1 {
+		t.Fatalf("submitted roles = %d, want 1", got)
+	}
+
+	shell.width = 120
+	shell.height = 32
+	view := shell.View()
+	for _, want := range []string{
+		"Submission locked for this round.",
+		"Waiting on: Production Manager, Sales Manager, Finance",
+		"Controller",
+		"Current-turn details stay out of the shared round feed",
+		"until reveal.",
+		"Order 2 of housing from forgeco",
+		"Commentary: Ordering only what assembly can absorb.",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("submitted action-entry view missing %q\n%s", want, view)
+		}
+	}
+}
+
+func TestRoundFeedKeepsCurrentTurnSubmissionHidden(t *testing.T) {
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.drafts[domain.RoleProcurementManager] = actionDraft{
+		stage: draftStageSubmitted,
+		submission: &domain.ActionSubmission{
+			Action: domain.RoleAction{
+				Procurement: &domain.ProcurementAction{
+					Orders: []domain.PurchaseOrderIntent{{PartID: "housing", SupplierID: "forgeco", Quantity: 2}},
+				},
+			},
+			Commentary: domain.CommentaryRecord{Body: "Hidden until reveal."},
+		},
+	}
+	shell.workspace = workspaceRoundFeed
+	shell.width = 120
+	shell.height = 32
+
+	view := shell.View()
+	for _, want := range []string{
+		"Mode: round feed",
+		"Navigate: 1 action | 2 report | [3 feed] | 4 archive | [/]",
+		"cycle",
+		"Submissions received: 1/4",
+		"Waiting on: Production Manager, Sales Manager, Finance",
+		"Controller",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("round feed missing %q\n%s", want, view)
+		}
+	}
+	for _, unwanted := range []string{
+		"Order 2 of housing from forgeco",
+		"Hidden until reveal.",
+	} {
+		if strings.Contains(view, unwanted) {
+			t.Fatalf("round feed leaked %q\n%s", unwanted, view)
+		}
+	}
+}
+
+func TestFinanceActionEntrySeedsCurrentTargetsAsDefaults(t *testing.T) {
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.selectedRole = 3
+
+	submission, err := shell.buildSubmissionDraft(actionDraft{
+		financeProcurement: "21",
+		financeProduction:  "17",
+		financeRevenue:     "33",
+		financeCashFloor:   "9",
+		financeDebtCeiling: "14",
+		commentary:         "Keeping target posture stable while we learn the plant.",
+	})
+	if err != nil {
+		t.Fatalf("buildSubmissionDraft() error = %v", err)
+	}
+
+	targets := submission.Action.Finance.NextRoundTargets
+	if targets.EffectiveRound != 2 {
+		t.Fatalf("targets.EffectiveRound = %d, want 2", targets.EffectiveRound)
+	}
+	if targets.ProcurementBudget != 21 || targets.ProductionSpendBudget != 17 || targets.RevenueTarget != 33 || targets.CashFloorTarget != 9 || targets.DebtCeilingTarget != 14 {
+		t.Fatalf("targets = %+v, want explicit values copied into next-round targets", targets)
 	}
 }
 
 func TestModelResubscribesToStateUpdates(t *testing.T) {
 	updates := make(chan domain.MatchState, 1)
-	model := NewModel("Prairie Pump Starter Plant", testStateSource{
+	model := NewModel(scenario.Starter(), testStateSource{
 		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
 		updates:  updates,
 	})
@@ -194,7 +320,7 @@ func TestModelResubscribesToStateUpdates(t *testing.T) {
 }
 
 func TestModelUsesCompactLayoutAndEmptyStatesOnSmallerTerminal(t *testing.T) {
-	model := NewModel("Prairie Pump Starter Plant", testStateSource{
+	model := NewModel(scenario.Starter(), testStateSource{
 		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
 	})
 
@@ -211,11 +337,11 @@ func TestModelUsesCompactLayoutAndEmptyStatesOnSmallerTerminal(t *testing.T) {
 		"Departments [focus]",
 		"Plant Stats",
 		"Center Workspace",
-		"Navigate: 1 report | [2 feed] | 3 archive | [/] cycle",
-		"The round is waiting for simultaneous submissions.",
-		"Waiting on: Procurement Manager, Production Manager, Sales Manager, Finance Controller",
+		"Navigate: [1 action] | 2 report | 3 feed | 4 archive | [/] cycle",
+		"Action entry for Procurement Manager",
+		"Orders: housing=2, seal_kit=1",
 		"Workstations: waiting for first telemetry",
-		"Mode: inspect | Focus: departments | Workspace: round feed | Role: Procurement Manager |",
+		"Mode: inspect | Focus: departments | Workspace: action entry | Role: Procurement Manager |",
 		"Round: 1 | Phase: collecting | Round 1 loaded for Procurement Manager",
 	} {
 		if !strings.Contains(view, want) {
@@ -225,7 +351,7 @@ func TestModelUsesCompactLayoutAndEmptyStatesOnSmallerTerminal(t *testing.T) {
 }
 
 func TestModelRoleReportShowsCompanySnapshot(t *testing.T) {
-	model := NewModel("Prairie Pump Starter Plant", testStateSource{
+	model := NewModel(scenario.Starter(), testStateSource{
 		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
 	})
 
@@ -238,7 +364,8 @@ func TestModelRoleReportShowsCompanySnapshot(t *testing.T) {
 	view := shell.View()
 	for _, want := range []string{
 		"Mode: role report",
-		"[1 report] | 2 feed | 3 archive | [/] cycle",
+		"1 action | [2 report] | 3 feed | 4 archive | [/]",
+		"cycle",
 		"Role report for Procurement Manager",
 		"Company snapshot",
 		"Inventory value:",
@@ -251,7 +378,7 @@ func TestModelRoleReportShowsCompanySnapshot(t *testing.T) {
 }
 
 func TestModelRoundFeedExplainsResolvingAndRevealedStates(t *testing.T) {
-	model := NewModel("Prairie Pump Starter Plant", testStateSource{
+	model := NewModel(scenario.Starter(), testStateSource{
 		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
 	})
 
@@ -259,6 +386,7 @@ func TestModelRoundFeedExplainsResolvingAndRevealedStates(t *testing.T) {
 	shell := loaded.(Model)
 	shell.width = 120
 	shell.height = 30
+	shell.workspace = workspaceRoundFeed
 
 	shell.state.RoundFlow.Phase = domain.RoundPhaseResolving
 	resolvingView := shell.View()
@@ -299,7 +427,7 @@ func TestModelRoundFeedExplainsResolvingAndRevealedStates(t *testing.T) {
 }
 
 func TestModelArchiveShowsRetainedHistorySummaries(t *testing.T) {
-	model := NewModel("Prairie Pump Starter Plant", testStateSource{
+	model := NewModel(scenario.Starter(), testStateSource{
 		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
 	})
 
@@ -325,7 +453,8 @@ func TestModelArchiveShowsRetainedHistorySummaries(t *testing.T) {
 	view := shell.View()
 	for _, want := range []string{
 		"Mode: history archive",
-		"1 report | 2 feed | [3 archive] | [/] cycle",
+		"1 action | 2 report | 3 feed | [4 archive] | [/]",
+		"cycle",
 		"Rounds retained: 1",
 		"Use this view for older rounds and per-round summaries",
 		"rather than the current feed.",

--- a/internal/adapters/tui/run.go
+++ b/internal/adapters/tui/run.go
@@ -9,7 +9,7 @@ import (
 // Run launches the main Bubble Tea shell for the current match snapshot.
 func Run(definition scenario.Definition, initial domain.MatchState) error {
 	program := tea.NewProgram(
-		NewModel(definition.DisplayName, newStaticStateSource(initial)),
+		NewModel(definition, newStaticStateSource(initial)),
 		tea.WithAltScreen(),
 	)
 	_, err := program.Run()


### PR DESCRIPTION
## Summary
- add a TUI-native action-entry workspace for human-controlled roles in the center pane
- support per-role drafting, review, submission, and immediate local locking without leaving Bubble Tea
- keep current-turn submissions private to the action-entry workspace while the shared round feed only shows submitted/waiting status
- expand TUI tests to cover draft/review/submit flow, hidden-feed behavior, finance defaults, and updated workspace navigation

## Why
Issue #66 asks for human action capture to move into the TUI workspace so the playable loop stays inside one surface and preserves hidden simultaneous-turn semantics.

## Implementation notes
- `NewModel` now carries the scenario definition so the TUI can validate parts, products, workstations, and finance defaults directly in the action-entry workspace.
- The new `action_entry.go` file adds lightweight form state, parsing, review, and submission rendering without introducing extra UI dependencies.
- Submitted human turns are tracked privately in the TUI model and overlaid onto round-flow status, so the command bar and round feed reflect waiting/submitted state without leaking current-turn action details.

## Validation
- `go run ./cmd/quality verify`

## Clarification questions
- After a human submits and the turn is locked, should the default UX stay on the locked action-entry workspace, or should it auto-switch to the round feed while preserving a way back to the private summary?
- In future mixed-human matches on one terminal, should private submitted summaries remain visible when cycling across human-controlled roles, or should the TUI hide another human role's locked draft unless that role is actively being played on that terminal?

Closes #66