### PR TITLE
[codex] Add MVP gameplay regression coverage

### DIFF
--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
 	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
 	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
@@ -592,6 +594,81 @@ func TestModelRoundFeedExplainsResolvingAndRevealedStates(t *testing.T) {
 	} {
 		if !strings.Contains(revealedView, want) {
 			t.Fatalf("revealed view missing %q\n%s", want, revealedView)
+		}
+	}
+}
+
+func TestModelRoundFeedShowsResolvedStarterHistory(t *testing.T) {
+	starter := scenario.Starter()
+	state := starter.InitialState("starter-match", starterAssignments())
+	resolver := engine.NewResolver(starter.ResolverOptions())
+
+	result, err := resolver.ResolveRound(state, []domain.ActionSubmission{
+		{
+			ActionID: "prod-1",
+			MatchID:  state.MatchID,
+			Round:    state.CurrentRound,
+			RoleID:   domain.RoleProductionManager,
+			Action: domain.RoleAction{
+				Production: &domain.ProductionAction{
+					CapacityAllocation: []domain.CapacityAllocation{
+						{WorkstationID: "assembly", ProductID: "pump", Capacity: 2},
+					},
+				},
+			},
+			Commentary: domain.CommentaryRecord{Body: "Finishing inherited pump WIP before releasing more work."},
+		},
+		{
+			ActionID: "sales-1",
+			MatchID:  state.MatchID,
+			Round:    state.CurrentRound,
+			RoleID:   domain.RoleSalesManager,
+			Action: domain.RoleAction{
+				Sales: &domain.SalesAction{
+					ProductOffers: []domain.ProductOffer{
+						{ProductID: "pump", UnitPrice: 14},
+						{ProductID: "valve", UnitPrice: 9},
+					},
+				},
+			},
+			Commentary: domain.CommentaryRecord{Body: "Holding starter prices while we clear inherited backlog."},
+		},
+	}, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	next := result.NextState
+	next.RoundFlow.Phase = domain.RoundPhaseRevealed
+	next.RoundFlow.SubmittedRoles = []domain.RoleID{
+		domain.RoleProductionManager,
+		domain.RoleSalesManager,
+	}
+	next.RoundFlow.WaitingOnRoles = []domain.RoleID{
+		domain.RoleProcurementManager,
+		domain.RoleFinanceController,
+	}
+
+	model := NewModel(starter, testStateSource{snapshot: next})
+	loaded, _ := model.Update(stateLoadedMsg{state: next})
+	shell := loaded.(Model)
+	shell.workspace = workspaceRoundFeed
+	shell.width = 120
+	shell.height = 32
+
+	view := shell.View()
+	for _, want := range []string{
+		"Current phase: revealed round results",
+		"Recent resolved rounds (1 shown)",
+		"[R1] 20 events | 2 commentary",
+		"Sales Manager: Holding starter prices while we",
+		"clear inherited backlog.",
+		"Event: Shipped 2 pump to northbuild",
+		"Event: Realized 4 units of pump demand from",
+		"northbuild",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("revealed round feed missing %q\n%s", want, view)
 		}
 	}
 }

--- a/internal/app/mvp_flow_test.go
+++ b/internal/app/mvp_flow_test.go
@@ -1,0 +1,154 @@
+package app_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/human"
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
+	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func TestStarterMVPFlowCollectsMixedPlayersAndResolvesRound(t *testing.T) {
+	starter := scenario.Starter()
+	state := starter.InitialState("starter-match", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", Provider: "ollama", ModelName: "gemma4:e4b"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", IsHuman: true},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "openrouter", ModelName: "openai/gpt-5-mini"},
+	})
+	now := time.Date(2026, time.April, 21, 19, 0, 0, 0, time.UTC)
+
+	collector := app.RoundCollector{
+		Now: func() time.Time { return now },
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProcurementManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Procurement: &domain.ProcurementAction{},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Holding cash until the bottleneck needs more parts."},
+				}, nil
+			}),
+			domain.RoleProductionManager: llm.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Production: &domain.ProductionAction{
+							CapacityAllocation: []domain.CapacityAllocation{
+								{WorkstationID: "assembly", ProductID: "pump", Capacity: 2},
+							},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Finishing inherited pump WIP before releasing more work."},
+				}, nil
+			}),
+			domain.RoleSalesManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Sales: &domain.SalesAction{
+							ProductOffers: []domain.ProductOffer{
+								{ProductID: "pump", UnitPrice: 14},
+								{ProductID: "valve", UnitPrice: 9},
+							},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Holding starter prices while we clear inherited backlog."},
+				}, nil
+			}),
+			domain.RoleFinanceController: llm.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Finance: &domain.FinanceAction{
+							NextRoundTargets: domain.BudgetTargets{
+								ProcurementBudget:     16,
+								ProductionSpendBudget: 12,
+								RevenueTarget:         34,
+								CashFloorTarget:       10,
+								DebtCeilingTarget:     15,
+							},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Keeping spending tight while backlog is still monetized."},
+				}, nil
+			}),
+		},
+	}
+
+	actions, err := collector.Collect(context.Background(), state, nil)
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+
+	if got := len(actions); got != 4 {
+		t.Fatalf("len(actions) = %d, want 4", got)
+	}
+	for _, action := range actions {
+		if action.MatchID != state.MatchID {
+			t.Fatalf("action.MatchID = %q, want %q", action.MatchID, state.MatchID)
+		}
+		if action.Round != state.CurrentRound {
+			t.Fatalf("action.Round = %d, want %d", action.Round, state.CurrentRound)
+		}
+		if action.SubmittedAt != now {
+			t.Fatalf("action.SubmittedAt = %s, want %s", action.SubmittedAt, now)
+		}
+		if action.ActionID == "" {
+			t.Fatalf("action for %q has empty ActionID", action.RoleID)
+		}
+	}
+
+	resolver := engine.NewResolver(starter.ResolverOptions())
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.NextState.CurrentRound; got != 2 {
+		t.Fatalf("CurrentRound = %d, want 2", got)
+	}
+	if got := result.NextState.ActiveTargets.EffectiveRound; got != 2 {
+		t.Fatalf("ActiveTargets.EffectiveRound = %d, want 2", got)
+	}
+	if got := len(result.NextState.History.RecentRounds); got != 1 {
+		t.Fatalf("History len = %d, want 1", got)
+	}
+	if got := result.Round.Metrics.ThroughputRevenue; got != 37 {
+		t.Fatalf("ThroughputRevenue = %d, want 37", got)
+	}
+	if got := result.Round.Metrics.ProductionSpend; got != 6 {
+		t.Fatalf("ProductionSpend = %d, want 6", got)
+	}
+	if got := result.Round.Metrics.ProductionOutputUnits; got != 2 {
+		t.Fatalf("ProductionOutputUnits = %d, want 2", got)
+	}
+	if got := result.Round.Metrics.BacklogUnits; got != 17 {
+		t.Fatalf("BacklogUnits = %d, want 17", got)
+	}
+	if !hasRoundEvent(result.Round.Events, domain.EventShipmentCompleted) {
+		t.Fatalf("Round.Events missing shipment event: %#v", result.Round.Events)
+	}
+	if !hasRoundEvent(result.Round.Events, domain.EventDemandRealized) {
+		t.Fatalf("Round.Events missing demand event: %#v", result.Round.Events)
+	}
+	if got := len(result.Round.Commentary); got != 4 {
+		t.Fatalf("Round.Commentary len = %d, want 4", got)
+	}
+	if len(result.Round.Timeline) == 0 {
+		t.Fatal("Round.Timeline is empty, want revealed chronology")
+	}
+}
+
+func hasRoundEvent(events []domain.RoundEvent, eventType domain.RoundEventType) bool {
+	for _, event := range events {
+		if event.Type == eventType {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scenario/starter_test.go
+++ b/internal/scenario/starter_test.go
@@ -209,6 +209,94 @@ func TestScenarioComponentsCanBeSelectedIndependently(t *testing.T) {
 	}
 }
 
+func TestStarterDemandFallsWhenPumpPriceRises(t *testing.T) {
+	starter := scenario.Starter()
+	state := starter.InitialState("match-17", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "proc"},
+		{RoleID: domain.RoleProductionManager, PlayerID: "prod"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "fin"},
+	})
+	state.Plant.Backlog = nil
+	for index := range state.Customers {
+		state.Customers[index].Backlog = nil
+	}
+
+	resolver := engine.NewResolver(starter.ResolverOptions())
+
+	lowPriceResult, err := resolver.ResolveRound(state, []domain.ActionSubmission{
+		starterSalesAction(state, 12, 9),
+	}, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() low price error = %v", err)
+	}
+
+	highPriceResult, err := resolver.ResolveRound(state, []domain.ActionSubmission{
+		starterSalesAction(state, 18, 9),
+	}, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() high price error = %v", err)
+	}
+
+	lowDemand := demandQuantityForProduct(lowPriceResult.Round.Events, "pump")
+	highDemand := demandQuantityForProduct(highPriceResult.Round.Events, "pump")
+	if lowDemand <= highDemand {
+		t.Fatalf("pump demand at low price = %d, want > high price demand %d", lowDemand, highDemand)
+	}
+
+	if got := backlogQuantityForProduct(lowPriceResult.NextState.Plant.Backlog, "pump"); got != lowDemand {
+		t.Fatalf("low price pump backlog = %d, want %d", got, lowDemand)
+	}
+	if got := backlogQuantityForProduct(highPriceResult.NextState.Plant.Backlog, "pump"); got != highDemand {
+		t.Fatalf("high price pump backlog = %d, want %d", got, highDemand)
+	}
+}
+
+func TestStarterExpiredBacklogBecomesLostSalesAndReducesSentiment(t *testing.T) {
+	starter := scenario.Starter()
+	state := starter.InitialState("match-18", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "proc"},
+		{RoleID: domain.RoleProductionManager, PlayerID: "prod"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "fin"},
+	})
+	state.CurrentRound = 3
+	state.Plant.Backlog = []domain.BacklogEntry{
+		{CustomerID: "northbuild", ProductID: "pump", Quantity: 2, OriginRound: 1, AgeInRounds: 2},
+	}
+	state.Plant.FinishedInventory = nil
+	for index := range state.Customers {
+		state.Customers[index].Backlog = nil
+	}
+	state.Customers[0].Backlog = []domain.BacklogEntry{
+		{CustomerID: "northbuild", ProductID: "pump", Quantity: 2, OriginRound: 1, AgeInRounds: 2},
+	}
+
+	resolver := engine.NewResolver(starter.ResolverOptions())
+	result, err := resolver.ResolveRound(state, []domain.ActionSubmission{
+		starterSalesAction(state, 100, 100),
+	}, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.Round.Metrics.LostSalesUnits; got != 2 {
+		t.Fatalf("LostSalesUnits = %d, want 2", got)
+	}
+	if got := result.NextState.Customers[0].Sentiment; got != 5 {
+		t.Fatalf("northbuild sentiment = %d, want 5", got)
+	}
+	if got := len(result.NextState.Plant.Backlog); got != 0 {
+		t.Fatalf("Plant.Backlog len = %d, want 0 after expiry without new demand", got)
+	}
+	if !containsEvent(result.Round.Events, domain.EventBacklogExpired) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventBacklogExpired, result.Round.Events)
+	}
+	if !containsEvent(result.Round.Events, domain.EventCustomerSentimentMoved) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventCustomerSentimentMoved, result.Round.Events)
+	}
+}
+
 func containsDemandEvent(events []domain.RoundEvent) bool {
 	for _, event := range events {
 		if event.Type == domain.EventDemandRealized {
@@ -216,4 +304,55 @@ func containsDemandEvent(events []domain.RoundEvent) bool {
 		}
 	}
 	return false
+}
+
+func containsEvent(events []domain.RoundEvent, eventType domain.RoundEventType) bool {
+	for _, event := range events {
+		if event.Type == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func starterSalesAction(state domain.MatchState, pumpPrice, valvePrice domain.Money) domain.ActionSubmission {
+	return domain.ActionSubmission{
+		ActionID: "sales-1",
+		MatchID:  state.MatchID,
+		Round:    state.CurrentRound,
+		RoleID:   domain.RoleSalesManager,
+		Action: domain.RoleAction{
+			Sales: &domain.SalesAction{
+				ProductOffers: []domain.ProductOffer{
+					{ProductID: "pump", UnitPrice: pumpPrice},
+					{ProductID: "valve", UnitPrice: valvePrice},
+				},
+			},
+		},
+	}
+}
+
+func demandQuantityForProduct(events []domain.RoundEvent, productID domain.ProductID) domain.Units {
+	total := domain.Units(0)
+	for _, event := range events {
+		if event.Type != domain.EventDemandRealized || event.Payload["product_id"] != string(productID) {
+			continue
+		}
+		quantity, ok := event.Payload["quantity"].(int)
+		if !ok {
+			continue
+		}
+		total += domain.Units(quantity)
+	}
+	return total
+}
+
+func backlogQuantityForProduct(backlog []domain.BacklogEntry, productID domain.ProductID) domain.Units {
+	total := domain.Units(0)
+	for _, entry := range backlog {
+		if entry.ProductID == productID {
+			total += entry.Quantity
+		}
+	}
+	return total
 }


### PR DESCRIPTION
## Summary
- add starter-scenario economic regression tests for price-sensitive demand and backlog expiry/sentiment behavior
- add an end-to-end mixed human/AI MVP round test that collects actions and resolves the real starter scenario
- add a TUI round-feed regression test that renders an actual resolved starter round in revealed state

## Why
Issue #26 asks for automated coverage around deterministic engine behavior and MVP flows. The repo already had strong resolver coverage, so this PR fills the remaining gap around starter-scenario economics plus higher-level mixed-play and TUI history rendering.

Closes #26.

## Validation
- `go test ./internal/scenario ./internal/app ./internal/adapters/tui`
- `go run ./cmd/quality verify`

## Clarification Questions
- I did not find a second open GitHub issue that looked like the duplicate partner for #26. If there is one, which issue should this PR also link or close?
- For the "terminal/TUI interaction tests" part of the scope, is the current render/navigation/revealed-history coverage enough for this pass, or do you want a follow-up that drives a fuller CLI round loop end-to-end as well?