### PR TITLE
[codex] Add playable MVP match loop

### DIFF
--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -1,19 +1,23 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/tui"
 	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/engine"
 )
 
 func main() {
 	var (
 		configPath   = flag.String("config", "herbiego.yaml", "path to YAML runtime configuration")
 		humanPlayers = flag.Int("human-players", -1, "override the number of human-controlled roles; use 0 for an AI-only test run")
+		rounds       = flag.Int("rounds", 3, "number of rounds to play before exiting")
 		seed         = flag.Uint64("seed", 0, "override the deterministic runtime seed")
+		inspect      = flag.Bool("inspect", false, "open the TUI inspector for the initial match instead of playing rounds")
 	)
 	flag.Parse()
 
@@ -32,8 +36,46 @@ func main() {
 		fmt.Fprintf(os.Stderr, "bootstrap failed:\n%v\n", err)
 		os.Exit(1)
 	}
-	if err := tui.Run(runtime.Scenario, runtime.InitialMatch); err != nil {
-		fmt.Fprintf(os.Stderr, "tui failed:\n%v\n", err)
+
+	if *inspect {
+		if err := tui.Run(runtime.Scenario, runtime.InitialMatch); err != nil {
+			fmt.Fprintf(os.Stderr, "tui failed:\n%v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	controller := newTerminalController(runtime.Scenario, os.Stdin, os.Stdout)
+	players, err := buildPlayers(runtime, controller)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "player setup failed:\n%v\n", err)
 		os.Exit(1)
 	}
+
+	fmt.Fprintf(os.Stdout, "HerbieGo MVP match: %s\n", runtime.Scenario.DisplayName)
+	fmt.Fprintf(os.Stdout, "Roles: %v\n", runtime.RoleSummaries())
+	fmt.Fprintf(os.Stdout, "Playing %d rounds. Use -human-players=0 for an unattended AI-only run.\n", *rounds)
+
+	runner := app.MatchRunner{
+		Collector: app.RoundCollector{Players: players},
+		Resolver:  engine.NewResolver(runtime.Scenario.ResolverOptions()),
+		Random:    runtime.Random,
+		OnRound: func(result engine.Result) {
+			renderRoundOutcome(os.Stdout, result)
+		},
+	}
+
+	final, _, err := runner.Play(context.Background(), runtime.InitialMatch, *rounds)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "match failed:\n%v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stdout, "\nMatch complete after round %d. Next round would be %d.\n", final.CurrentRound-1, final.CurrentRound)
+	fmt.Fprintf(os.Stdout, "Final cash %d | debt %d | backlog %d | profit %d\n",
+		final.Plant.Cash,
+		final.Plant.Debt,
+		len(final.Plant.Backlog),
+		final.Metrics.RoundProfit,
+	)
 }

--- a/cmd/herbiego/match_output.go
+++ b/cmd/herbiego/match_output.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
+)
+
+func renderRoundOutcome(writer io.Writer, result engine.Result) {
+	round := result.Round
+	metrics := round.Metrics
+
+	fmt.Fprintf(writer, "\n=== Round %d outcome ===\n", round.Round)
+	fmt.Fprintf(writer, "Revenue %d | profit %d | cash change %+d | backlog units %d | output units %d\n",
+		metrics.ThroughputRevenue,
+		metrics.RoundProfit,
+		metrics.NetCashChange,
+		metrics.BacklogUnits,
+		metrics.ProductionOutputUnits,
+	)
+
+	if len(round.Commentary) > 0 {
+		fmt.Fprintln(writer, "Commentary:")
+		for _, commentary := range round.Commentary {
+			fmt.Fprintf(writer, "- %s: %s\n", displayRoleName(commentary.RoleID), commentary.Body)
+		}
+	}
+
+	if len(round.Events) > 0 {
+		fmt.Fprintln(writer, "Events:")
+		for _, event := range headlineEvents(round.Events, 6) {
+			fmt.Fprintf(writer, "- %s\n", event.Summary)
+		}
+	}
+}
+
+func headlineEvents(events []domain.RoundEvent, limit int) []domain.RoundEvent {
+	if len(events) <= limit {
+		return events
+	}
+	return events[:limit]
+}

--- a/internal/app/match_runner.go
+++ b/internal/app/match_runner.go
@@ -1,0 +1,134 @@
+package app
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+// MatchRunner drives the MVP match loop by collecting every role's simultaneous
+// action, resolving the round, and carrying the resulting state forward.
+type MatchRunner struct {
+	Collector RoundCollector
+	Resolver  *engine.Resolver
+	Random    ports.RandomSource
+	OnState   func(domain.MatchState)
+	OnRound   func(engine.Result)
+}
+
+// Play advances the match for the requested number of rounds.
+func (r MatchRunner) Play(ctx context.Context, initial domain.MatchState, rounds int) (domain.MatchState, []engine.Result, error) {
+	if rounds <= 0 {
+		return domain.MatchState{}, nil, fmt.Errorf("app: match rounds must be positive")
+	}
+	if r.Resolver == nil {
+		return domain.MatchState{}, nil, fmt.Errorf("app: match resolver is not configured")
+	}
+	if r.Random == nil {
+		return domain.MatchState{}, nil, fmt.Errorf("app: match random source is not configured")
+	}
+
+	state := prepareCollectionState(initial.Clone())
+	previous := previousAcceptedActions(state)
+	results := make([]engine.Result, 0, rounds)
+
+	for range rounds {
+		r.emitState(state)
+
+		actions, err := r.Collector.Collect(ctx, state, previous)
+		if err != nil {
+			return state, results, err
+		}
+
+		resolving := state.Clone()
+		resolving.RoundFlow = roundFlowFor(state.Roles, actions, domain.RoundPhaseResolving, state.RoundFlow.AIRevealDelaySeconds)
+		r.emitState(resolving)
+
+		result, err := r.Resolver.ResolveRound(state, actions, r.Random)
+		if err != nil {
+			return state, results, err
+		}
+
+		revealed := result.NextState.Clone()
+		revealed.RoundFlow = roundFlowFor(state.Roles, actions, domain.RoundPhaseRevealed, state.RoundFlow.AIRevealDelaySeconds)
+		result.NextState = revealed.Clone()
+		results = append(results, result)
+		for _, action := range result.Round.Actions {
+			previous[action.RoleID] = action.Clone()
+		}
+		r.emitRound(result)
+		r.emitState(revealed)
+
+		state = prepareCollectionState(revealed)
+	}
+
+	return state.Clone(), results, nil
+}
+
+func (r MatchRunner) emitState(state domain.MatchState) {
+	if r.OnState != nil {
+		r.OnState(state.Clone())
+	}
+}
+
+func (r MatchRunner) emitRound(result engine.Result) {
+	if r.OnRound != nil {
+		r.OnRound(engine.Result{
+			NextState: result.NextState.Clone(),
+			Round:     result.Round.Clone(),
+		})
+	}
+}
+
+func prepareCollectionState(state domain.MatchState) domain.MatchState {
+	state.RoundFlow = domain.RoundFlowState{
+		Phase:                domain.RoundPhaseCollecting,
+		WaitingOnRoles:       roleIDs(state.Roles),
+		AIRevealDelaySeconds: state.RoundFlow.AIRevealDelaySeconds,
+	}
+	return state
+}
+
+func roundFlowFor(assignments []domain.RoleAssignment, actions []domain.ActionSubmission, phase domain.RoundPhase, revealDelaySeconds int) domain.RoundFlowState {
+	submitted := make([]domain.RoleID, 0, len(actions))
+	submittedSet := make(map[domain.RoleID]bool, len(actions))
+	for _, action := range actions {
+		submitted = append(submitted, action.RoleID)
+		submittedSet[action.RoleID] = true
+	}
+
+	waiting := make([]domain.RoleID, 0, max(len(assignments)-len(submitted), 0))
+	for _, assignment := range assignments {
+		if !submittedSet[assignment.RoleID] {
+			waiting = append(waiting, assignment.RoleID)
+		}
+	}
+
+	return domain.RoundFlowState{
+		Phase:                phase,
+		SubmittedRoles:       submitted,
+		WaitingOnRoles:       waiting,
+		AIRevealDelaySeconds: revealDelaySeconds,
+	}
+}
+
+func roleIDs(assignments []domain.RoleAssignment) []domain.RoleID {
+	ids := make([]domain.RoleID, 0, len(assignments))
+	for _, assignment := range assignments {
+		ids = append(ids, assignment.RoleID)
+	}
+	return ids
+}
+
+func previousAcceptedActions(state domain.MatchState) map[domain.RoleID]domain.ActionSubmission {
+	previous := make(map[domain.RoleID]domain.ActionSubmission, len(state.Roles))
+	for _, round := range state.History.RecentRounds {
+		for _, action := range round.Actions {
+			previous[action.RoleID] = action.Clone()
+		}
+	}
+	return previous
+}

--- a/internal/app/match_runner_test.go
+++ b/internal/app/match_runner_test.go
@@ -1,0 +1,143 @@
+package app_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func TestMatchRunnerPlaysMultipleResolvedRounds(t *testing.T) {
+	starter := scenario.Starter()
+	initial := starter.InitialState("starter-match", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", Provider: "ollama", ModelName: "gemma4:e4b"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", Provider: "openrouter", ModelName: "openai/gpt-5-mini"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "openai", ModelName: "gpt-5-mini"},
+	})
+	initial.RoundFlow.AIRevealDelaySeconds = 15
+
+	phaseCounts := map[domain.RoundPhase]int{}
+	runner := app.MatchRunner{
+		Collector: app.RoundCollector{
+			Players: scriptedPlayers(),
+		},
+		Resolver: engine.NewResolver(starter.ResolverOptions()),
+		Random:   seeded.New(1),
+		OnState: func(state domain.MatchState) {
+			phaseCounts[state.RoundFlow.Phase]++
+		},
+	}
+
+	final, results, err := runner.Play(context.Background(), initial, 3)
+	if err != nil {
+		t.Fatalf("Play() error = %v", err)
+	}
+
+	if got := len(results); got != 3 {
+		t.Fatalf("len(results) = %d, want 3", got)
+	}
+	if got := final.CurrentRound; got != 4 {
+		t.Fatalf("final.CurrentRound = %d, want 4", got)
+	}
+	if got := len(final.History.RecentRounds); got != 3 {
+		t.Fatalf("history rounds = %d, want 3", got)
+	}
+	if final.RoundFlow.Phase != domain.RoundPhaseCollecting {
+		t.Fatalf("final phase = %q, want collecting", final.RoundFlow.Phase)
+	}
+	if got := len(final.RoundFlow.WaitingOnRoles); got != 4 {
+		t.Fatalf("waiting roles = %d, want 4", got)
+	}
+	if phaseCounts[domain.RoundPhaseCollecting] != 3 {
+		t.Fatalf("collecting states emitted = %d, want 3", phaseCounts[domain.RoundPhaseCollecting])
+	}
+	if phaseCounts[domain.RoundPhaseResolving] != 3 {
+		t.Fatalf("resolving states emitted = %d, want 3", phaseCounts[domain.RoundPhaseResolving])
+	}
+	if phaseCounts[domain.RoundPhaseRevealed] != 3 {
+		t.Fatalf("revealed states emitted = %d, want 3", phaseCounts[domain.RoundPhaseRevealed])
+	}
+
+	for index, result := range results {
+		if got := len(result.Round.Actions); got != 4 {
+			t.Fatalf("round %d actions = %d, want 4", index+1, got)
+		}
+		if got := len(result.Round.Commentary); got != 4 {
+			t.Fatalf("round %d commentary = %d, want 4", index+1, got)
+		}
+		if len(result.Round.Timeline) == 0 {
+			t.Fatalf("round %d timeline is empty", index+1)
+		}
+	}
+}
+
+func scriptedPlayers() map[domain.RoleID]ports.Player {
+	return map[domain.RoleID]ports.Player{
+		domain.RoleProcurementManager: scriptPlayer(func(request ports.RoundRequest) domain.ActionSubmission {
+			return domain.ActionSubmission{
+				Action: domain.RoleAction{Procurement: &domain.ProcurementAction{}},
+				Commentary: domain.CommentaryRecord{
+					Body: fmt.Sprintf("Round %d procurement protects cash for the bottleneck.", request.RoleView.Round),
+				},
+			}
+		}),
+		domain.RoleProductionManager: scriptPlayer(func(request ports.RoundRequest) domain.ActionSubmission {
+			return domain.ActionSubmission{
+				Action: domain.RoleAction{
+					Production: &domain.ProductionAction{
+						CapacityAllocation: []domain.CapacityAllocation{
+							{WorkstationID: "assembly", ProductID: "pump", Capacity: 2},
+						},
+					},
+				},
+				Commentary: domain.CommentaryRecord{
+					Body: fmt.Sprintf("Round %d production favors throughput over local utilization.", request.RoleView.Round),
+				},
+			}
+		}),
+		domain.RoleSalesManager: scriptPlayer(func(request ports.RoundRequest) domain.ActionSubmission {
+			return domain.ActionSubmission{
+				Action: domain.RoleAction{
+					Sales: &domain.SalesAction{
+						ProductOffers: []domain.ProductOffer{
+							{ProductID: "pump", UnitPrice: 14},
+							{ProductID: "valve", UnitPrice: 9},
+						},
+					},
+				},
+				Commentary: domain.CommentaryRecord{
+					Body: fmt.Sprintf("Round %d sales holds price while backlog is visible.", request.RoleView.Round),
+				},
+			}
+		}),
+		domain.RoleFinanceController: scriptPlayer(func(request ports.RoundRequest) domain.ActionSubmission {
+			targets := request.RoleView.ActiveTargets
+			targets.EffectiveRound = request.RoleView.Round + 1
+			return domain.ActionSubmission{
+				Action: domain.RoleAction{
+					Finance: &domain.FinanceAction{NextRoundTargets: targets},
+				},
+				Commentary: domain.CommentaryRecord{
+					Body: fmt.Sprintf("Round %d finance keeps targets stable to compare tradeoffs.", request.RoleView.Round),
+				},
+			}
+		}),
+	}
+}
+
+type scriptPlayer func(ports.RoundRequest) domain.ActionSubmission
+
+func (p scriptPlayer) SubmitRound(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+	return p(request), nil
+}
+
+func (scriptPlayer) RecoverFromNonResponse(_ context.Context, request ports.RoundRequest, cause error) (domain.ActionSubmission, error) {
+	return domain.ActionSubmission{}, fmt.Errorf("role %q did not respond: %w", request.Assignment.RoleID, cause)
+}


### PR DESCRIPTION
## Summary
- Adds an app-level `MatchRunner` that repeatedly collects mixed human/AI submissions, resolves rounds, preserves previous actions, and emits collecting/resolving/revealed phase snapshots.
- Wires `cmd/herbiego` to play a configurable number of rounds with terminal human prompts, AI role adapters, and per-round outcome/commentary summaries.
- Keeps the existing Bubble Tea shell available as an initial-state inspector via `-inspect`.

Closes #25.

## Validation
- `go test ./...`

## Clarification questions
- Issue #25 overlaps with the already-closed #26 MVP flow/testing work; I treated #25 as the playable runtime wiring that uses the tested collector/resolver path. Is that the intended duplicate split?
- Should the Bubble Tea action-entry UI become the primary driver of this same runner in a follow-up, or should the MVP playable loop remain terminal-first while TUI stays focused on inspection?