### PR TITLE
[codex] Add live Bubble Tea gameplay validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,3 +393,21 @@ For CI or other automation, use the non-mutating verification command:
 ```bash
 go run ./cmd/quality verify
 ```
+
+## Manual Smoke Test
+
+The supported local playtesting path is the default Bubble Tea runtime in `cmd/herbiego`.
+
+Run a short mixed match with:
+
+```bash
+go run ./cmd/herbiego -rounds 2 -human-players 1
+```
+
+Quick checks for the current MVP path:
+
+- Confirm the Bubble Tea shell opens immediately without a separate inspect or terminal-prompt mode.
+- Enter a Procurement turn in the action-entry workspace and submit it.
+- Verify the round feed shows submission progress without exposing the current-turn action or commentary before reveal.
+- Wait for the AI-controlled roles to finish and confirm the shell advances through collecting, resolving, and revealed phases.
+- Confirm the revealed feed shows the resolved round commentary and that round two becomes playable without restarting the program.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ HerbieGo is a multiplayer computer board game inspired by the manufacturing plan
 
 The project is designed as both a strategy game and a simulation. Over many in-game years, the plant, the market, the available management ideas, and the viable strategies all evolve. New methods can emerge as the simulation progresses, allowing the game to reflect changing thinking in operations and management over time.
 
+## Quick Start
+
+The current supported playtesting path is the Bubble Tea runtime in `cmd/herbiego`.
+
+Install dependencies and verify the repo:
+
+```bash
+go run ./cmd/quality verify
+```
+
+Run the default local mixed match:
+
+```bash
+go run ./cmd/herbiego -rounds 2 -human-players 1
+```
+
+For setup details, config options, launch examples, and a short play guide, see [Configure, Launch, and Play](docs/configure-launch-play.md).
+
 ## Game Overview
 
 ### Premise
@@ -357,6 +375,7 @@ HerbieGo aims to be both a game and a systems-thinking simulation: a place where
 
 - [MVP Game Design](docs/mvp-game-design.md)
 - [Canonical Domain Model](docs/domain-model.md)
+- [Configure, Launch, and Play](docs/configure-launch-play.md)
 - [Architecture Decision Records](docs/adr/README.md)
 - [Contributor Guide](CONTRIBUTING.md)
 
@@ -393,21 +412,3 @@ For CI or other automation, use the non-mutating verification command:
 ```bash
 go run ./cmd/quality verify
 ```
-
-## Manual Smoke Test
-
-The supported local playtesting path is the default Bubble Tea runtime in `cmd/herbiego`.
-
-Run a short mixed match with:
-
-```bash
-go run ./cmd/herbiego -rounds 2 -human-players 1
-```
-
-Quick checks for the current MVP path:
-
-- Confirm the Bubble Tea shell opens immediately without a separate inspect or terminal-prompt mode.
-- Enter a Procurement turn in the action-entry workspace and submit it.
-- Verify the round feed shows submission progress without exposing the current-turn action or commentary before reveal.
-- Wait for the AI-controlled roles to finish and confirm the shell advances through collecting, resolving, and revealed phases.
-- Confirm the revealed feed shows the resolved round commentary and that round two becomes playable without restarting the program.

--- a/docs/configure-launch-play.md
+++ b/docs/configure-launch-play.md
@@ -1,0 +1,132 @@
+# Configure, Launch, and Play
+
+This guide covers the current MVP runtime path for HerbieGo: a Bubble Tea shell with one or more human-controlled roles and the remaining roles handled by AI providers.
+
+## Files
+
+- `herbiego.yaml`: runtime settings for environment, seed, human player count, UI timing, and role-to-provider mapping
+- `llm.yaml`: provider catalog that maps provider names to model names, URLs, API protocol families, and optional API keys
+
+## Configure
+
+The repo ships with a local-first default setup:
+
+- `human_players: 1` makes one role human-controlled by default
+- `random.seed: 1` keeps startup deterministic unless you override it
+- `ui.ai_reveal_delay_seconds: 15` pauses revealed AI-only rounds briefly before advancing
+- each canonical role is mapped to a provider name in `herbiego.yaml`
+- each provider name is resolved through `llm.yaml`
+
+Default `herbiego.yaml`:
+
+```yaml
+environment: local
+random:
+  seed: 1
+human_players: 1
+ui:
+  ai_reveal_delay_seconds: 15
+roles:
+  - role_id: procurement_manager
+    provider: ollama-localhost
+  - role_id: production_manager
+    provider: ollama-localhost
+  - role_id: sales_manager
+    provider: ollama-localhost
+  - role_id: finance_controller
+    provider: ollama-localhost
+```
+
+Default `llm.yaml` provider catalog:
+
+```yaml
+models:
+  - provider_name: ollama-localhost
+    model_name: gemma4:e4b
+    url: http://localhost:11434/
+    api_sdk_type: ollama
+    api_key: ""
+  - provider_name: ollama-cloud
+    model_name: gemma4:e4b
+    url: https://ollama.com/api/
+    api_sdk_type: ollama
+    api_key: ""
+  - provider_name: openrouter
+    model_name: openai/gpt-5-mini
+    url: https://openrouter.ai/api/v1/
+    api_sdk_type: openai
+    api_key: ""
+```
+
+If you want a different local profile:
+
+- change `human_players` in `herbiego.yaml`
+- swap a role's `provider` label in `herbiego.yaml`
+- update the matching provider entry in `llm.yaml`
+- pass `-human-players` or `-seed` at launch time for a one-off override
+
+## Launch
+
+Verify the repo before running:
+
+```bash
+go run ./cmd/quality verify
+```
+
+Launch the default mixed human-plus-AI game:
+
+```bash
+go run ./cmd/herbiego -rounds 2 -human-players 1
+```
+
+Useful launch variants:
+
+```bash
+go run ./cmd/herbiego
+go run ./cmd/herbiego -rounds 5
+go run ./cmd/herbiego -human-players 0
+go run ./cmd/herbiego -seed 7
+go run ./cmd/herbiego -config custom-herbiego.yaml
+```
+
+Current CLI flags:
+
+- `-config`: path to the runtime YAML file, default `herbiego.yaml`
+- `-human-players`: override the number of human-controlled roles, use `0` for an AI-only run
+- `-rounds`: number of rounds to play before exiting, default `3`
+- `-seed`: override the deterministic runtime seed
+
+## Play
+
+The Bubble Tea shell is the primary gameplay surface.
+
+At startup:
+
+- the left pane shows departments and the selected role
+- the center workspace starts in action entry for the current human-controlled role
+- the right pane shows plant stats and current targets
+- the command bar shows navigation and editing hints
+
+The current human turn flow:
+
+1. Edit the action-entry fields for the selected role.
+2. Add commentary describing the reasoning for the turn.
+3. Enter review mode.
+4. Submit the turn.
+5. Wait while AI-controlled roles finish the same hidden simultaneous round.
+6. Inspect the revealed feed once the round resolves.
+7. Move into the next round without restarting the shell.
+
+What to verify during a manual smoke test:
+
+- the Bubble Tea shell opens immediately without a separate terminal-prompt gameplay flow
+- the human role can draft, review, and submit a turn inside the action-entry workspace
+- the round feed shows submission progress without leaking the current-turn action or commentary before reveal
+- the shell advances through collecting, resolving, and revealed states without deadlocking
+- after reveal, the resolved commentary and events appear in the feed and the next round becomes playable
+
+## Notes
+
+- The default local profile assumes the configured provider endpoints are available.
+- Human role selection still follows the app's preferred role order when `human_players` is greater than zero.
+- AI-only runs stay in the Bubble Tea shell so the match can be watched as it resolves.

--- a/internal/adapters/tui/live_runtime_test.go
+++ b/internal/adapters/tui/live_runtime_test.go
@@ -1,0 +1,382 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/human"
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
+	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func TestModelSupportsMultiRoundLiveHumanPlusAIPlay(t *testing.T) {
+	t.Parallel()
+
+	starter := scenario.Starter()
+	initial := starter.InitialState("starter-match", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", Provider: "ollama", ModelName: "gemma"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", Provider: "ollama", ModelName: "gemma"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "ollama", ModelName: "gemma"},
+	})
+
+	source := newLiveTestSource(initial)
+	model := NewModelWithSubmit(starter, source, source.Submit)
+	now := time.Date(2026, time.April, 21, 21, 0, 0, 0, time.UTC)
+
+	runner := app.MatchRunner{
+		Collector: app.RoundCollector{
+			Now:     func() time.Time { return now },
+			Players: scriptedLivePlayers(source),
+		},
+		Resolver: engine.NewResolver(starter.ResolverOptions()),
+		Random:   seeded.New(1),
+		OnState:  source.Publish,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		defer source.Close()
+		_, _, err := runner.Play(ctx, initial, 2)
+		result <- err
+	}()
+
+	loaded, next := model.Update(stateLoadedMsg{state: source.Snapshot()})
+	shell := loaded.(Model)
+	shell.width = 160
+	shell.height = 80
+
+	shell, next, collectingView := expectStateUpdate(t, shell, next,
+		"Action entry for Procurement Manager",
+		"Workspace: action entry",
+		"Round: 1 | Phase: collecting",
+		"Round 1 loaded for Procurement",
+		"Manager",
+	)
+
+	shell = submitProcurementTurn(t, shell, "housing=1", "Round 1 keeps housing tight while assembly clears backlog.")
+	if shell.workspace != workspaceRoundFeed {
+		t.Fatalf("workspace = %v, want %v", shell.workspace, workspaceRoundFeed)
+	}
+
+	lockedView := shell.View()
+	for _, want := range []string{
+		"Mode: round feed",
+		"Submissions received: 1/4",
+		"Waiting on: Production Manager, Sales Manager, Finance",
+		"Controller",
+		"Current-turn actions remain hidden until every role is collected",
+		"resolves.",
+	} {
+		if !strings.Contains(lockedView, want) {
+			t.Fatalf("locked collecting view missing %q\n%s", want, lockedView)
+		}
+	}
+	for _, unwanted := range []string{
+		"Order 1 of housing from forgeco",
+		"Round 1 keeps housing tight while assembly clears backlog.",
+	} {
+		if strings.Contains(lockedView, unwanted) {
+			t.Fatalf("locked collecting view leaked %q\n%s", unwanted, lockedView)
+		}
+	}
+
+	shell, next, _ = expectStateUpdate(t, shell, next,
+		"Round 1 for Procurement Manager",
+		"Current phase: resolving simultaneous turn",
+		"The round is resolving.",
+	)
+	shell, next, revealedView := expectStateUpdate(t, shell, next,
+		"Round 2 for Procurement Manager",
+		"Current phase: revealed round results",
+		"[R1]",
+		"Procurement Manager: Round 1 keeps housing tight while assembly",
+		"clears backlog.",
+	)
+	shell, next, _ = expectStateUpdate(t, shell, next,
+		"Round 2 for Procurement Manager",
+		"Current phase: hidden simultaneous turn collection",
+		"[R1]",
+	)
+
+	nextModel, _ := shell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
+	shell = nextModel.(Model)
+	roundTwoView := shell.View()
+	if !strings.Contains(roundTwoView, "Action entry for Procurement Manager") {
+		t.Fatalf("round two action entry not available\n%s", roundTwoView)
+	}
+	for _, want := range []string{
+		"Previous accepted commentary",
+		"Round 1 keeps housing tight while assembly clears backlog.",
+	} {
+		if !strings.Contains(roundTwoView, want) {
+			t.Fatalf("round two action entry missing prior-round carryover %q\n%s", want, roundTwoView)
+		}
+	}
+	if strings.Contains(roundTwoView, "Submission locked for this round.") {
+		t.Fatalf("round two action entry retained locked-round state\n%s", roundTwoView)
+	}
+
+	shell = submitProcurementTurn(t, shell, "housing=2", "Round 2 buys ahead of the now-visible pump pull.")
+	shell, next, _ = expectStateUpdate(t, shell, next,
+		"Round 2 for Procurement Manager",
+		"Current phase: resolving simultaneous turn",
+	)
+	shell, _, finalView := expectStateUpdate(t, shell, next,
+		"Round 3 for Procurement Manager",
+		"Current phase: revealed round results",
+		"[R2]",
+		"Procurement Manager: Round 2 buys ahead of the now-visible",
+		"pump pull.",
+	)
+
+	if err := <-result; err != nil {
+		t.Fatalf("runner.Play() error = %v", err)
+	}
+	if !strings.Contains(collectingView, "Action entry for Procurement Manager") {
+		t.Fatalf("collecting view missing action-entry workspace\n%s", collectingView)
+	}
+	if !strings.Contains(revealedView, "[R1]") {
+		t.Fatalf("revealed view missing round one history\n%s", revealedView)
+	}
+	if !strings.Contains(finalView, "[R2]") {
+		t.Fatalf("final view missing round two history\n%s", finalView)
+	}
+}
+
+type liveSubmissionKey struct {
+	roleID domain.RoleID
+	round  domain.RoundNumber
+}
+
+type liveTestSource struct {
+	mu          sync.Mutex
+	latest      domain.MatchState
+	updates     chan domain.MatchState
+	submissions chan domain.ActionSubmission
+	pending     map[liveSubmissionKey][]domain.ActionSubmission
+	closed      bool
+}
+
+func newLiveTestSource(initial domain.MatchState) *liveTestSource {
+	return &liveTestSource{
+		latest:      initial.Clone(),
+		updates:     make(chan domain.MatchState, 8),
+		submissions: make(chan domain.ActionSubmission, len(initial.Roles)+1),
+		pending:     make(map[liveSubmissionKey][]domain.ActionSubmission),
+	}
+}
+
+func (s *liveTestSource) Snapshot() domain.MatchState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.latest.Clone()
+}
+
+func (s *liveTestSource) Updates() <-chan domain.MatchState {
+	return s.updates
+}
+
+func (s *liveTestSource) Publish(state domain.MatchState) {
+	cloned := state.Clone()
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.latest = cloned.Clone()
+	updates := s.updates
+	s.mu.Unlock()
+
+	updates <- cloned
+}
+
+func (s *liveTestSource) Close() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	updates := s.updates
+	close(s.submissions)
+	s.mu.Unlock()
+
+	close(updates)
+}
+
+func (s *liveTestSource) Submit(submission domain.ActionSubmission) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return fmt.Errorf("the live match is no longer accepting submissions")
+	}
+	submissions := s.submissions
+	s.mu.Unlock()
+
+	select {
+	case submissions <- submission.Clone():
+		return nil
+	default:
+		return fmt.Errorf("submission queue is full; wait for the current round to catch up")
+	}
+}
+
+func (s *liveTestSource) SubmitRound(ctx context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+	key := liveSubmissionKey{
+		roleID: request.Assignment.RoleID,
+		round:  request.RoleView.Round,
+	}
+	if submission, ok := s.takePending(key); ok {
+		return submission, nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return domain.ActionSubmission{}, fmt.Errorf("tui player %q: %w", request.Assignment.RoleID, ctx.Err())
+		case submission, ok := <-s.submissions:
+			if !ok {
+				return domain.ActionSubmission{}, fmt.Errorf("tui player %q: live submission channel closed", request.Assignment.RoleID)
+			}
+
+			submissionKey := liveSubmissionKey{roleID: submission.RoleID, round: submission.Round}
+			if submissionKey == key {
+				return submission.Clone(), nil
+			}
+			s.storePending(submissionKey, submission)
+		}
+	}
+}
+
+func (s *liveTestSource) takePending(key liveSubmissionKey) (domain.ActionSubmission, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	items := s.pending[key]
+	if len(items) == 0 {
+		return domain.ActionSubmission{}, false
+	}
+
+	submission := items[0].Clone()
+	if len(items) == 1 {
+		delete(s.pending, key)
+	} else {
+		s.pending[key] = items[1:]
+	}
+	return submission, true
+}
+
+func (s *liveTestSource) storePending(key liveSubmissionKey, submission domain.ActionSubmission) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pending[key] = append(s.pending[key], submission.Clone())
+}
+
+func scriptedLivePlayers(source *liveTestSource) map[domain.RoleID]ports.Player {
+	return map[domain.RoleID]ports.Player{
+		domain.RoleProcurementManager: human.New(source.SubmitRound),
+		domain.RoleProductionManager: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+			return domain.ActionSubmission{
+				Action: domain.RoleAction{
+					Production: &domain.ProductionAction{
+						CapacityAllocation: []domain.CapacityAllocation{
+							{WorkstationID: "assembly", ProductID: "pump", Capacity: 2},
+						},
+					},
+				},
+				Commentary: domain.CommentaryRecord{
+					Body: fmt.Sprintf("Round %d production protects the assembly bottleneck.", request.RoleView.Round),
+				},
+			}, nil
+		}),
+		domain.RoleSalesManager: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+			return domain.ActionSubmission{
+				Action: domain.RoleAction{
+					Sales: &domain.SalesAction{
+						ProductOffers: []domain.ProductOffer{
+							{ProductID: "pump", UnitPrice: 14},
+							{ProductID: "valve", UnitPrice: 9},
+						},
+					},
+				},
+				Commentary: domain.CommentaryRecord{
+					Body: fmt.Sprintf("Round %d sales keeps starter pricing stable.", request.RoleView.Round),
+				},
+			}, nil
+		}),
+		domain.RoleFinanceController: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+			targets := request.RoleView.ActiveTargets
+			targets.EffectiveRound = request.RoleView.Round + 1
+			return domain.ActionSubmission{
+				Action: domain.RoleAction{
+					Finance: &domain.FinanceAction{NextRoundTargets: targets},
+				},
+				Commentary: domain.CommentaryRecord{
+					Body: fmt.Sprintf("Round %d finance holds targets steady for comparison.", request.RoleView.Round),
+				},
+			}, nil
+		}),
+	}
+}
+
+func expectStateUpdate(t *testing.T, model Model, cmd tea.Cmd, wants ...string) (Model, tea.Cmd, string) {
+	t.Helper()
+
+	if cmd == nil {
+		t.Fatal("expected live update subscription command")
+	}
+
+	msg := cmd()
+	nextModel, nextCmd := model.Update(msg)
+	shell := nextModel.(Model)
+	shell.width = 160
+	shell.height = 80
+	view := shell.View()
+
+	for _, want := range wants {
+		if !strings.Contains(view, want) {
+			t.Fatalf("live update missing %q\n%s", want, view)
+		}
+	}
+
+	return shell, nextCmd, view
+}
+
+func submitProcurementTurn(t *testing.T, model Model, orders string, commentary string) Model {
+	t.Helper()
+
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune{'1'}},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune(orders)},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyDown},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune(commentary)},
+		{Type: tea.KeyEnter},
+		{Type: tea.KeyRunes, Runes: []rune{'r'}},
+		{Type: tea.KeyRunes, Runes: []rune{'s'}},
+	} {
+		nextModel, _ := model.Update(key)
+		model = nextModel.(Model)
+	}
+	model.width = 160
+	model.height = 80
+
+	return model
+}


### PR DESCRIPTION
## Summary
- add a multi-round live Bubble Tea integration test that drives one human procurement role against AI-controlled roles through collecting, resolving, revealed, and next-round transitions
- assert current-turn human submissions stay hidden until reveal while the next round becomes playable without leaving the Bubble Tea shell
- document the supported default `go run ./cmd/herbiego` smoke-test path for local mixed human/AI playtesting

## Testing
- `go test ./...`
- `go run ./cmd/quality verify`

Closes #79.

## Clarification Questions
- I treated `#79` as the validation follow-up to the already-merged live-driver work in `#80`, not as a strict duplicate to close without code. If you want this tracked differently, should `#79` be closed as a duplicate of `#78` after merge, or kept as the explicit regression-coverage follow-up?
- The manual smoke-test note is in `README.md` for now so it stays close to the default runtime entrypoint. Would you rather move that guidance into a dedicated playtesting doc under `docs/` once the MVP flow settles further?