### PR TITLE
[codex] Fix stuck AI turn progression

### DIFF
--- a/internal/adapters/ai/ollama/client.go
+++ b/internal/adapters/ai/ollama/client.go
@@ -119,9 +119,7 @@ func (c *Client) endpointURL(path string) string {
 	cleanPath := strings.TrimLeft(path, "/")
 	if trimmedBase := strings.TrimLeft(basePath, "/"); trimmedBase != "" {
 		prefix := trimmedBase + "/"
-		if strings.HasPrefix(cleanPath, prefix) {
-			cleanPath = strings.TrimPrefix(cleanPath, prefix)
-		}
+		cleanPath = strings.TrimPrefix(cleanPath, prefix)
 	}
 	switch {
 	case basePath == "":

--- a/internal/adapters/ai/ollama/client.go
+++ b/internal/adapters/ai/ollama/client.go
@@ -114,7 +114,24 @@ func (c *Client) RequestDecision(ctx context.Context, request ports.ProviderDeci
 }
 
 func (c *Client) endpointURL(path string) string {
-	return c.baseURL.ResolveReference(&url.URL{Path: path}).String()
+	endpoint := *c.baseURL
+	basePath := strings.TrimSuffix(endpoint.Path, "/")
+	cleanPath := strings.TrimLeft(path, "/")
+	if trimmedBase := strings.TrimLeft(basePath, "/"); trimmedBase != "" {
+		prefix := trimmedBase + "/"
+		if strings.HasPrefix(cleanPath, prefix) {
+			cleanPath = strings.TrimPrefix(cleanPath, prefix)
+		}
+	}
+	switch {
+	case basePath == "":
+		endpoint.Path = "/" + cleanPath
+	case cleanPath == "":
+		endpoint.Path = basePath
+	default:
+		endpoint.Path = basePath + "/" + cleanPath
+	}
+	return endpoint.String()
 }
 
 func parseBaseURL(rawURL string) (*url.URL, error) {

--- a/internal/adapters/ai/ollama/client_test.go
+++ b/internal/adapters/ai/ollama/client_test.go
@@ -88,3 +88,30 @@ func TestClientReturnsHTTPFailures(t *testing.T) {
 		t.Fatalf("RequestDecision() error = %v, want response body", err)
 	}
 }
+
+func TestClientPreservesConfiguredAPIPrefix(t *testing.T) {
+	var requestPath string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestPath = request.URL.Path
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"response":"{\"contract_version\":\"herbiego.ai.v1\"}"}`))
+	}))
+	defer server.Close()
+
+	client, err := New(
+		WithBaseURL(server.URL+"/api/"),
+		WithHTTPClient(server.Client()),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = client.RequestDecision(context.Background(), ports.ProviderDecisionRequest{Model: "gemma4:e4b"})
+	if err != nil {
+		t.Fatalf("RequestDecision() error = %v", err)
+	}
+
+	if requestPath != "/api/generate" {
+		t.Fatalf("request path = %q, want /api/generate", requestPath)
+	}
+}

--- a/internal/app/round_collection.go
+++ b/internal/app/round_collection.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/ports"
 	"github.com/jpconstantineau/herbiego/internal/projection"
+	"golang.org/x/sync/errgroup"
 )
 
 // RoundCollector gathers one action submission per assigned role through the
@@ -28,8 +29,12 @@ func (c RoundCollector) Collect(ctx context.Context, state domain.MatchState, pr
 	}
 
 	now := c.now()
-	collected := make([]domain.ActionSubmission, 0, len(state.Roles))
-	for _, assignment := range state.Roles {
+	collected := make([]domain.ActionSubmission, len(state.Roles))
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	for i, assignment := range state.Roles {
+		i := i
+		assignment := assignment
 		player, ok := c.Players[assignment.RoleID]
 		if !ok {
 			return nil, fmt.Errorf("app: collect round %d: player missing for role %q", state.CurrentRound, assignment.RoleID)
@@ -42,15 +47,22 @@ func (c RoundCollector) Collect(ctx context.Context, state domain.MatchState, pr
 			PreviousAcceptedAction: clonePrevious(previous[assignment.RoleID]),
 		}
 
-		submission, err := player.SubmitRound(ctx, request)
-		if err != nil {
-			submission, err = player.RecoverFromNonResponse(ctx, request, err)
+		group.Go(func() error {
+			submission, err := player.SubmitRound(groupCtx, request)
 			if err != nil {
-				return nil, fmt.Errorf("app: collect round %d for %q: %w", state.CurrentRound, assignment.RoleID, err)
+				submission, err = player.RecoverFromNonResponse(groupCtx, request, err)
+				if err != nil {
+					return fmt.Errorf("app: collect round %d for %q: %w", state.CurrentRound, assignment.RoleID, err)
+				}
 			}
-		}
 
-		collected = append(collected, normalizeSubmission(submission, request, now))
+			collected[i] = normalizeSubmission(submission, request, now)
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 
 	return collected, nil

--- a/internal/app/round_collection_test.go
+++ b/internal/app/round_collection_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -271,6 +272,112 @@ func TestRoundCollectorReturnsErrorWhenHumanPlayerDoesNotRespond(t *testing.T) {
 	}
 	if !errors.Is(err, ports.ErrNonResponsive) {
 		t.Fatalf("Collect() error = %v, want ErrNonResponsive", err)
+	}
+}
+
+func TestRoundCollectorStartsAIPlayersBeforeEarlierHumanSubmits(t *testing.T) {
+	state := fixtureMatchState()
+	humanRelease := make(chan struct{})
+	aiStarted := make(chan struct{}, 1)
+
+	collector := app.RoundCollector{
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProcurementManager: human.New(func(ctx context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				select {
+				case <-humanRelease:
+					return procurementSubmission(), nil
+				case <-ctx.Done():
+					return domain.ActionSubmission{}, ctx.Err()
+				}
+			}),
+			domain.RoleProductionManager: llm.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				select {
+				case aiStarted <- struct{}{}:
+				default:
+				}
+				return productionSubmission(), nil
+			}),
+			domain.RoleSalesManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Sales: &domain.SalesAction{
+							ProductOffers: []domain.ProductOffer{{ProductID: "pump", UnitPrice: 14}},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Sales ready."},
+				}, nil
+			}),
+			domain.RoleFinanceController: llm.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return financeSubmission(), nil
+			}),
+		},
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := collector.Collect(context.Background(), state, nil)
+		result <- err
+	}()
+
+	select {
+	case <-aiStarted:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("AI player was not started while the earlier human role was still waiting")
+	}
+
+	close(humanRelease)
+
+	if err := <-result; err != nil {
+		t.Fatalf("Collect() error = %v, want nil", err)
+	}
+}
+
+func TestRoundCollectorPreservesCanonicalRoleOrder(t *testing.T) {
+	state := fixtureMatchState()
+
+	collector := app.RoundCollector{
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProcurementManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				time.Sleep(40 * time.Millisecond)
+				return procurementSubmission(), nil
+			}),
+			domain.RoleProductionManager: llm.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return productionSubmission(), nil
+			}),
+			domain.RoleSalesManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				time.Sleep(10 * time.Millisecond)
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Sales: &domain.SalesAction{
+							ProductOffers: []domain.ProductOffer{{ProductID: "pump", UnitPrice: 14}},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Sales ready."},
+				}, nil
+			}),
+			domain.RoleFinanceController: llm.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return financeSubmission(), nil
+			}),
+		},
+	}
+
+	actions, err := collector.Collect(context.Background(), state, nil)
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+
+	got := make([]domain.RoleID, 0, len(actions))
+	for _, action := range actions {
+		got = append(got, action.RoleID)
+	}
+
+	want := make([]domain.RoleID, 0, len(state.Roles))
+	for _, assignment := range state.Roles {
+		want = append(want, assignment.RoleID)
+	}
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("collected role order = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## What changed
- collect role submissions concurrently so AI-controlled roles can start working even when an earlier human-controlled role is still entering a turn
- preserve canonical role ordering when concurrent submissions are normalized back into the round result
- fix the Ollama endpoint builder so base URLs that already include `/api/` still resolve to `/api/generate`
- add regression coverage for both the mixed human+AI collection path and the Ollama API-prefix case

## Why
The live match could appear stuck in two different ways:
- in mixed human+AI games, the round collector waited on roles sequentially, so a human role earlier in the assignment order prevented downstream AI roles from being asked to act at all
- in AI-only runs using an Ollama base URL with an `/api/` prefix, requests could be sent to the wrong endpoint, so no AI decisions were produced

## Impact
- AI roles now begin their work immediately during round collection instead of waiting behind earlier human submissions
- zero-human matches work with Ollama configurations that point at `http://localhost:11434/api/`
- mixed matches no longer leave the UI waiting forever for AI actions that were never started

## Validation
- `go test ./cmd/herbiego ./internal/app ./internal/adapters/ai/ollama`
- `go test ./...`