### PR TITLE
[codex] Show AI waiting spinner during provider calls

### DIFF
--- a/cmd/herbiego/live_gameplay_controller_test.go
+++ b/cmd/herbiego/live_gameplay_controller_test.go
@@ -148,28 +148,6 @@ func TestLiveGameplayControllerDeliversHumanSubmissionAndStreamsRoundPhases(t *t
 	}
 }
 
-func collectStates(t *testing.T, updates <-chan domain.MatchState, want int) []domain.MatchState {
-	t.Helper()
-
-	states := make([]domain.MatchState, 0, want)
-	timeout := time.NewTimer(2 * time.Second)
-	defer timeout.Stop()
-
-	for len(states) < want {
-		select {
-		case state, ok := <-updates:
-			if !ok {
-				t.Fatalf("updates closed after %d states, want %d", len(states), want)
-			}
-			states = append(states, state.Clone())
-		case <-timeout.C:
-			t.Fatalf("timed out after collecting %d/%d states", len(states), want)
-		}
-	}
-
-	return states
-}
-
 func collectStatesUntilPhase(t *testing.T, updates <-chan domain.MatchState, target domain.RoundPhase) []domain.MatchState {
 	t.Helper()
 

--- a/cmd/herbiego/live_gameplay_controller_test.go
+++ b/cmd/herbiego/live_gameplay_controller_test.go
@@ -103,7 +103,7 @@ func TestLiveGameplayControllerDeliversHumanSubmissionAndStreamsRoundPhases(t *t
 		Commentary: domain.CommentaryRecord{Body: "Buying only what the bottleneck can absorb."},
 	})
 
-	states := collectStates(t, controller.Updates(), 3)
+	states := collectStatesUntilPhase(t, controller.Updates(), domain.RoundPhaseRevealed)
 	if err := <-result; err != nil {
 		t.Fatalf("runner.Play() error = %v", err)
 	}
@@ -111,17 +111,35 @@ func TestLiveGameplayControllerDeliversHumanSubmissionAndStreamsRoundPhases(t *t
 	if got := states[0].RoundFlow.Phase; got != domain.RoundPhaseCollecting {
 		t.Fatalf("first phase = %q, want collecting", got)
 	}
-	if got := states[1].RoundFlow.Phase; got != domain.RoundPhaseResolving {
-		t.Fatalf("second phase = %q, want resolving", got)
+
+	resolvingIndex := -1
+	revealedIndex := -1
+	for index, state := range states {
+		switch state.RoundFlow.Phase {
+		case domain.RoundPhaseResolving:
+			if resolvingIndex < 0 {
+				resolvingIndex = index
+			}
+		case domain.RoundPhaseRevealed:
+			if revealedIndex < 0 {
+				revealedIndex = index
+			}
+		}
 	}
-	if got := states[2].RoundFlow.Phase; got != domain.RoundPhaseRevealed {
-		t.Fatalf("third phase = %q, want revealed", got)
+	if resolvingIndex < 0 {
+		t.Fatalf("states never reached resolving: %+v", states)
 	}
-	if got := states[2].History.RecentRounds; len(got) != 1 {
+	if revealedIndex < 0 {
+		t.Fatalf("states never reached revealed: %+v", states)
+	}
+	if resolvingIndex > revealedIndex {
+		t.Fatalf("resolving phase arrived after revealed phase: %+v", states)
+	}
+	if got := states[revealedIndex].History.RecentRounds; len(got) != 1 {
 		t.Fatalf("revealed history len = %d, want 1", len(got))
 	}
 
-	commentary := states[2].History.RecentRounds[0].Commentary
+	commentary := states[revealedIndex].History.RecentRounds[0].Commentary
 	if len(commentary) == 0 || commentary[0].RoleID != domain.RoleProcurementManager {
 		t.Fatalf("revealed commentary = %#v, want procurement commentary first", commentary)
 	}
@@ -150,4 +168,27 @@ func collectStates(t *testing.T, updates <-chan domain.MatchState, want int) []d
 	}
 
 	return states
+}
+
+func collectStatesUntilPhase(t *testing.T, updates <-chan domain.MatchState, target domain.RoundPhase) []domain.MatchState {
+	t.Helper()
+
+	states := make([]domain.MatchState, 0, 6)
+	timeout := time.NewTimer(2 * time.Second)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case state, ok := <-updates:
+			if !ok {
+				t.Fatalf("updates closed before phase %q; saw %d states", target, len(states))
+			}
+			states = append(states, state.Clone())
+			if state.RoundFlow.Phase == target {
+				return states
+			}
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for phase %q after collecting %d states", target, len(states))
+		}
+	}
 }

--- a/internal/adapters/tui/live_runtime_test.go
+++ b/internal/adapters/tui/live_runtime_test.go
@@ -436,68 +436,6 @@ func scriptedLivePlayers(source *liveTestSource) map[domain.RoleID]ports.Player 
 	}
 }
 
-func expectStateUpdate(t *testing.T, model Model, cmd tea.Cmd, wants ...string) (Model, tea.Cmd, string) {
-	t.Helper()
-
-	if cmd == nil {
-		t.Fatal("expected live update subscription command")
-	}
-
-	msg := cmd()
-	nextModel, nextCmd := model.Update(msg)
-	shell := nextModel.(Model)
-	shell.width = 160
-	shell.height = 80
-	view := shell.View()
-
-	for _, want := range wants {
-		if !strings.Contains(view, want) {
-			t.Fatalf("live update missing %q\n%s", want, view)
-		}
-	}
-
-	return shell, nextCmd, view
-}
-
-func expectEventuallyStateUpdate(t *testing.T, model Model, cmd tea.Cmd, wants ...string) (Model, tea.Cmd, string) {
-	t.Helper()
-
-	currentModel := model
-	currentCmd := cmd
-	var lastView string
-
-	for range 12 {
-		if currentCmd == nil {
-			t.Fatalf("expected live update subscription command while waiting for %q", wants)
-		}
-
-		msg := currentCmd()
-		nextModel, nextCmd := currentModel.Update(msg)
-		shell := nextModel.(Model)
-		shell.width = 160
-		shell.height = 80
-		view := shell.View()
-		lastView = view
-
-		matched := true
-		for _, want := range wants {
-			if !strings.Contains(view, want) {
-				matched = false
-				break
-			}
-		}
-		if matched {
-			return shell, nextCmd, view
-		}
-
-		currentModel = shell
-		currentCmd = nextCmd
-	}
-
-	t.Fatalf("live update never matched %q\n%s", wants, lastView)
-	return Model{}, nil, ""
-}
-
 func expectPublishedView(t *testing.T, source *liveTestSource, model Model, wants ...string) (Model, tea.Cmd, string) {
 	t.Helper()
 

--- a/internal/adapters/tui/live_runtime_test.go
+++ b/internal/adapters/tui/live_runtime_test.go
@@ -54,12 +54,12 @@ func TestModelSupportsMultiRoundLiveHumanPlusAIPlay(t *testing.T) {
 		result <- err
 	}()
 
-	loaded, next := model.Update(stateLoadedMsg{state: source.Snapshot()})
+	loaded, _ := model.Update(stateLoadedMsg{state: source.Snapshot()})
 	shell := loaded.(Model)
 	shell.width = 160
 	shell.height = 80
 
-	shell, next, collectingView := expectStateUpdate(t, shell, next,
+	shell, _, collectingView := expectPublishedView(t, source, shell,
 		"Action entry for Procurement Manager",
 	)
 
@@ -90,19 +90,19 @@ func TestModelSupportsMultiRoundLiveHumanPlusAIPlay(t *testing.T) {
 		}
 	}
 
-	shell, next, _ = expectStateUpdate(t, shell, next,
+	shell, _, _ = expectPublishedView(t, source, shell,
 		"Round 1 for Procurement Manager",
 		"Current phase: resolving simultaneous turn",
 		"The round is resolving.",
 	)
-	shell, next, revealedView := expectStateUpdate(t, shell, next,
+	shell, _, revealedView := expectPublishedView(t, source, shell,
 		"Round 2 for Procurement Manager",
 		"Current phase: revealed round results",
 		"[R1]",
 		"Procurement Manager: Round 1 keeps housing tight while assembly",
 		"clears backlog.",
 	)
-	shell, next, _ = expectStateUpdate(t, shell, next,
+	shell, _, _ = expectPublishedView(t, source, shell,
 		"Round 2 for Procurement Manager",
 		"Current phase: hidden simultaneous turn collection",
 		"[R1]",
@@ -127,11 +127,11 @@ func TestModelSupportsMultiRoundLiveHumanPlusAIPlay(t *testing.T) {
 	}
 
 	shell = submitProcurementTurn(t, shell, "housing=2", "Round 2 buys ahead of the now-visible pump pull.")
-	shell, next, _ = expectStateUpdate(t, shell, next,
+	shell, _, _ = expectPublishedView(t, source, shell,
 		"Round 2 for Procurement Manager",
 		"Current phase: resolving simultaneous turn",
 	)
-	shell, _, finalView := expectStateUpdate(t, shell, next,
+	shell, _, finalView := expectPublishedView(t, source, shell,
 		"Round 3 for Procurement Manager",
 		"Current phase: revealed round results",
 		"[R2]",
@@ -150,6 +150,112 @@ func TestModelSupportsMultiRoundLiveHumanPlusAIPlay(t *testing.T) {
 	}
 	if !strings.Contains(finalView, "[R2]") {
 		t.Fatalf("final view missing round two history\n%s", finalView)
+	}
+}
+
+func TestLiveMatchPublishesProviderWaitingSpinnerState(t *testing.T) {
+	t.Parallel()
+
+	starter := scenario.Starter()
+	initial := starter.InitialState("starter-match", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", Provider: "ollama", ModelName: "gemma"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", Provider: "ollama", ModelName: "gemma"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "ollama", ModelName: "gemma"},
+	})
+
+	source := newLiveTestSource(initial)
+	model := NewModelWithSubmit(starter, source, source.Submit)
+	productionRelease := make(chan struct{})
+	now := time.Date(2026, time.April, 21, 21, 0, 0, 0, time.UTC)
+
+	runner := app.MatchRunner{
+		Collector: app.RoundCollector{
+			Now: func() time.Time { return now },
+			Players: map[domain.RoleID]ports.Player{
+				domain.RoleProcurementManager: human.New(source.SubmitRound),
+				domain.RoleProductionManager: llm.New(func(ctx context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+					select {
+					case <-productionRelease:
+						return domain.ActionSubmission{
+							Action: domain.RoleAction{
+								Production: &domain.ProductionAction{
+									CapacityAllocation: []domain.CapacityAllocation{
+										{WorkstationID: "assembly", ProductID: "pump", Capacity: 2},
+									},
+								},
+							},
+							Commentary: domain.CommentaryRecord{
+								Body: fmt.Sprintf("Round %d production protects the assembly bottleneck.", request.RoleView.Round),
+							},
+						}, nil
+					case <-ctx.Done():
+						return domain.ActionSubmission{}, ctx.Err()
+					}
+				}),
+				domain.RoleSalesManager: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+					return domain.ActionSubmission{
+						Action: domain.RoleAction{
+							Sales: &domain.SalesAction{
+								ProductOffers: []domain.ProductOffer{
+									{ProductID: "pump", UnitPrice: 14},
+									{ProductID: "valve", UnitPrice: 9},
+								},
+							},
+						},
+						Commentary: domain.CommentaryRecord{
+							Body: fmt.Sprintf("Round %d sales keeps starter pricing stable.", request.RoleView.Round),
+						},
+					}, nil
+				}),
+				domain.RoleFinanceController: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+					targets := request.RoleView.ActiveTargets
+					targets.EffectiveRound = request.RoleView.Round + 1
+					return domain.ActionSubmission{
+						Action: domain.RoleAction{
+							Finance: &domain.FinanceAction{NextRoundTargets: targets},
+						},
+						Commentary: domain.CommentaryRecord{
+							Body: fmt.Sprintf("Round %d finance holds targets steady for comparison.", request.RoleView.Round),
+						},
+					}, nil
+				}),
+			},
+		},
+		Resolver: engine.NewResolver(starter.ResolverOptions()),
+		Random:   seeded.New(1),
+		OnState:  source.Publish,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+	go func() {
+		defer source.Close()
+		_, _, err := runner.Play(ctx, initial, 1)
+		result <- err
+	}()
+
+	loaded, _ := model.Update(stateLoadedMsg{state: source.Snapshot()})
+	shell := loaded.(Model)
+	shell.width = 160
+	shell.height = 80
+
+	shell, _, _ = expectPublishedView(t, source, shell, "Action entry for Procurement Manager")
+
+	shell = submitProcurementTurn(t, shell, "housing=1", "Holding material spend while AI players finish.")
+	shell, _, spinnerView := expectPublishedView(t, source, shell,
+		"Mode: round feed",
+		"Production Manager "+providerSpinnerFrames[0]+" [AI]",
+	)
+	if strings.Contains(spinnerView, "Procurement Manager "+providerSpinnerFrames[0]+" [Human]") {
+		t.Fatalf("spinner leaked onto human role\n%s", spinnerView)
+	}
+
+	close(productionRelease)
+	if err := <-result; err != nil {
+		t.Fatalf("runner.Play() error = %v", err)
 	}
 }
 
@@ -351,6 +457,85 @@ func expectStateUpdate(t *testing.T, model Model, cmd tea.Cmd, wants ...string) 
 	}
 
 	return shell, nextCmd, view
+}
+
+func expectEventuallyStateUpdate(t *testing.T, model Model, cmd tea.Cmd, wants ...string) (Model, tea.Cmd, string) {
+	t.Helper()
+
+	currentModel := model
+	currentCmd := cmd
+	var lastView string
+
+	for range 12 {
+		if currentCmd == nil {
+			t.Fatalf("expected live update subscription command while waiting for %q", wants)
+		}
+
+		msg := currentCmd()
+		nextModel, nextCmd := currentModel.Update(msg)
+		shell := nextModel.(Model)
+		shell.width = 160
+		shell.height = 80
+		view := shell.View()
+		lastView = view
+
+		matched := true
+		for _, want := range wants {
+			if !strings.Contains(view, want) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return shell, nextCmd, view
+		}
+
+		currentModel = shell
+		currentCmd = nextCmd
+	}
+
+	t.Fatalf("live update never matched %q\n%s", wants, lastView)
+	return Model{}, nil, ""
+}
+
+func expectPublishedView(t *testing.T, source *liveTestSource, model Model, wants ...string) (Model, tea.Cmd, string) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	var lastView string
+
+	for time.Now().Before(deadline) {
+		select {
+		case state, ok := <-source.Updates():
+			if !ok {
+				t.Fatalf("live update stream closed while waiting for %q", wants)
+			}
+
+			nextModel, nextCmd := model.Update(stateLoadedMsg{state: state})
+			shell := nextModel.(Model)
+			shell.width = 160
+			shell.height = 80
+			view := shell.View()
+			lastView = view
+
+			matched := true
+			for _, want := range wants {
+				if !strings.Contains(view, want) {
+					matched = false
+					break
+				}
+			}
+			if matched {
+				return shell, nextCmd, view
+			}
+
+			model = shell
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	t.Fatalf("published view never matched %q\n%s", wants, lastView)
+	return Model{}, nil, ""
 }
 
 func submitProcurementTurn(t *testing.T, model Model, orders string, commentary string) Model {

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -170,7 +170,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-var providerSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+var providerSpinnerFrames = []string{"⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇"}
 
 func (m Model) spinnerCmd() tea.Cmd {
 	if !m.hasProviderWaits() {

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -43,6 +44,8 @@ type stateLoadedMsg struct {
 
 type stateStreamClosedMsg struct{}
 
+type spinnerTickMsg struct{}
+
 // StatusMsg updates the command-bar status from outside the Bubble Tea model.
 type StatusMsg struct {
 	Text string
@@ -64,6 +67,7 @@ type Model struct {
 	height       int
 	status       string
 	streamClosed bool
+	spinnerFrame int
 	drafts       map[domain.RoleID]actionDraft
 	lookup       lookupBrowserState
 }
@@ -142,7 +146,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = typed.state.Clone()
 		m.selectedRole = clampRoleIndex(m.selectedRole, len(m.state.Roles))
 		m.status = fmt.Sprintf("Round %d loaded for %s", m.state.CurrentRound, m.roleTitle())
-		return m, waitForUpdateCmd(m.updates)
+		return m, tea.Batch(waitForUpdateCmd(m.updates), m.spinnerCmd())
 	case StatusMsg:
 		if strings.TrimSpace(typed.Text) != "" {
 			m.status = typed.Text
@@ -154,9 +158,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.status = "Match updates complete. Inspect results and press q to exit."
 		}
 		return m, nil
+	case spinnerTickMsg:
+		if !m.hasProviderWaits() {
+			m.spinnerFrame = 0
+			return m, nil
+		}
+		m.spinnerFrame = (m.spinnerFrame + 1) % len(providerSpinnerFrames)
+		return m, m.spinnerCmd()
 	}
 
 	return m, nil
+}
+
+var providerSpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+func (m Model) spinnerCmd() tea.Cmd {
+	if !m.hasProviderWaits() {
+		return nil
+	}
+	return tea.Tick(120*time.Millisecond, func(time.Time) tea.Msg {
+		return spinnerTickMsg{}
+	})
+}
+
+func (m Model) hasProviderWaits() bool {
+	return len(m.effectiveRoundFlow().ProviderWaitingRoles) > 0
 }
 
 // View renders the four-pane shell.
@@ -275,7 +301,11 @@ func (m Model) renderDepartmentsPane(width, height int) string {
 		if assignment.IsHuman {
 			controller = "Human"
 		}
-		lines = append(lines, fmt.Sprintf("%s %s [%s]", cursor, displayRoleName(assignment.RoleID), controller))
+		waiting := ""
+		if slices.Contains(m.effectiveRoundFlow().ProviderWaitingRoles, assignment.RoleID) {
+			waiting = " " + providerSpinnerFrames[m.spinnerFrame%len(providerSpinnerFrames)]
+		}
+		lines = append(lines, fmt.Sprintf("%s %s%s [%s]", cursor, displayRoleName(assignment.RoleID), waiting, controller))
 	}
 
 	if report.BonusReminder != "" {

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -746,6 +746,26 @@ func TestModelRoundFeedShowsResolvedStarterHistory(t *testing.T) {
 	}
 }
 
+func TestModelDepartmentsPaneShowsBrailleSpinnerForProviderWaits(t *testing.T) {
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.width = 120
+	shell.height = 32
+	shell.state.RoundFlow.ProviderWaitingRoles = []domain.RoleID{domain.RoleProductionManager}
+
+	view := shell.View()
+	if !strings.Contains(view, "Production Manager "+providerSpinnerFrames[0]+" [AI]") {
+		t.Fatalf("departments view missing provider spinner\n%s", view)
+	}
+	if strings.Contains(view, "Procurement Manager "+providerSpinnerFrames[0]+" [Human]") {
+		t.Fatalf("departments view showed spinner for unrelated human role\n%s", view)
+	}
+}
+
 func TestModelArchiveShowsRetainedHistorySummaries(t *testing.T) {
 	model := NewModel(scenario.Starter(), testStateSource{
 		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),

--- a/internal/app/match_runner.go
+++ b/internal/app/match_runner.go
@@ -38,7 +38,14 @@ func (r MatchRunner) Play(ctx context.Context, initial domain.MatchState, rounds
 	for range rounds {
 		r.emitState(state)
 
-		actions, err := r.Collector.Collect(ctx, state, previous)
+		collector := r.Collector
+		collector.OnRoundFlow = func(flow domain.RoundFlowState) {
+			progress := state.Clone()
+			progress.RoundFlow = flow.Clone()
+			r.emitState(progress)
+		}
+
+		actions, err := collector.Collect(ctx, state, previous)
 		if err != nil {
 			return state, results, err
 		}
@@ -87,6 +94,7 @@ func prepareCollectionState(state domain.MatchState) domain.MatchState {
 	state.RoundFlow = domain.RoundFlowState{
 		Phase:                domain.RoundPhaseCollecting,
 		WaitingOnRoles:       roleIDs(state.Roles),
+		ProviderWaitingRoles: nil,
 		AIRevealDelaySeconds: state.RoundFlow.AIRevealDelaySeconds,
 	}
 	return state
@@ -111,6 +119,7 @@ func roundFlowFor(assignments []domain.RoleAssignment, actions []domain.ActionSu
 		Phase:                phase,
 		SubmittedRoles:       submitted,
 		WaitingOnRoles:       waiting,
+		ProviderWaitingRoles: nil,
 		AIRevealDelaySeconds: revealDelaySeconds,
 	}
 }

--- a/internal/app/match_runner_test.go
+++ b/internal/app/match_runner_test.go
@@ -55,8 +55,8 @@ func TestMatchRunnerPlaysMultipleResolvedRounds(t *testing.T) {
 	if got := len(final.RoundFlow.WaitingOnRoles); got != 4 {
 		t.Fatalf("waiting roles = %d, want 4", got)
 	}
-	if phaseCounts[domain.RoundPhaseCollecting] != 3 {
-		t.Fatalf("collecting states emitted = %d, want 3", phaseCounts[domain.RoundPhaseCollecting])
+	if phaseCounts[domain.RoundPhaseCollecting] < 3 {
+		t.Fatalf("collecting states emitted = %d, want at least 3", phaseCounts[domain.RoundPhaseCollecting])
 	}
 	if phaseCounts[domain.RoundPhaseResolving] != 3 {
 		t.Fatalf("resolving states emitted = %d, want 3", phaseCounts[domain.RoundPhaseResolving])

--- a/internal/app/round_collection.go
+++ b/internal/app/round_collection.go
@@ -3,6 +3,9 @@ package app
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
@@ -14,8 +17,9 @@ import (
 // RoundCollector gathers one action submission per assigned role through the
 // shared player contract.
 type RoundCollector struct {
-	Players map[domain.RoleID]ports.Player
-	Now     func() time.Time
+	Players     map[domain.RoleID]ports.Player
+	Now         func() time.Time
+	OnRoundFlow func(domain.RoundFlowState)
 }
 
 // Collect walks the assigned roles in stable match order so mixed human and AI
@@ -31,6 +35,7 @@ func (c RoundCollector) Collect(ctx context.Context, state domain.MatchState, pr
 	now := c.now()
 	collected := make([]domain.ActionSubmission, len(state.Roles))
 	group, groupCtx := errgroup.WithContext(ctx)
+	progress := newRoundFlowProgress(state.RoundFlow, state.Roles, c.OnRoundFlow)
 
 	for i, assignment := range state.Roles {
 		i := i
@@ -48,15 +53,18 @@ func (c RoundCollector) Collect(ctx context.Context, state domain.MatchState, pr
 		}
 
 		group.Go(func() error {
+			progress.markProviderWaiting(assignment, true)
 			submission, err := player.SubmitRound(groupCtx, request)
 			if err != nil {
 				submission, err = player.RecoverFromNonResponse(groupCtx, request, err)
 				if err != nil {
+					progress.markProviderWaiting(assignment, false)
 					return fmt.Errorf("app: collect round %d for %q: %w", state.CurrentRound, assignment.RoleID, err)
 				}
 			}
 
 			collected[i] = normalizeSubmission(submission, request, now)
+			progress.markSubmitted(assignment.RoleID)
 			return nil
 		})
 	}
@@ -139,4 +147,68 @@ func commentaryVisibility(existing domain.CommentaryVisibility) domain.Commentar
 		return existing
 	}
 	return domain.CommentaryPublic
+}
+
+type roundFlowProgress struct {
+	mu     sync.Mutex
+	flow   domain.RoundFlowState
+	notify func(domain.RoundFlowState)
+}
+
+func newRoundFlowProgress(flow domain.RoundFlowState, assignments []domain.RoleAssignment, notify func(domain.RoundFlowState)) *roundFlowProgress {
+	progress := &roundFlowProgress{
+		flow:   flow.Clone(),
+		notify: notify,
+	}
+	if progress.flow.Phase == "" {
+		progress.flow.Phase = domain.RoundPhaseCollecting
+	}
+	if len(progress.flow.WaitingOnRoles) == 0 && len(assignments) > 0 {
+		progress.flow.WaitingOnRoles = roleIDs(assignments)
+	}
+	return progress
+}
+
+func (p *roundFlowProgress) markProviderWaiting(assignment domain.RoleAssignment, active bool) {
+	if strings.TrimSpace(assignment.Provider) == "" {
+		return
+	}
+
+	p.mu.Lock()
+	if active {
+		if !slices.Contains(p.flow.ProviderWaitingRoles, assignment.RoleID) {
+			p.flow.ProviderWaitingRoles = append(p.flow.ProviderWaitingRoles, assignment.RoleID)
+		}
+	} else {
+		p.flow.ProviderWaitingRoles = removeRoleID(p.flow.ProviderWaitingRoles, assignment.RoleID)
+	}
+	flow := p.flow.Clone()
+	p.mu.Unlock()
+
+	p.emit(flow)
+}
+
+func (p *roundFlowProgress) markSubmitted(roleID domain.RoleID) {
+	p.mu.Lock()
+	if !slices.Contains(p.flow.SubmittedRoles, roleID) {
+		p.flow.SubmittedRoles = append(p.flow.SubmittedRoles, roleID)
+	}
+	p.flow.WaitingOnRoles = removeRoleID(p.flow.WaitingOnRoles, roleID)
+	p.flow.ProviderWaitingRoles = removeRoleID(p.flow.ProviderWaitingRoles, roleID)
+	flow := p.flow.Clone()
+	p.mu.Unlock()
+
+	p.emit(flow)
+}
+
+func (p *roundFlowProgress) emit(flow domain.RoundFlowState) {
+	if p.notify != nil {
+		p.notify(flow)
+	}
+}
+
+func removeRoleID(items []domain.RoleID, target domain.RoleID) []domain.RoleID {
+	return slices.DeleteFunc(items, func(roleID domain.RoleID) bool {
+		return roleID == target
+	})
 }

--- a/internal/app/round_collection_test.go
+++ b/internal/app/round_collection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,14 +19,17 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 	state := fixtureMatchState()
 	now := time.Date(2026, time.April, 19, 16, 0, 0, 0, time.UTC)
 
+	var collectedMu sync.Mutex
 	collectedViews := map[domain.RoleID]domain.RoundView{}
 	collectedReports := map[domain.RoleID]domain.RoleRoundReport{}
 	collector := app.RoundCollector{
 		Now: func() time.Time { return now },
 		Players: map[domain.RoleID]ports.Player{
 			domain.RoleProcurementManager: human.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+				collectedMu.Lock()
 				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
 				collectedReports[request.Assignment.RoleID] = request.RoleReport.Clone()
+				collectedMu.Unlock()
 				return domain.ActionSubmission{
 					Action: domain.RoleAction{
 						Procurement: &domain.ProcurementAction{
@@ -38,8 +42,10 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 				}, nil
 			}),
 			domain.RoleProductionManager: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+				collectedMu.Lock()
 				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
 				collectedReports[request.Assignment.RoleID] = request.RoleReport.Clone()
+				collectedMu.Unlock()
 				return domain.ActionSubmission{
 					Action: domain.RoleAction{
 						Production: &domain.ProductionAction{
@@ -55,8 +61,10 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 				}, nil
 			}),
 			domain.RoleSalesManager: human.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+				collectedMu.Lock()
 				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
 				collectedReports[request.Assignment.RoleID] = request.RoleReport.Clone()
+				collectedMu.Unlock()
 				return domain.ActionSubmission{
 					Action: domain.RoleAction{
 						Sales: &domain.SalesAction{
@@ -69,8 +77,10 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 				}, nil
 			}),
 			domain.RoleFinanceController: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+				collectedMu.Lock()
 				collectedViews[request.Assignment.RoleID] = request.RoleView.Clone()
 				collectedReports[request.Assignment.RoleID] = request.RoleReport.Clone()
+				collectedMu.Unlock()
 				return domain.ActionSubmission{
 					Action: domain.RoleAction{
 						Finance: &domain.FinanceAction{
@@ -97,6 +107,7 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 	if got := len(actions); got != len(state.Roles) {
 		t.Fatalf("len(actions) = %d, want %d", got, len(state.Roles))
 	}
+	collectedMu.Lock()
 	for _, assignment := range state.Roles {
 		view, ok := collectedViews[assignment.RoleID]
 		if !ok {
@@ -130,6 +141,7 @@ func TestRoundCollectorCollectsMixedPlayersWithoutBranching(t *testing.T) {
 			t.Fatalf("action.Commentary.Visibility = %q, want %q", action.Commentary.Visibility, domain.CommentaryPublic)
 		}
 	}
+	collectedMu.Unlock()
 }
 
 func TestRoundCollectorReusesPreviousActionWhenAIPlayerTimesOut(t *testing.T) {
@@ -379,6 +391,104 @@ func TestRoundCollectorPreservesCanonicalRoleOrder(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Fatalf("collected role order = %v, want %v", got, want)
 	}
+}
+
+func TestRoundCollectorReportsProviderWaitingProgress(t *testing.T) {
+	state := fixtureMatchState()
+	productionRelease := make(chan struct{})
+	financeRelease := make(chan struct{})
+
+	var (
+		mu       sync.Mutex
+		progress []domain.RoundFlowState
+	)
+
+	collector := app.RoundCollector{
+		OnRoundFlow: func(flow domain.RoundFlowState) {
+			mu.Lock()
+			progress = append(progress, flow.Clone())
+			mu.Unlock()
+		},
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProcurementManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return procurementSubmission(), nil
+			}),
+			domain.RoleProductionManager: llm.New(func(ctx context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				select {
+				case <-productionRelease:
+					return productionSubmission(), nil
+				case <-ctx.Done():
+					return domain.ActionSubmission{}, ctx.Err()
+				}
+			}),
+			domain.RoleSalesManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return domain.ActionSubmission{
+					Action: domain.RoleAction{
+						Sales: &domain.SalesAction{
+							ProductOffers: []domain.ProductOffer{{ProductID: "pump", UnitPrice: 14}},
+						},
+					},
+					Commentary: domain.CommentaryRecord{Body: "Sales ready."},
+				}, nil
+			}),
+			domain.RoleFinanceController: llm.New(func(ctx context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				select {
+				case <-financeRelease:
+					return financeSubmission(), nil
+				case <-ctx.Done():
+					return domain.ActionSubmission{}, ctx.Err()
+				}
+			}),
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := collector.Collect(context.Background(), state, nil)
+		done <- err
+	}()
+
+	requireProgressState := func(t *testing.T, predicate func(domain.RoundFlowState) bool, description string) {
+		t.Helper()
+
+		deadline := time.Now().Add(time.Second)
+		for time.Now().Before(deadline) {
+			mu.Lock()
+			snapshots := slices.Clone(progress)
+			mu.Unlock()
+
+			for _, snapshot := range snapshots {
+				if predicate(snapshot) {
+					return
+				}
+			}
+
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("did not observe progress state %s; saw %+v", description, progress)
+	}
+
+	requireProgressState(t, func(flow domain.RoundFlowState) bool {
+		return slices.Contains(flow.ProviderWaitingRoles, domain.RoleProductionManager)
+	}, "containing production_manager")
+	requireProgressState(t, func(flow domain.RoundFlowState) bool {
+		return slices.Contains(flow.ProviderWaitingRoles, domain.RoleProductionManager) &&
+			slices.Contains(flow.ProviderWaitingRoles, domain.RoleFinanceController)
+	}, "containing both production_manager and finance_controller")
+
+	close(productionRelease)
+	requireProgressState(t, func(flow domain.RoundFlowState) bool {
+		return slices.Equal(flow.ProviderWaitingRoles, []domain.RoleID{domain.RoleFinanceController})
+	}, "equal to [finance_controller]")
+
+	close(financeRelease)
+	if err := <-done; err != nil {
+		t.Fatalf("Collect() error = %v, want nil", err)
+	}
+
+	requireProgressState(t, func(flow domain.RoundFlowState) bool {
+		return len(flow.ProviderWaitingRoles) == 0
+	}, "with no provider waits")
 }
 
 func fixtureMatchState() domain.MatchState {

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -64,6 +64,7 @@ type RoundFlowState struct {
 	Phase                RoundPhase
 	SubmittedRoles       []RoleID
 	WaitingOnRoles       []RoleID
+	ProviderWaitingRoles []RoleID
 	AIRevealDelaySeconds int
 }
 
@@ -551,6 +552,7 @@ func (f RoundFlowState) Clone() RoundFlowState {
 		Phase:                f.Phase,
 		SubmittedRoles:       slices.Clone(f.SubmittedRoles),
 		WaitingOnRoles:       slices.Clone(f.WaitingOnRoles),
+		ProviderWaitingRoles: slices.Clone(f.ProviderWaitingRoles),
 		AIRevealDelaySeconds: f.AIRevealDelaySeconds,
 	}
 }


### PR DESCRIPTION
## Summary
- add provider-in-flight tracking to the round flow state during collection
- publish live collection progress updates so the TUI can see which AI roles are actively waiting on provider responses
- render an animated braille spinner beside waiting roles in the departments pane and cover the new flow with live/runtime tests

## Why
Issue #84 asks for clear feedback about which AI player is currently blocked on a provider API call. Before this change, the UI only received round-state updates before collection began and after all players finished, so there was no source-of-truth signal for in-flight provider work.

## Root Cause
The match loop emitted only coarse collection/resolving/revealed snapshots. Mid-collection provider activity was never surfaced in `RoundFlow`, so the UI could not distinguish a normal collecting phase from an AI request that was actively waiting on a backend response.

## Confirmed Behavior
- each role with a provider request in flight shows a spinner, even when multiple roles are waiting at the same time
- spinner behavior is provider-agnostic and does not depend on which LLM backend is serving the role
- the left-hand departments pane is the intended location for the indicator
- the spinner clears when that role completes or falls back after a provider failure
- human-controlled roles do not get the indicator unless they ever participate in the same provider-backed async flow

Closes #84.

## Validation
- `staticcheck ./...`
- `go test ./...`