### PR TITLE
Audit simulation invariants and fix critical consistency gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ HerbieGo aims to be both a game and a systems-thinking simulation: a place where
 
 - [MVP Game Design](docs/mvp-game-design.md)
 - [Canonical Domain Model](docs/domain-model.md)
+- [Simulation Invariants](docs/simulation-invariants.md)
+- [Invariant Audit](docs/invariant-audit.md)
 - [Configure, Launch, and Play](docs/configure-launch-play.md)
 - [Architecture Decision Records](docs/adr/README.md)
 - [Contributor Guide](CONTRIBUTING.md)

--- a/docs/invariant-audit.md
+++ b/docs/invariant-audit.md
@@ -1,0 +1,65 @@
+# Invariant Audit
+
+This audit accompanies [Simulation Invariants](simulation-invariants.md) and records the current state of enforcement in the MVP engine.
+
+## Scope Reviewed
+
+The audit focused on:
+
+- [internal/engine/resolver.go](/C:/GIT/HerbieGo/internal/engine/resolver.go)
+- [internal/scenario/scenario.go](/C:/GIT/HerbieGo/internal/scenario/scenario.go)
+- [internal/scenario/starter.go](/C:/GIT/HerbieGo/internal/scenario/starter.go)
+- [docs/mvp-game-design.md](/C:/GIT/HerbieGo/docs/mvp-game-design.md)
+- [docs/domain-model.md](/C:/GIT/HerbieGo/docs/domain-model.md)
+
+## Findings
+
+### Rules already enforced
+
+- Negative inventory is prevented by trimming releases, capacity advances, and shipments to available state.
+- Procurement and production spending are trimmed to budget and debt-constrained spend capacity.
+- Revenue is recognized only when finished goods ship.
+- Purchase orders move through `InTransitSupply` before parts inventory.
+- Production route transitions are controlled by the scenario route hook.
+- Backlog expiration generates lost-sales and sentiment events.
+- Finance targets are recorded for the next round instead of retroactively changing the current one.
+
+### Rules only partially enforced
+
+- Inventory value is projected into metrics, but there is no standalone reconciliation assertion to prove mass-balance across every state bucket.
+- Budget overspend inside the permitted `110%` window is allowed, but soft-target misses are not separately surfaced in events or reports.
+- Finance targets include revenue and cash-floor guidance, but those targets are not used as enforceable plant rules today.
+- The event stream records many automatic adjustments, but there is no dedicated anomaly report that summarizes invariant-related trims, rejections, or reconciliation mismatches for a round.
+
+### Confirmed gaps and discrepancies
+
+- The engine had a hardcoded backlog-expiry threshold even though scenarios already define `BacklogExpiryRounds`.
+- Finance-set debt ceiling targets were stored in `ActiveTargets` but were not flowing into the next-round `Plant.DebtCeiling`.
+- The MVP design doc says sales pricing changes affect customer demand in the subsequent round, while the current scenario demand model uses prices from the round being resolved.
+- The MVP design doc still lists `set_offer_quantity(customer_id, product_id, quantity)` for Sales, but the current domain model exposes price-setting only.
+- The MVP design doc says soft budget misses should be logged, but the resolver currently trims only hard violations.
+
+## Resolved in the issue `#142` implementation
+
+- backlog expiry now honors the scenario-configured expiry window
+- finance-set debt ceiling targets now flow into next-round plant state
+- tests now cover both behaviors
+
+## Follow-up work
+
+The follow-up issues filed from this audit should cover:
+
+- `#143` scenario-configured backlog expiry
+- `#144` next-round debt ceiling activation
+- `#145` pricing-timing semantics versus current demand resolution
+- `#146` Sales action vocabulary mismatch between docs and code
+- `#147` missing soft-budget-miss reporting
+- future reconciliation checks or anomaly summaries beyond the scope of this change set
+
+## Clarifications that remain open
+
+No unresolved clarification blocked the current implementation work.
+
+There is one design choice worth keeping visible for future discussion:
+
+- if Finance lowers the next-round debt ceiling below the debt carried out of the current round, the project still needs an explicit product decision on whether to auto-clamp, reject the finance target, force immediate loss, or allow a temporarily out-of-policy opening state with a warning

--- a/docs/simulation-invariants.md
+++ b/docs/simulation-invariants.md
@@ -1,0 +1,287 @@
+# Simulation Invariants
+
+This document is the canonical reference for physical, business, temporal, and role-boundary invariants in the HerbieGo simulation.
+
+Issue `#142` asked for a stable document contributors can use when they extend the engine, add reports, or debug surprising outcomes. These rules describe what the simulation should never violate, which rules are currently enforced centrally by the plant system, and where future work is still needed.
+
+## Purpose
+
+The invariants in this document serve four jobs:
+
+- protect the simulation from physically impossible state transitions
+- protect the business model from internally inconsistent cash, debt, and revenue updates
+- keep round timing deterministic
+- clarify which roles may request an action versus which rules the plant system must enforce centrally
+
+## Physical Flow And Mass-Balance Invariants
+
+These invariants protect the plant from impossible material flow.
+
+### PF-1. Inventory cannot become negative
+
+- parts inventory cannot go below zero
+- work-in-progress cannot go below zero
+- finished goods inventory cannot go below zero
+
+Current status:
+
+- enforced for parts by trimming production releases to buildable BOM quantities
+- enforced for WIP and finished goods by trimming capacity advances and shipments to available quantities
+
+### PF-2. Production releases must consume the required upstream parts
+
+- a unit may not be released into production unless the required BOM inputs exist
+- releasing work must reduce parts inventory by the consumed amount
+
+Current status:
+
+- enforced when the scenario provides BOM data
+- unknown products are rejected
+
+### PF-3. Route transitions must follow a legal production route
+
+- WIP can only advance from its current workstation to the scenario-defined next workstation
+- finished goods can only be created from a route step marked as finished
+
+Current status:
+
+- enforced through the scenario route hook
+- invalid or missing continuations generate a rule-adjustment event and leave work in place
+
+### PF-4. Work advanced in a round cannot exceed effective capacity
+
+- workstation usage cannot exceed `CapacityPerRound`
+- work advanced at a workstation cannot exceed the WIP waiting at that workstation
+
+Current status:
+
+- enforced by trimming requested capacity to remaining workstation capacity and available WIP
+
+### PF-5. Finished goods cannot be shipped unless they physically exist
+
+- shipments draw only from finished inventory
+- backlog may remain after shipment if inventory is insufficient
+
+Current status:
+
+- enforced by trimming each shipment to current finished-goods on-hand
+
+### PF-6. Ordered material cannot arrive before lead time completes
+
+- purchase orders enter `InTransitSupply`
+- parts become usable only when their arrival round is reached
+
+Current status:
+
+- enforced with one-round lead time in the current MVP scenario model
+
+### PF-7. Units must stay in a visible state bucket
+
+Every unit should always be representable as one of:
+
+- parts inventory
+- WIP at a named workstation
+- finished goods
+- in-transit supply
+- backlog
+- lost sales or expired demand through explicit events
+
+Current status:
+
+- mostly enforced by resolver transitions and event emission
+- not yet fully audited through explicit reconciliation metrics
+
+## Financial And Business Invariants
+
+These invariants protect the bookkeeping side of the simulation.
+
+### FB-1. Cash, debt, and spending updates must remain internally consistent
+
+- procurement spend reduces cash and may create debt
+- production spend reduces cash and may create debt
+- shipment revenue increases cash and automatically pays down debt first
+- round-end carrying costs reduce cash and may create debt
+
+Current status:
+
+- enforced centrally through `applyCashDelta`
+
+### FB-2. Debt-constrained spending cannot exceed the active debt ceiling
+
+- procurement and production must be trimmed or rejected when the plant cannot legally fund them
+
+Current status:
+
+- enforced through available-spend calculations against `Plant.DebtCeiling`
+- finance-set debt ceiling targets now flow into the next-round plant state
+
+### FB-3. Revenue cannot be recognized without shipment
+
+- only shipped finished goods create revenue
+- price offers by themselves do not create revenue
+
+Current status:
+
+- enforced
+
+### FB-4. Inventory value must reconcile with on-hand state
+
+- parts, WIP, and finished goods each contribute to inventory value
+- round metrics should match the state snapshot at the end of resolution
+
+Current status:
+
+- enforced for round-end metric projection
+- not yet enforced through a separate reconciliation check
+
+### FB-5. Backlog expiration and lost sales must be explicit
+
+- expired demand must leave backlog
+- lost sales must be counted
+- affected customer sentiment must move in the same resolution step
+
+Current status:
+
+- enforced
+- backlog expiry is now driven by the scenario-configured expiry window instead of a hardcoded constant
+
+### FB-6. Finance targets are directives, not retroactive overrides
+
+- procurement and production budgets act as soft targets with a `110%` hard cap
+- finance targets shape future rounds instead of rewriting already-resolved current-round actions
+
+Current status:
+
+- budget hard caps are enforced
+- debt ceiling targets now become part of next-round state
+- revenue-target and cash-floor handling remain advisory rather than enforced rules
+
+## Temporal Invariants
+
+These invariants keep the turn order deterministic.
+
+### TR-1. Current-round resolution order is stable
+
+The MVP resolver follows this sequence:
+
+1. activate current-round targets
+2. resolve procurement
+3. receive due supply
+4. resolve production
+5. resolve sales
+6. apply scenario/world demand updates
+7. finalize finance targets and round-end metrics
+
+Current status:
+
+- enforced by the resolver flow
+
+### TR-2. Finance actions cannot retroactively affect the current round
+
+- finance submissions set next-round targets
+- they do not veto current-round procurement, production, or sales after seeing their outcomes
+
+Current status:
+
+- enforced
+
+### TR-3. Demand and backlog aging move forward round by round
+
+- new demand enters backlog with the current round as origin
+- backlog age increases once during round finalization
+- expired backlog produces explicit events
+
+Current status:
+
+- enforced
+
+### TR-4. Purchase orders cannot skip the transit state
+
+- orders placed in round `N` arrive in a later round, not immediately
+
+Current status:
+
+- enforced
+
+## Role-Responsibility Boundaries
+
+Roles may request actions inside their decision space. The plant system is still responsible for rejecting or trimming illegal actions.
+
+### Procurement Manager
+
+Relevant invariants:
+
+- cannot request negative quantities
+- cannot create immediate inventory from an order
+- cannot spend beyond legal budget and debt constraints once the plant applies enforcement
+
+Plant-system responsibility:
+
+- trimming to budget and spend capacity
+- preserving lead-time behavior
+
+### Production Manager
+
+Relevant invariants:
+
+- cannot release more work than available BOM parts support
+- cannot advance more work than available WIP and workstation capacity allow
+- cannot skip route stages
+
+Plant-system responsibility:
+
+- route enforcement
+- capacity enforcement
+- material consumption
+
+### Sales Manager
+
+Relevant invariants:
+
+- cannot recognize revenue without shipment
+- cannot ship more finished goods than exist
+- cannot directly mutate backlog or sentiment outside plant rules
+
+Plant-system responsibility:
+
+- demand realization
+- shipment trimming
+- backlog aging and expiration
+
+### Finance Controller
+
+Relevant invariants:
+
+- cannot set negative budgets or targets
+- cannot retroactively alter already-resolved current-round actions
+- can influence next-round procurement, production, and debt policy
+
+Plant-system responsibility:
+
+- activating next-round targets at the right time
+- enforcing budget hard caps and debt limits
+
+### Plant/System
+
+The plant system is the invariant owner of last resort. If a role requests an impossible action, the system must reject it, trim it, or surface the inconsistency through events and tests rather than allowing impossible state.
+
+### Future Roles
+
+These responsibility areas should keep the same pattern when introduced:
+
+- Quality: defects, scrap, rework, release holds
+- Maintenance: downtime, repair completion, capacity restoration
+- Logistics/Warehouse: storage state, transfer legality, inbound/outbound timing
+- Plant Manager: cross-functional policy, priority setting, escalation, exception handling
+
+## Audit Summary
+
+Issue `#142` also required an audit of the current implementation. The companion document [Invariant Audit](invariant-audit.md) records which rules are already enforced, which are partial, and which need follow-up work.
+
+Current follow-up issues:
+
+- `#143` scenario-configured backlog expiry
+- `#144` next-round debt ceiling activation
+- `#145` pricing timing alignment
+- `#146` Sales action vocabulary alignment
+- `#147` soft-budget-miss reporting

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -13,13 +13,14 @@ import (
 )
 
 type Options struct {
-	HistoryLimit     int
-	ProcurementTerms ProcurementTermsHook
-	ProductionBOM    ProductionBOMHook
-	ProductionRoute  ProductionRouteHook
-	ProductionCost   ProductionCostHook
-	InventoryCost    InventoryCarryingCostHook
-	WorldUpdate      WorldUpdateHook
+	HistoryLimit        int
+	BacklogExpiryRounds int
+	ProcurementTerms    ProcurementTermsHook
+	ProductionBOM       ProductionBOMHook
+	ProductionRoute     ProductionRouteHook
+	ProductionCost      ProductionCostHook
+	InventoryCost       InventoryCarryingCostHook
+	WorldUpdate         WorldUpdateHook
 }
 
 // ProcurementTermsHook lets scenario data supply part cost, MOQ, and quantity-based pricing rules.
@@ -120,24 +121,26 @@ type Result struct {
 }
 
 type Resolver struct {
-	historyLimit     int
-	procurementTerms ProcurementTermsHook
-	productionBOM    ProductionBOMHook
-	productionRoute  ProductionRouteHook
-	productionCost   ProductionCostHook
-	inventoryCost    InventoryCarryingCostHook
-	worldUpdate      WorldUpdateHook
+	historyLimit        int
+	backlogExpiryRounds int
+	procurementTerms    ProcurementTermsHook
+	productionBOM       ProductionBOMHook
+	productionRoute     ProductionRouteHook
+	productionCost      ProductionCostHook
+	inventoryCost       InventoryCarryingCostHook
+	worldUpdate         WorldUpdateHook
 }
 
 func NewResolver(options Options) *Resolver {
 	return &Resolver{
-		historyLimit:     normalizedHistoryLimit(options.HistoryLimit),
-		procurementTerms: defaultProcurementTerms(options.ProcurementTerms),
-		productionBOM:    defaultProductionBOM(options.ProductionBOM),
-		productionRoute:  defaultProductionRoute(options.ProductionRoute),
-		productionCost:   defaultProductionCost(options.ProductionCost),
-		inventoryCost:    options.InventoryCost,
-		worldUpdate:      options.WorldUpdate,
+		historyLimit:        normalizedHistoryLimit(options.HistoryLimit),
+		backlogExpiryRounds: normalizedBacklogExpiryRounds(options.BacklogExpiryRounds),
+		procurementTerms:    defaultProcurementTerms(options.ProcurementTerms),
+		productionBOM:       defaultProductionBOM(options.ProductionBOM),
+		productionRoute:     defaultProductionRoute(options.ProductionRoute),
+		productionCost:      defaultProductionCost(options.ProductionCost),
+		inventoryCost:       options.InventoryCost,
+		worldUpdate:         options.WorldUpdate,
 	}
 }
 
@@ -164,15 +167,16 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 	}
 
 	phase := roundPhase{
-		state:            &nextState,
-		round:            &round,
-		currentRound:     state.CurrentRound,
-		stats:            &resolutionStats{},
-		procurementTerms: r.procurementTerms,
-		productionBOM:    r.productionBOM,
-		productionRoute:  r.productionRoute,
-		productionCost:   r.productionCost,
-		inventoryCost:    r.inventoryCost,
+		state:               &nextState,
+		round:               &round,
+		currentRound:        state.CurrentRound,
+		stats:               &resolutionStats{},
+		backlogExpiryRounds: r.backlogExpiryRounds,
+		procurementTerms:    r.procurementTerms,
+		productionBOM:       r.productionBOM,
+		productionRoute:     r.productionRoute,
+		productionCost:      r.productionCost,
+		inventoryCost:       r.inventoryCost,
 	}
 
 	if nextState.ActiveTargets.EffectiveRound == state.CurrentRound {
@@ -218,16 +222,17 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 }
 
 type roundPhase struct {
-	state            *domain.MatchState
-	round            *domain.RoundRecord
-	currentRound     domain.RoundNumber
-	stats            *resolutionStats
-	procurementTerms ProcurementTermsHook
-	productionBOM    ProductionBOMHook
-	productionRoute  ProductionRouteHook
-	productionCost   ProductionCostHook
-	inventoryCost    InventoryCarryingCostHook
-	eventSeq         int
+	state               *domain.MatchState
+	round               *domain.RoundRecord
+	currentRound        domain.RoundNumber
+	stats               *resolutionStats
+	backlogExpiryRounds int
+	procurementTerms    ProcurementTermsHook
+	productionBOM       ProductionBOMHook
+	productionRoute     ProductionRouteHook
+	productionCost      ProductionCostHook
+	inventoryCost       InventoryCarryingCostHook
+	eventSeq            int
 }
 
 type resolutionStats struct {
@@ -622,7 +627,7 @@ func (p *roundPhase) finalizeRound(action *domain.ActionSubmission) {
 	aged := make([]domain.BacklogEntry, 0, len(backlog))
 	for _, entry := range backlog {
 		entry.AgeInRounds++
-		if entry.AgeInRounds > 2 {
+		if entry.AgeInRounds > p.backlogExpiryRounds {
 			p.stats.lostSalesUnits += entry.Quantity
 			p.appendEvent(domain.EventBacklogExpired, domain.ActorPlantSystem, fmt.Sprintf("Expired backlog for %s/%s", entry.CustomerID, entry.ProductID), map[string]any{
 				"customer_id": string(entry.CustomerID),
@@ -648,6 +653,7 @@ func (p *roundPhase) finalizeRound(action *domain.ActionSubmission) {
 		targets := action.Action.Finance.NextRoundTargets
 		targets.EffectiveRound = p.currentRound + 1
 		p.state.ActiveTargets = targets
+		p.state.Plant.DebtCeiling = targets.DebtCeilingTarget
 	}
 
 	holdingCost, debtCost := p.applyRoundOperatingCosts()
@@ -1332,6 +1338,13 @@ func normalizedHistoryLimit(limit int) int {
 		return 10
 	}
 	return limit
+}
+
+func normalizedBacklogExpiryRounds(rounds int) int {
+	if rounds <= 0 {
+		return 2
+	}
+	return rounds
 }
 
 func minUnits(values ...domain.Units) domain.Units {

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -67,6 +67,9 @@ func TestResolverExecutesRoundPhasesAndSchedulesNextTargets(t *testing.T) {
 	if result.NextState.ActiveTargets.EffectiveRound != 3 {
 		t.Fatalf("ActiveTargets.EffectiveRound = %d, want 3", result.NextState.ActiveTargets.EffectiveRound)
 	}
+	if result.NextState.Plant.DebtCeiling != 6 {
+		t.Fatalf("Plant.DebtCeiling = %d, want 6", result.NextState.Plant.DebtCeiling)
+	}
 	if result.NextState.Plant.Cash != 19 {
 		t.Fatalf("Plant.Cash = %d, want 19", result.NextState.Plant.Cash)
 	}
@@ -578,6 +581,42 @@ func TestResolverTracksLostSalesAndDebtServiceInMetrics(t *testing.T) {
 	}
 	if got := result.NextState.Customers[0].Sentiment; got != 4 {
 		t.Fatalf("Customer sentiment = %d, want 4", got)
+	}
+}
+
+func TestResolverUsesConfiguredBacklogExpiryRounds(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		BacklogExpiryRounds: 3,
+	})
+	state := fixtureState()
+	state.Plant.Backlog = []domain.BacklogEntry{
+		{CustomerID: "cust-1", ProductID: "widget", Quantity: 2, OriginRound: 1, AgeInRounds: 2},
+	}
+	state.Plant.FinishedInventory = nil
+	state.Plant.InTransitSupply = nil
+
+	actions := fixtureActions()
+	actions[0].Action.Procurement.Orders = nil
+	actions[1].Action.Production.Releases = nil
+	actions[1].Action.Production.CapacityAllocation = nil
+	actions[2].Action.Sales.ProductOffers = nil
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := backlogQty(result.NextState.Plant.Backlog, "cust-1", "widget"); got != 2 {
+		t.Fatalf("Backlog(cust-1/widget) = %d, want 2", got)
+	}
+	if got := result.Round.Metrics.LostSalesUnits; got != 0 {
+		t.Fatalf("LostSalesUnits = %d, want 0", got)
+	}
+
+	for _, event := range result.Round.Events {
+		if event.Type == domain.EventBacklogExpired {
+			t.Fatalf("unexpected backlog expiry event: %#v", event)
+		}
 	}
 }
 

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -150,7 +150,8 @@ func (d Definition) ResolverOptions() engine.Options {
 	workstationByID := d.workstationsByID()
 
 	return engine.Options{
-		HistoryLimit: d.DefaultHistoryLimit,
+		HistoryLimit:        d.DefaultHistoryLimit,
+		BacklogExpiryRounds: d.MarketModel.DemandAssumptions.BacklogExpiryRounds,
 		ProcurementTerms: func(ctx engine.ProcurementTermsContext) engine.ProcurementTerms {
 			part, ok := partByID[ctx.Order.PartID]
 			if !ok {


### PR DESCRIPTION
## Summary
- add a canonical simulation invariants document and companion audit report under `docs/`
- fix two critical enforcement gaps by honoring scenario-configured backlog expiry and applying finance debt ceiling targets to next-round plant state
- add resolver coverage for the new invariant behavior and link the new docs from the README

## Audit findings filed as follow-ups
- closes #143
- closes #144
- references #145
- references #146
- references #147

## Main issue
- closes #142

## Verification
- `go run ./cmd/quality verify`