### PR TITLE
[codex] Document the Sales Manager role card

### DIFF
--- a/docs/roles/sales-manager-role-card.md
+++ b/docs/roles/sales-manager-role-card.md
@@ -1,0 +1,184 @@
+# Sales Manager Role Card
+
+## Document Metadata
+
+- Role name: `Sales Manager`
+- Status: `MVP`
+- Canonical ID: `sales_manager`
+- Last updated: `2026-04-22`
+- Related issues: `#93`, `#98`, `#103`
+
+## I. Identity And Objectives (The "Who")
+
+### Description And Core Goal
+
+The Sales Manager turns market opportunity into revenue by setting prices and shaping demand. In strong play, this role builds profitable backlog that the plant can credibly serve instead of chasing orders that overwhelm capacity or damage customer trust.
+
+This role's natural local bias is to treat bookings, customer promises, and revenue momentum as success even when the plant cannot fulfill those commitments cleanly or profitably.
+
+### Success And Failure Criteria
+
+Success signals:
+
+- demand is captured at prices that support healthy revenue and margin
+- backlog stays productive rather than becoming an unmanageable promise queue
+- customer sentiment remains healthy because lead times and service stay credible
+- pricing decisions align with the plant's actual ability to produce and ship
+
+Failure signals:
+
+- backlog grows faster than the plant can realistically clear
+- low pricing or aggressive promise making drives revenue while hurting profitability
+- late shipments or expired backlog reduce customer sentiment
+- Sales keeps pushing demand into a plant that is already materially constrained
+
+Key tradeoff:
+
+- local sales success can look strong on bookings or volume while still hurting plant-wide service, margin, and operational stability
+
+### Key Performance Indicators (KPIs)
+
+| KPI | Why It Matters | Healthy Signal | Warning Signal | Typical Decision Trigger |
+| --- | --- | --- | --- | --- |
+| Revenue versus target | Shows whether Sales is creating meaningful top-line performance. | Revenue tracks target without obvious service strain. | Revenue misses badly or only improves through damaging discounts. | Revisit pricing or demand posture. |
+| Backlog pressure | Reveals whether accepted demand is still manageable. | Backlog is large enough to keep the plant busy but not out of control. | Backlog ages, grows rapidly, or exceeds visible production support. | Slow demand growth, raise price, or coordinate on capacity risk. |
+| Customer sentiment and service reliability | Sales depends on future willingness to buy. | Sentiment remains stable or improving because service is credible. | Missed promises and backlog expiry start reducing demand quality. | Protect key orders or adjust market promises. |
+| Average selling price | Connects demand capture to economic quality. | Price supports demand without needless margin erosion. | ASP drops mainly to chase volume the plant cannot support well. | Raise price, narrow pursuit, or prioritize better-fit demand. |
+| Lost-sales or backlog-expiry risk | Shows where demand is being accepted but not converted. | Accepted orders are shipped before they decay. | Orders age into expiry or repeated lateness. | Reduce pressure, protect key backlog, or escalate plant constraints. |
+
+## II. Operational Domain (The "What")
+
+### Responsibilities
+
+- set market price for each product
+- interpret backlog, customer sentiment, and revenue pressure
+- decide how aggressively to pursue demand given the plant's visible situation
+- explain why a pricing move is meant to support growth, service, or recovery
+
+### Decision Levers
+
+| Lever | MVP Or Future | What The Player Changes | Immediate Tradeoff | Likely Downstream Effect |
+| --- | --- | --- | --- | --- |
+| Market price by product | `MVP` | Chooses the price signal that affects subsequent customer demand. | Lower price may win demand but hurt margin or overload the plant. | Changes future demand, backlog pressure, and revenue quality. |
+| Demand posture | `MVP` | Chooses whether to push volume, protect margin, or cool demand indirectly through pricing. | More demand now can create more service risk later. | Changes backlog, customer expectations, and plant pressure. |
+| Customer-priority framing | `MVP` | Highlights which backlog or service problems matter most. | Some opportunities get less attention. | Helps the plant align limited output with the best commercial outcome. |
+| Deal and channel shaping | `Future Role` | Chooses segment focus, discount structures, or account tactics. | Greater commercial complexity versus more targeted demand. | Changes mix quality once broader market mechanics exist. |
+| Promise-date management | `Future Role` | Actively controls quoted lead times and commitments. | More conservative promises may reduce bookings. | Can improve sentiment and reduce expiry once modeled explicitly. |
+
+### Constraints
+
+- Sales controls price, not physical production or inventory
+- finished goods can only ship if they already exist in inventory
+- pricing decisions affect subsequent demand rather than retroactive same-round demand
+- customer backlog expires if it remains unshipped too long
+- current-turn actions remain hidden until round resolution
+
+## III. Ecosystem (The "How")
+
+### Synergies
+
+- Production Manager: realistic demand priorities help the plant focus on the most valuable output
+- Procurement Manager: clearer demand direction improves material planning
+- Finance Controller: better revenue quality helps Finance support the right growth instead of reacting to weak-margin volume
+
+Shared information that matters most:
+
+- visible backlog and shipment performance
+- customer sentiment
+- finished goods availability
+- active revenue and financial targets
+
+### Conflicts
+
+- Production Manager: Sales wants more fulfilled demand while Production must honor parts and capacity reality
+- Finance Controller: Sales may want lower pricing or aggressive pursuit while Finance worries about margin and cash quality
+- Procurement Manager: Sales can create product pressure that supply coverage does not support well
+
+Escalation guidance:
+
+- negotiate when the disagreement is about mix, timing, or acceptable demand pacing
+- escalate when customer promises or backlog pressure materially exceed visible plant capability
+
+### Reports And Data
+
+| Information | Visibility | Why The Role Needs It | Shared Before Reveal? | Shared After Resolution? |
+| --- | --- | --- | --- | --- |
+| Customer backlog by product | Plant-wide | Shows what demand is already waiting to be served. | Yes | Yes |
+| Customer sentiment | Plant-wide | Helps Sales judge how much demand the market will still tolerate. | Yes | Yes |
+| Finished goods inventory | Plant-wide | Shows what can actually ship soon. | Yes | Yes |
+| Recent shipment and service signals | Plant-wide | Tells Sales where trust is rising or falling. | Yes | Yes |
+| Sales pipeline and pricing interpretation | Role-specific interpretation | Helps Sales explain whether growth or restraint is wiser. | Yes | Yes |
+| Current-turn pricing intent | Hidden current-turn action | Must stay hidden until reveal. | No | Yes |
+
+## IV. Dynamic Variables (The "What If")
+
+### Opportunities
+
+- raising price when the plant is constrained and demand is still strong
+- protecting key backlog rather than chasing every possible new order
+- using selective price moves to rebalance mix toward what the plant can serve better
+
+### Events
+
+Common shocks for this role:
+
+- a demand spike exceeds visible plant support
+- customer sentiment falls after repeated late service
+- backlog grows into a credibility risk
+- margin pressure makes volume chasing less attractive
+
+Reasonable responses:
+
+- raise price to moderate demand and protect quality of backlog
+- accept slower growth in order to rebuild service reliability
+- align commercial pressure with what Production can credibly finish
+- escalate when the market opportunity is real but the plant cannot support it alone
+
+Overreaction examples:
+
+- discounting to win demand the plant cannot serve
+- protecting bookings volume while customer trust collapses
+- demanding more output without acknowledging physical constraints
+
+## V. Additional Aspects To Consider
+
+### Information Asymmetry
+
+The Sales Manager usually sees market opportunity and customer frustration earlier than the rest of the plant. This role is often first to recognize that service misses are becoming a demand problem rather than just an internal operations problem.
+
+That privileged view does not include hidden current-turn actions from Procurement, Production, or Finance.
+
+### Resource Ownership
+
+- product pricing posture
+- revenue pressure by product
+- backlog quality and customer expectation pressure
+- commercial risk tied to service credibility
+
+### Risk Profile
+
+| Risk | Earliest Warning Sign | What Happens If Ignored | Typical Mitigation |
+| --- | --- | --- | --- |
+| Backlog overload | Order queue grows faster than shipments. | Customers wait too long, demand quality falls, and backlog expires. | Moderate demand, prioritize backlog quality, or escalate plant limits. |
+| Margin erosion through pricing | ASP falls while operational stress stays high. | Revenue may rise while profitability weakens. | Raise price or focus demand on better-fit opportunities. |
+| Credibility loss with customers | Sentiment or service signals start trending down. | Future demand becomes harder to win even after operations recover. | Protect key orders and align promises with visible capacity. |
+| Commercial pressure detached from plant reality | Sales keeps demanding more despite visible constraints. | Other roles firefight, service degrades, and conflict intensifies. | Rebalance the demand posture and coordinate more explicitly. |
+
+## VI. Relationships
+
+| Other Role | Primary Synergy | Primary Conflict | Information To Share | When To Escalate |
+| --- | --- | --- | --- | --- |
+| Production Manager | Shared service priorities help the plant ship the most valuable work first. | Sales may want more output than parts and capacity can support. | Backlog urgency, product priorities, and customer-risk implications. | When customer commitments exceed feasible production support. |
+| Procurement Manager | Better demand direction helps supply planning follow the right mix. | Sales can push demand that materials coverage cannot support. | Demand trend, product pressure, and risk of the wrong inventory mix. | When demand growth materially outpaces supply coverage. |
+| Finance Controller | Better revenue quality helps Finance support growth with clearer economics. | Finance may resist pricing or demand moves that look risky in the short term. | Revenue target risk, margin tradeoffs, and service-related revenue loss. | When commercial support requires accepting temporary cost or cash pressure. |
+
+## Notes For Role Briefings And Playbooks
+
+For a short role briefing, keep the focus on mission, legal actions, and the local bias toward bookings and revenue capture.
+
+For a longer gameplay playbook, expand:
+
+- how to read backlog and service pressure before adjusting price
+- when higher price protects the plant better than more demand
+- how to distinguish healthy backlog from dangerous backlog
+- how to coordinate growth pressure with production and finance limits


### PR DESCRIPTION
## Summary
- add a Sales Manager role card under `docs/roles`
- map the role to the role-card structure and canonical MVP vocabulary
- document sales goals, KPIs, decision levers, risks, and cross-role relationships

## Why
Issue #93 asks for the Sales Manager role to be documented using the role card template.

Closes #93

## Validation
- documentation change only
- CI will run on this PR