### PR TITLE
[codex] Document the Logistics and Warehouse Manager weekly report

### DIFF
--- a/docs/reports/logistics-and-warehouse-manager-weekly-report.md
+++ b/docs/reports/logistics-and-warehouse-manager-weekly-report.md
@@ -1,0 +1,203 @@
+# Logistics And Warehouse Manager Weekly Report
+
+This document defines the weekly report a future `Logistics and Warehouse Manager` role would likely need in HerbieGo.
+
+The report should help the player answer one core question before acting:
+
+`Where is physical flow breaking down, and which action best improves storage, movement, and shipping reliability without creating avoidable cost or labor waste?`
+
+## Future Role Status
+
+The `Logistics and Warehouse Manager` is not currently implemented in the MVP action roster. This document is forward-looking design guidance for future expansion, onboarding, and AI-role planning.
+
+Several signals here build on concepts that are adjacent to today's MVP, such as finished-goods inventory, backlog pressure, and inbound or outbound movement, but the full warehouse-control surface remains future work.
+
+## Role Scope
+
+- Role: `Logistics and Warehouse Manager`
+- Status: `Future Role`
+- Primary decision horizon: this round's movement and space pressure plus the next few rounds of shipping reliability
+- Main tradeoff: physical flow and service reliability versus labor effort, storage density, and freight cost
+
+## What This Report Should Support
+
+The weekly logistics report should help the player decide whether to:
+
+- reprioritize shipping or receiving flow
+- accept higher freight spend to protect critical service
+- reorganize or reslot storage to improve movement
+- escalate when inventory buildup is turning into a physical bottleneck
+- push back on plant behavior that overloads space or handling capacity
+
+The report should make physical constraints visible before they show up only as missed shipments or warehouse chaos.
+
+## Recommended Report Structure
+
+Present the report in this order.
+
+## 1. Executive Summary
+
+Start with a short summary panel that highlights the biggest flow and storage risks.
+
+Recommended summary items:
+
+- whether warehouse occupancy is healthy, stretched, or critical
+- whether outbound shipping reliability is stable or degrading
+- whether inbound flow is creating congestion
+- where physical movement is the current bottleneck
+- whether expediting pressure is rising
+
+Why first:
+
+- the role should know immediately whether the week is about keeping flow stable, relieving congestion, or protecting key shipments
+
+## 2. Warehouse Capacity And Storage Pressure
+
+This is the core of the report because physical space often becomes an invisible bottleneck before the rest of the plant recognizes it.
+
+Use one row per storage zone, inventory class, or warehouse area:
+
+| Area | Occupancy Signal | Overflow Risk | Flow Impact | Risk Level | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `example_area` | Current space use. | Stable, rising, or critical. | What movement it disrupts. | `Low`, `Medium`, or `High`. | Main interpretation. |
+
+Recommended fields:
+
+- storage occupancy percentage
+- overflow condition
+- location congestion
+- bin or location accuracy risk
+- whether current density is hurting movement speed or picking reliability
+
+Decision value:
+
+- helps Logistics decide whether to re-slot, accelerate outbound flow, or escalate inventory buildup
+
+## 3. Shipping And Receiving Throughput
+
+This section shows whether material and product are moving through the warehouse at a sustainable pace.
+
+Use a table like this:
+
+| Flow Area | Current Throughput Signal | Main Constraint | Service Risk | Notes |
+| --- | --- | --- | --- | --- |
+| `example_flow` | Current movement condition. | Main limiting factor. | `Low`, `Medium`, or `High`. | Main interpretation. |
+
+Recommended fields:
+
+- inbound volume
+- outbound volume
+- dock or staging pressure
+- picking or handling efficiency
+- where receipts or shipments are waiting too long
+
+Decision value:
+
+- helps Logistics distinguish a storage problem from a handling problem and choose the right corrective action
+
+## 4. Freight And Expediting Pressure
+
+Logistics often absorbs the cost of a plant that is already out of rhythm.
+
+Recommended fields:
+
+- outbound freight spend
+- inbound freight spend
+- premium or expedited freight signal
+- detention or waiting-cost signal
+- repeated causes of costly shipments, such as lateness, congestion, or missing material
+
+Use one row per freight category:
+
+| Freight Signal | Current Status | Why It Matters | Warning Trigger | Likely Response |
+| --- | --- | --- | --- | --- |
+| `example_signal` | Current condition. | Cost or service implication. | What should worry Logistics. | Expedite, reschedule, or escalate. |
+
+Decision value:
+
+- helps the role decide when premium spend is justified and when it only hides deeper process problems
+
+## 5. Inventory Aging And Flow Quality
+
+Not all stored inventory is equally healthy.
+
+Use one row per inventory class:
+
+| Inventory Class | Aging Signal | Why It Is Sitting | Space Impact | Commercial Or Operating Risk |
+| --- | --- | --- | --- | --- |
+| `example_class` | Fresh, slow-moving, or critical. | Main cause. | Light, moderate, or severe. | What it threatens. |
+
+Recommended fields:
+
+- slow-moving stock
+- obsolete or stranded stock
+- dead-stock value or equivalent burden signal
+- inventory that is consuming space without helping service
+
+Decision value:
+
+- helps Logistics identify when the real problem is not movement speed but bad inventory mix and accumulation
+
+## 6. Logistics Decision Prompts
+
+End the report with 3 to 5 plain-language prompts that guide the next logistics decision.
+
+Recommended prompts:
+
+- Is space the problem, or is movement discipline the problem?
+- Which shipment is worth expediting, and which is not?
+- Which inventory is supporting real flow, and which inventory is only taking up room?
+- Is the warehouse overloaded because of demand, overproduction, overbuy, or poor slotting?
+- What should be escalated to Sales, Production, Procurement, or Finance before congestion gets worse?
+
+Why this matters:
+
+- the report should help the role act on physical flow, not only observe congestion after the fact
+
+## Visibility Guidance
+
+This report would combine plant-wide inventory and service signals with logistics-specific interpretation.
+
+Plant-wide or shared inputs:
+
+- inbound material arrival signals
+- finished-goods and inventory levels
+- shipment demand and backlog pressure
+- service reliability indicators
+
+Role-focused interpretation:
+
+- whether space or handling is the current bottleneck
+- whether expediting is economically justified
+- where physical flow is breaking down
+
+When this role exists in runtime play, its report should still respect hidden simultaneous turns and must not expose other roles' current-turn actions before reveal.
+
+## MVP Versus Future Expansion
+
+| Report Element | MVP Now | Future Expansion |
+| --- | --- | --- |
+| Finished-goods inventory signals | Yes | Yes |
+| Backlog-linked shipment pressure | Yes | Yes |
+| Inbound receipt pressure | Limited | Yes |
+| Warehouse occupancy and slotting | No | Yes |
+| Dock utilization | No | Yes |
+| Freight and expedite tracking | No | Yes |
+| Bin accuracy and cycle-count control | No | Yes |
+| Dead-stock and obsolete-stock analysis | Limited | Yes |
+
+## Example Decisions This Report Should Enable
+
+- `Expedite shipment`: spend more to protect a high-value order or customer
+- `Re-slot warehouse`: trade labor effort for better picking and movement flow
+- `Force inventory cleanup`: push the plant to clear stock that is blocking useful flow
+- `Escalate congestion`: surface when space limits are becoming a plant-level bottleneck
+
+## Design Guardrails
+
+When contributors implement or refine this report, they should:
+
+- frame it clearly as future-role guidance until the role exists in-game
+- connect warehouse metrics to real decisions and plant tradeoffs
+- treat physical space and movement as constraints, not just background detail
+- keep the interaction between logistics cost and service reliability explicit


### PR DESCRIPTION
## Summary
- add a dedicated logistics and warehouse weekly report guide under `docs/reports`
- define the recommended report sections, decision prompts, and visibility rules
- frame the document as future-role guidance instead of current MVP runtime behavior

## Why
Issue #100 asks for the weekly report structure the Logistics and Warehouse Manager wants so contributors can design future flow and storage views around real logistics decisions.

Closes #100

## Validation
- documentation change only
- CI will run on this PR