### PR TITLE
[codex] Add the Sales Manager gameplay playbook

### DIFF
--- a/docs/playbooks/sales-manager-gameplay-playbook.md
+++ b/docs/playbooks/sales-manager-gameplay-playbook.md
@@ -1,0 +1,288 @@
+# Sales Manager Gameplay Playbook
+
+This playbook teaches a human player or AI agent how to perform the `Sales Manager` role in realistic weekly MVP play.
+
+## Mission
+
+Your job is to convert market opportunity into revenue without creating promises the plant cannot credibly keep. Good sales play grows demand at prices and volumes the plant can support. Bad sales play wins orders that later become backlog decay, customer frustration, and weak-margin chaos.
+
+## What You Control
+
+In the current MVP, you control:
+
+- market price for each product
+- the commercial posture implied by that pricing
+- the rationale you attach to your decision
+
+You do not control:
+
+- finished-goods availability
+- production capacity or part supply
+- current-round procurement or production decisions
+- same-round shipment outcomes beyond what already exists in inventory
+
+Critical MVP constraint:
+
+- pricing decisions this round affect subsequent demand, not retroactive same-round demand
+
+## Core Tension
+
+You are balancing:
+
+- revenue growth
+- backlog size
+- delivery reliability
+- customer sentiment
+- profitability
+
+The role becomes dangerous when you chase bookings or volume without respecting service credibility.
+
+Examples:
+
+- lower prices can win demand while overwhelming the plant
+- higher prices can protect backlog quality but may sacrifice short-term volume
+- strong revenue can still be bad if it comes with aging backlog and falling trust
+
+## What You Should Read First Each Turn
+
+Read the sales report in this order:
+
+1. Executive summary
+2. Revenue and demand pipeline
+3. Backlog and fulfillment pressure
+4. Customer sentiment and service credibility
+5. Price and margin quality
+
+Questions to answer before deciding:
+
+- Is backlog healthy, overloaded, or too thin?
+- Which product has room for more demand without creating service damage?
+- Are we winning demand at prices that still make sense?
+- Is customer trust improving or deteriorating?
+- Do we need growth this round, or do we need credibility restoration?
+
+## Top Metrics To Watch
+
+- revenue versus target
+- backlog pressure
+- customer sentiment and service reliability
+- average selling price
+- lost-sales or backlog-expiry risk
+
+Interpret them together.
+
+Examples:
+
+- high revenue with worsening backlog can be a warning, not a success
+- low backlog with healthy service may justify more aggressive pricing
+- falling sentiment usually means Sales should stop making promises the plant cannot support
+
+## Weekly Decision Checklist
+
+Use this checklist every turn:
+
+1. Check whether current backlog is healthy demand or dangerous overcommitment.
+2. Check whether finished-goods availability and service signals support more commercial pressure.
+3. Identify which product has the best combination of demand opportunity and service support.
+4. Decide whether price should rise, hold, or fall.
+5. Sanity-check whether your choice improves revenue quality or only volume.
+6. Consider what should be escalated to Production or Finance before you push demand harder.
+7. Write a short rationale that explains the tradeoff you are accepting.
+
+## Revenue Vs Service Tradeoffs
+
+Good tradeoffs:
+
+- raising price when backlog is already too fragile
+- keeping price steady when the plant can support the current demand well
+- using lower price selectively only where the plant has room and credibility
+
+Bad tradeoffs:
+
+- discounting to chase volume while backlog is already aging
+- treating every open order as equally valuable even when some are becoming unserviceable
+- prioritizing bookings optics over future demand quality
+
+## Trigger Guide
+
+### When backlog is rising
+
+Default response:
+
+- slow demand growth unless the plant clearly has room to absorb it
+
+Reasonable actions:
+
+- raise price on the overloaded product
+- protect backlog quality instead of pushing more volume
+
+Bad response:
+
+- discounting further because revenue targets feel urgent
+
+### When customer sentiment is weakening
+
+Default response:
+
+- stop making aggressive commercial promises the plant may not keep
+
+Reasonable actions:
+
+- hold or raise price
+- align demand with visible service capability
+- escalate recurring service problems
+
+Bad response:
+
+- trying to “sell through” a credibility problem with lower price
+
+### When finished goods are available and backlog is thin
+
+Default response:
+
+- consider a more aggressive pricing posture
+
+Reasonable actions:
+
+- lower price selectively or hold price if demand is already healthy
+
+Bad response:
+
+- raising price reflexively and leaving the plant short of useful demand
+
+### When cash pressure is high
+
+What this usually means for Sales:
+
+- Finance may need better revenue quality, not just more volume
+
+Reasonable response:
+
+- protect price discipline and avoid low-quality backlog
+
+Bad response:
+
+- chasing volume at poor price while the plant is already under financial stress
+
+## Common Failure Modes
+
+- chasing order volume while backlog ages out
+- discounting without operational support
+- ignoring service credibility until sentiment drops sharply
+- treating revenue growth as good even when margin and delivery quality deteriorate
+- pressuring Production for more without acknowledging visible constraints
+
+## Working With Other Roles
+
+### Production Manager
+
+You need Production when:
+
+- backlog priorities are changing
+- one product is far more commercially important than the other
+
+What to share:
+
+- which backlog is most valuable to protect
+- what customer risk is rising
+- where service misses are already harming demand quality
+
+### Finance Controller
+
+You need Finance when:
+
+- growth pressure conflicts with margin or cash discipline
+- commercial support may require accepting short-term financial risk
+
+What to share:
+
+- why a higher or lower price is strategically justified
+- whether weak service is already reducing future revenue quality
+
+### Procurement Manager
+
+You need Procurement when:
+
+- demand concentration is shifting product priorities
+- sales pressure is likely to expose future supply gaps
+
+What to share:
+
+- where demand is becoming more important
+- which product mix matters most commercially
+
+### Future Logistics And Quality Roles
+
+Once those roles exist, Sales should also coordinate on:
+
+- shipment reliability and expedite tradeoffs
+- returns, complaints, and customer-protection decisions
+
+## Example Decision Patterns
+
+### Safe Decision
+
+Situation:
+
+- backlog is healthy
+- sentiment is stable
+- finished goods availability is reasonable
+
+Decision:
+
+- hold price and preserve current demand quality
+
+Why it works:
+
+- it avoids creating unnecessary instability when commercial conditions are already healthy
+
+### Aggressive Decision
+
+Situation:
+
+- backlog is thin
+- service is healthy
+- the plant appears able to support more demand
+
+Decision:
+
+- lower price selectively on the product with the strongest room for growth
+
+Why it can be right:
+
+- it fills the plant with useful work before service becomes fragile
+
+Main risk:
+
+- if operations worsen unexpectedly, backlog can shift from healthy to overloaded quickly
+
+### Risky Decision
+
+Situation:
+
+- backlog is already aging
+- service reliability is weakening
+- revenue target pressure feels urgent
+
+Decision:
+
+- discount further to drive more orders
+
+Why it is risky:
+
+- it increases promises when the plant is already struggling to keep the ones it has
+
+## Notes For Human Briefings And AI Role Instructions
+
+Reusable guidance:
+
+- protect revenue quality, not just order volume
+- price with service credibility in mind
+- do not create backlog the plant cannot support
+- escalate operational constraints before you amplify them commercially
+
+Good sales reasoning should sound like:
+
+- `This price protects backlog quality rather than chasing weak volume.`
+- `I am growing demand only where the plant can credibly support it.`
+- `I am accepting slower revenue growth to protect customer trust.`


### PR DESCRIPTION
## Summary
- add a dedicated Sales Manager gameplay playbook under `docs/playbooks`
- explain how to read the report, balance backlog quality against revenue growth, and price with service credibility in mind
- include trigger-based guidance, common failure modes, and reusable briefing language

## Why
Issue #106 asks for a practical Sales Manager gameplay playbook grounded in the current MVP action model.

Closes #106

## Validation
- documentation change only
- CI will run on this PR