### PR TITLE
[codex] Add the Logistics and Warehouse Manager gameplay playbook

### DIFF
--- a/docs/playbooks/logistics-and-warehouse-manager-gameplay-playbook.md
+++ b/docs/playbooks/logistics-and-warehouse-manager-gameplay-playbook.md
@@ -1,0 +1,323 @@
+# Logistics And Warehouse Manager Gameplay Playbook (Future Role)
+
+This playbook defines how a human player or AI agent would likely perform the future `Logistics and Warehouse Manager` role in realistic HerbieGo play once that role is implemented.
+
+## Future Role Status
+
+The `Logistics and Warehouse Manager` is not currently implemented in the MVP action roster.
+
+This document is forward-looking design guidance for future expansion, contributor onboarding, and AI-role planning. It describes what the role would likely control, monitor, and optimize if explicit warehouse and logistics mechanics are added later.
+
+## Mission
+
+Your job would be to keep material and finished goods moving reliably through the plant without allowing warehouse congestion, shipping chaos, or premium freight to become the hidden cost of poor plant coordination. Good logistics play protects physical flow and service credibility. Bad logistics play lets space, movement, and shipment reliability break down until the plant discovers too late that inventory alone is not the same as usable flow.
+
+## What This Role Would Likely Control
+
+If implemented, the `Logistics and Warehouse Manager` would likely control:
+
+- shipping prioritization
+- receiving flow and staging discipline
+- storage, slotting, and overflow decisions
+- inventory movement priorities inside the warehouse
+- expedite or premium-freight recommendations
+- cleanup pressure on slow-moving or stranded stock
+
+This role would likely not control directly:
+
+- sales pricing or customer-demand shaping
+- production releases or line scheduling
+- procurement order placement
+- plant-wide financial policy beyond logistics-specific escalation
+
+Critical future-role constraint:
+
+- logistics should improve physical flow and service reliability, not simply spend money or shuffle inventory around to make congestion look temporarily quieter
+
+## Core Tension
+
+You would be balancing:
+
+- shipping reliability
+- warehouse efficiency
+- labor effort and handling discipline
+- freight cost
+- storage and space limits
+
+The role becomes dangerous when you optimize only for one of those outcomes.
+
+Examples:
+
+- pushing every urgent shipment can protect one order while creating chaos and freight waste
+- maximizing storage density can save space while making movement slower and less reliable
+- accepting every inbound receipt without flow discipline can bury the warehouse in congestion
+
+## What You Should Read First Each Turn
+
+Read the logistics report in this order:
+
+1. Executive summary
+2. Warehouse capacity and storage pressure
+3. Shipping and receiving throughput
+4. Freight and expediting pressure
+5. Inventory aging and flow quality
+
+Questions to answer before deciding:
+
+- Is the real problem space, movement discipline, shipping priority, or bad inventory mix?
+- Which shipment or receipt is most important to plant-wide performance?
+- Are we paying premium freight for a real service need or to hide a coordination failure?
+- Which stock is helping useful flow, and which stock is only consuming space?
+- What should be escalated before physical congestion turns into service failure?
+
+## Top Signals To Watch
+
+- warehouse occupancy and overflow pressure
+- outbound shipping reliability
+- inbound congestion and dock delay
+- premium-freight or expedite pressure
+- slow-moving, obsolete, or stranded inventory burden
+
+Interpret them together.
+
+Examples:
+
+- high occupancy with rising picking delay usually means the space problem is already affecting service
+- rising premium freight often points to deeper planning or coordination failure
+- inventory growth is not helpful if it blocks movement and delays the wrong shipments
+
+## Weekly Decision Checklist
+
+Use this checklist every turn:
+
+1. Identify whether the main constraint is storage, movement, or shipment prioritization.
+2. Protect the highest-value outbound commitments first.
+3. Check whether inbound flow is creating avoidable congestion or overflow.
+4. Decide whether to re-slot, expedite, delay, or escalate.
+5. Challenge inventory that is consuming space without improving service.
+6. Sanity-check that your action improves useful flow instead of only moving the problem around.
+7. Write a short rationale that explains the tradeoff you are accepting.
+
+## Flow Vs Cost Tradeoffs
+
+Good tradeoffs:
+
+- accepting selective expedite cost to protect a high-value shipment
+- reorganizing storage to improve sustained movement, even if it takes short-term labor
+- pushing inventory cleanup when dead stock is harming useful flow
+
+Bad tradeoffs:
+
+- expediting routinely because prioritization failed upstream
+- delaying all inbound or outbound work equally when only one area is truly overloaded
+- protecting warehouse appearance while ignoring service deterioration
+
+## Trigger Guide
+
+### When warehouse occupancy is high
+
+Default response:
+
+- relieve the space that is blocking useful movement first
+
+Reasonable actions:
+
+- accelerate shipment of the most important finished goods
+- re-slot or isolate the inventory causing the worst congestion
+- escalate dead-stock or overflow risk before it becomes a plant-wide bottleneck
+
+Bad response:
+
+- stacking more inventory into already-fragile space because receipts keep arriving
+
+### When shipping delays are growing
+
+Default response:
+
+- protect the outbound flow with the biggest service and commercial impact
+
+Reasonable actions:
+
+- reprioritize shipments
+- escalate where backlog promises exceed warehouse capability
+- use premium freight selectively when it prevents a much larger service failure
+
+Bad response:
+
+- treating every late shipment as equally urgent
+
+### When inbound congestion is rising
+
+Default response:
+
+- keep receiving disciplined enough that inbound flow does not crush warehouse movement
+
+Reasonable actions:
+
+- stagger receipts where possible
+- prioritize the materials that directly protect plant throughput
+- pressure Procurement or Production when the warehouse is being used as a parking lot
+
+Bad response:
+
+- accepting all inbound flow without regard for space, staging, or downstream handling
+
+### When expedite costs are climbing
+
+Default response:
+
+- separate justified service protection from recurring process failure
+
+Reasonable actions:
+
+- approve selective expedites for high-value orders
+- surface the root causes behind repeated expediting
+- push the plant to fix the planning or flow issue creating the cost
+
+Bad response:
+
+- normalizing premium freight as the default way to keep service working
+
+## Common Failure Modes
+
+- treating warehouse congestion as an unavoidable background problem
+- using premium freight to hide chronic coordination failures
+- allowing slow-moving stock to consume space needed for useful flow
+- prioritizing storage density over movement reliability
+- failing to distinguish high-value service risk from generic busyness
+
+## Working With Other Roles
+
+### Sales Manager
+
+You need Sales when:
+
+- service promises are colliding with physical shipping limits
+- one customer or product needs explicit outbound prioritization
+
+What to share:
+
+- which commitments are physically at risk
+- when shipping urgency is real versus commercially overstated
+
+### Production Manager
+
+You need Production when:
+
+- finished-goods buildup is overloading storage
+- outbound or internal movement is being disrupted by production behavior
+
+What to share:
+
+- where the warehouse is becoming a constraint
+- which output patterns are creating avoidable congestion
+
+### Procurement Manager
+
+You need Procurement when:
+
+- inbound material flow is overloading receiving or storage
+- warehouse strain is being driven by overbuy or poor timing
+
+What to share:
+
+- where receipts are no longer landing cleanly
+- which incoming inventory is helping versus hurting total flow
+
+### Finance Controller
+
+You need Finance when:
+
+- expediting, overflow handling, or extra labor cost may be justified
+- inventory congestion is trapping cash as well as space
+
+What to share:
+
+- why a logistics spend protects service or avoids bigger disruption
+- where cost pressure is being created by plant behavior, not by logistics preference
+
+### Future Plant Manager
+
+Once that role exists, Logistics should also coordinate on:
+
+- plant-level decisions when space, shipping reliability, and upstream behavior are in conflict
+
+## Example Decision Patterns
+
+### Safe Decision
+
+Situation:
+
+- occupancy is elevated but stable
+- one outbound flow is commercially important
+- premium freight pressure is still manageable
+
+Decision:
+
+- reprioritize warehouse effort toward the most important outbound commitments without broadly expediting
+
+Why it works:
+
+- it protects useful service while preserving discipline and cost control
+
+### Aggressive Decision
+
+Situation:
+
+- congestion is rising quickly
+- one group of shipments is at risk of missing key commitments
+- dead or slow-moving stock is consuming prime space
+
+Decision:
+
+- clear obstructive inventory aggressively, re-slot key zones, and use selective expedite support
+
+Why it can be right:
+
+- it trades short-term effort and some cost for restoring usable physical flow
+
+Main risk:
+
+- if the cleanup is poorly targeted, labor and freight spend can rise without fixing the real bottleneck
+
+### Risky Decision
+
+Situation:
+
+- inbound and outbound pressure are both rising
+- occupancy is near critical
+- the team is already using expedites frequently
+
+Decision:
+
+- keep accepting all flow and solve service risk with more premium freight
+
+Why it is risky:
+
+- it protects short-term appearances while making the underlying warehouse instability more expensive and harder to unwind
+
+## Likely Future Mechanics Needed
+
+To support this role well, future simulation design would likely need:
+
+- warehouse occupancy and location pressure
+- inbound and outbound movement queues
+- shipment prioritization and reliability signals
+- freight-cost and expedite tracking
+- slow-moving, obsolete, and stranded-stock visibility
+- some representation of slotting or space quality
+
+## Notes For Human Briefings And AI Role Instructions
+
+Reusable guidance:
+
+- inventory only helps if it can move
+- protect the most important flow, not every request equally
+- use expediting selectively, not as a substitute for discipline
+- warehouse space is a real plant constraint, not background scenery
+
+Good logistics reasoning should sound like:
+
+- `I am protecting the outbound flow that matters most instead of treating every shipment as equally urgent.`
+- `This expedite is justified because the service risk is larger than the freight cost.`
+- `I am escalating inventory congestion because the warehouse is becoming the next real bottleneck.`


### PR DESCRIPTION
## Summary
- add a future-role Logistics and Warehouse Manager gameplay playbook under `docs/playbooks`
- define the likely control surface, decision checklist, trigger guidance, and cross-role interactions
- call out the future warehouse and logistics mechanics needed to support the role well

## Why
Issue #109 asks for a practical future-role gameplay playbook that supports design, onboarding, and AI-role prompting.

Closes #109

## Validation
- documentation change only
- CI will run on this PR