### PR TITLE
[codex] Change TUI role navigation bindings

### DIFF
--- a/internal/adapters/tui/action_entry.go
+++ b/internal/adapters/tui/action_entry.go
@@ -65,7 +65,7 @@ type fieldSpec struct {
 }
 
 func (m *Model) handleActionEntryKey(msg tea.KeyMsg) bool {
-	if m.workspace != workspaceActionEntry {
+	if m.workspace != workspaceActionEntry || m.focusedPane != paneHistory {
 		return false
 	}
 

--- a/internal/adapters/tui/live_runtime_test.go
+++ b/internal/adapters/tui/live_runtime_test.go
@@ -478,6 +478,7 @@ func expectPublishedView(t *testing.T, source *liveTestSource, model Model, want
 
 func submitProcurementTurn(t *testing.T, model Model, orders string, commentary string) Model {
 	t.Helper()
+	model.focusedPane = paneHistory
 
 	for _, key := range []tea.KeyMsg{
 		{Type: tea.KeyRunes, Runes: []rune{'1'}},

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -137,10 +137,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.setWorkspace(workspaceRoundFeed)
 		case "5":
 			m.setWorkspace(workspaceHistoryArchive)
-		case "left", "h", "p":
-			m.moveRole(-1)
-		case "right", "l", "n":
-			m.moveRole(1)
+		case "up", "k":
+			if m.focusedPane == paneDepartments {
+				m.moveRole(-1)
+			}
+		case "down", "j":
+			if m.focusedPane == paneDepartments {
+				m.moveRole(1)
+			}
 		}
 		return m, nil
 	case tea.MouseMsg:
@@ -479,7 +483,7 @@ func (m Model) renderCommandBar(width, height int) string {
 	}
 
 	lines := []string{
-		workspaceCommandHints(m.workspace),
+		focusedPaneCommandHints(m.focusedPane, m.workspace),
 		wrapLine(status, paneTextWidth(width)),
 	}
 	return renderPane("Command Bar", lines, width, height, m.focusedPane == paneCommandBar)
@@ -890,20 +894,35 @@ func workspaceNavigationLine(active workspaceMode) string {
 	return "Navigate: " + strings.Join(labels, " | ") + " | [/] cycle"
 }
 
-func workspaceCommandHints(active workspaceMode) string {
-	base := "Inspect mode | tab/shift+tab focus panes | left/right cycle roles | 1/2/3/4/5 switch workspace | [/] cycle | q quit"
+func focusedPaneCommandHints(focusedPane int, active workspaceMode) string {
+	base := "Inspect mode | tab/shift+tab focus panes | 1/2/3/4/5 switch workspace | [/] cycle | q quit"
 
+	switch focusedPane {
+	case paneDepartments:
+		return base + " | departments: up/down select role"
+	case paneHistory:
+		return base + " | center workspace: " + workspaceInteractionHint(active)
+	case paneStats:
+		return base + " | plant stats: read-only summary"
+	case paneCommandBar:
+		return base + " | command bar: status and focused-pane shortcuts"
+	default:
+		return base
+	}
+}
+
+func workspaceInteractionHint(active workspaceMode) string {
 	switch active {
 	case workspaceActionEntry:
-		return base + " | action entry uses up/down to move fields, enter to edit, r review, s submit"
+		return "up/down move fields, enter edit/save, esc cancel, r review, s submit"
 	case workspaceScenarioLookup:
-		return base + " | lookup uses v/r/b/d tabs and up/down to browse scenario data"
+		return "v/r/b/d switch lookup tabs, up/down browse entries"
 	case workspaceRoleReport:
-		return base + " | report shows briefing, company snapshot, and role metrics"
+		return "role report is read-only"
 	case workspaceHistoryArchive:
-		return base + " | up/down/pgup/pgdn/home/end scroll history | archive shows retained round summaries and older history"
+		return "up/down/pgup/pgdn/home/end scroll archive history"
 	default:
-		return base + " | up/down/pgup/pgdn/home/end scroll history | round feed shows current phase plus the most recent resolved rounds"
+		return "up/down/pgup/pgdn/home/end scroll round feed history"
 	}
 }
 

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -130,7 +130,7 @@ func TestModelCyclesRoleSelectionAndPaneFocus(t *testing.T) {
 	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
 	shell := loaded.(Model)
 
-	shifted, _ := shell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	shifted, _ := shell.Update(tea.KeyMsg{Type: tea.KeyDown})
 	shiftedShell := shifted.(Model)
 	if got := shiftedShell.roleTitle(); got != "Production Manager" {
 		t.Fatalf("roleTitle() = %q, want Production Manager", got)
@@ -142,7 +142,13 @@ func TestModelCyclesRoleSelectionAndPaneFocus(t *testing.T) {
 		t.Fatalf("focusedPane = %d, want %d", focusedShell.focusedPane, paneHistory)
 	}
 
-	switched, _ := focusedShell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{']'}})
+	unchanged, _ := focusedShell.Update(tea.KeyMsg{Type: tea.KeyDown})
+	unchangedShell := unchanged.(Model)
+	if got := unchangedShell.roleTitle(); got != "Production Manager" {
+		t.Fatalf("roleTitle() with history focus = %q, want Production Manager", got)
+	}
+
+	switched, _ := unchangedShell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{']'}})
 	switchedShell := switched.(Model)
 	if switchedShell.workspace != workspaceScenarioLookup {
 		t.Fatalf("workspace = %v, want %v", switchedShell.workspace, workspaceScenarioLookup)
@@ -188,6 +194,7 @@ func TestModelRendersScenarioLookupWorkspaceAndSupportsBrowsing(t *testing.T) {
 	shell := loaded.(Model)
 	shell.width = 120
 	shell.height = 32
+	shell.focusedPane = paneHistory
 
 	lookup, _ := shell.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}})
 	shell = lookup.(Model)
@@ -227,6 +234,7 @@ func TestModelSupportsHumanActionDraftReviewAndSubmit(t *testing.T) {
 
 	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
 	shell := loaded.(Model)
+	shell.focusedPane = paneHistory
 
 	for _, key := range []tea.KeyMsg{
 		{Type: tea.KeyEnter},
@@ -292,6 +300,7 @@ func TestModelSubmitForwardsLockedDraftToLiveHook(t *testing.T) {
 
 	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
 	shell := loaded.(Model)
+	shell.focusedPane = paneHistory
 
 	for _, key := range []tea.KeyMsg{
 		{Type: tea.KeyEnter},
@@ -332,6 +341,7 @@ func TestModelAdvancesAcrossHumanRolesAndHidesLockedDrafts(t *testing.T) {
 
 	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
 	shell := loaded.(Model)
+	shell.focusedPane = paneHistory
 
 	for _, key := range []tea.KeyMsg{
 		{Type: tea.KeyEnter},
@@ -401,6 +411,7 @@ func TestModelSwitchesToRoundFeedAfterFinalHumanSubmission(t *testing.T) {
 		},
 	}
 	shell.selectedRole = 2
+	shell.focusedPane = paneHistory
 
 	for _, key := range []tea.KeyMsg{
 		{Type: tea.KeyEnter},
@@ -594,6 +605,40 @@ func TestModelViewFitsWithinTerminalWidth(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCommandBarHintsFollowFocusedPane(t *testing.T) {
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.width = 120
+	shell.height = 32
+
+	departmentsView := shell.View()
+	if !strings.Contains(departmentsView, "departments: up/down") || !strings.Contains(departmentsView, "select role") {
+		t.Fatalf("departments hint missing\n%s", departmentsView)
+	}
+
+	shell.focusedPane = paneHistory
+	historyView := shell.View()
+	if !strings.Contains(historyView, "center workspace: up/down") || !strings.Contains(historyView, "move fields, enter edit/save, esc cancel, r review, s submit") {
+		t.Fatalf("history hint missing action-entry controls\n%s", historyView)
+	}
+
+	shell.workspace = workspaceScenarioLookup
+	lookupView := shell.View()
+	if !strings.Contains(lookupView, "center workspace: v/r/b/d") || !strings.Contains(lookupView, "switch lookup tabs, up/down browse entries") {
+		t.Fatalf("history hint missing lookup controls\n%s", lookupView)
+	}
+
+	shell.focusedPane = paneStats
+	statsView := shell.View()
+	if !strings.Contains(statsView, "plant stats: read-only") || !strings.Contains(statsView, "summary") {
+		t.Fatalf("stats hint missing\n%s", statsView)
 	}
 }
 

--- a/internal/adapters/tui/scenario_lookup.go
+++ b/internal/adapters/tui/scenario_lookup.go
@@ -27,7 +27,7 @@ type lookupBrowserState struct {
 }
 
 func (m *Model) handleScenarioLookupKey(msg tea.KeyMsg) bool {
-	if m.workspace != workspaceScenarioLookup {
+	if m.workspace != workspaceScenarioLookup || m.focusedPane != paneHistory {
 		return false
 	}
 


### PR DESCRIPTION
## Summary
- change role navigation to `up`/`down` only when the `Departments` pane is focused
- gate center-workspace interaction keys on center-pane focus so pane focus matches actual behavior
- update command-bar hints to reflect the bindings available on the currently focused pane

## Why
Fixes #89.

The roles are listed vertically in the left pane, so `up`/`down` is a more natural fit than `left`/`right`. This also leaves horizontal navigation available for future drill-down/back behavior in that pane.

## Validation
- `go test ./internal/adapters/tui`
- `go test ./...`