### PR TITLE
Add cash timing mechanics to starter scenario

### DIFF
--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -782,7 +782,7 @@ func TestModelRoundFeedShowsResolvedStarterHistory(t *testing.T) {
 	for _, want := range []string{
 		"Current phase: revealed round results",
 		"Recent resolved rounds (1 shown)",
-		"[R1] 20 events | 2 commentary",
+		"[R1] 21 events | 2 commentary",
 		"Sales Manager: Holding starter prices while we",
 		"clear inherited backlog.",
 		"Event: Shipped 2 pump to northbuild",

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -76,6 +76,8 @@ type PlantState struct {
 	WIPInventory      []WIPInventory
 	FinishedInventory []FinishedInventory
 	InTransitSupply   []SupplyLot
+	Receivables       []CashCommitment
+	Payables          []CashCommitment
 	Workstations      []WorkstationState
 	Backlog           []BacklogEntry
 }
@@ -108,6 +110,22 @@ type SupplyLot struct {
 	OrderedRound    RoundNumber
 	ArrivalRound    RoundNumber
 }
+
+type CashCommitment struct {
+	CommitmentID string
+	Kind         CashCommitmentKind
+	Amount       Money
+	DueRound     RoundNumber
+	CreatedRound RoundNumber
+	ReferenceID  string
+}
+
+type CashCommitmentKind string
+
+const (
+	CashCommitmentReceivable CashCommitmentKind = "receivable"
+	CashCommitmentPayable    CashCommitmentKind = "payable"
+)
 
 type WorkstationState struct {
 	WorkstationID              WorkstationID
@@ -159,10 +177,14 @@ type PlantMetrics struct {
 	OperatingExpense      Money
 	ProcurementSpend      Money
 	ProductionSpend       Money
+	PayrollExpense        Money
 	HoldingCost           Money
 	DebtServiceCost       Money
 	InventoryValue        Money
 	NetCashChange         Money
+	CashReceipts          Money
+	CashDisbursements     Money
+	EndingCash            Money
 	RoundProfit           Money
 	OnTimeShipmentRate    Percentage
 	BacklogUnits          Units
@@ -327,6 +349,8 @@ type RoundEventType string
 const (
 	EventBudgetActivated        RoundEventType = "budget_activated"
 	EventPurchaseOrderPlaced    RoundEventType = "purchase_order_placed"
+	EventPayableScheduled       RoundEventType = "payable_scheduled"
+	EventPayablePaid            RoundEventType = "payable_paid"
 	EventSupplyArrived          RoundEventType = "supply_arrived"
 	EventProductionReleased     RoundEventType = "production_released"
 	EventWorkstationStressed    RoundEventType = "workstation_stressed"
@@ -334,10 +358,13 @@ const (
 	EventFinishedGoodsProduced  RoundEventType = "finished_goods_produced"
 	EventDemandRealized         RoundEventType = "demand_realized"
 	EventShipmentCompleted      RoundEventType = "shipment_completed"
+	EventReceivableScheduled    RoundEventType = "receivable_scheduled"
+	EventReceivableCollected    RoundEventType = "receivable_collected"
 	EventBacklogCreated         RoundEventType = "backlog_created"
 	EventBacklogExpired         RoundEventType = "backlog_expired"
 	EventCustomerSentimentMoved RoundEventType = "customer_sentiment_moved"
 	EventCashChanged            RoundEventType = "cash_changed"
+	EventPayrollPaid            RoundEventType = "payroll_paid"
 	EventMetricSnapshot         RoundEventType = "metric_snapshot"
 	EventRuleAdjustment         RoundEventType = "rule_adjustment"
 )
@@ -396,6 +423,8 @@ func (s PlantState) Clone() PlantState {
 		WIPInventory:      slices.Clone(s.WIPInventory),
 		FinishedInventory: slices.Clone(s.FinishedInventory),
 		InTransitSupply:   slices.Clone(s.InTransitSupply),
+		Receivables:       slices.Clone(s.Receivables),
+		Payables:          slices.Clone(s.Payables),
 		Workstations:      slices.Clone(s.Workstations),
 		Backlog:           slices.Clone(s.Backlog),
 	}

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -157,10 +157,11 @@ type PartDefinition struct {
 }
 
 type CustomerState struct {
-	CustomerID  CustomerID
-	DisplayName string
-	Sentiment   int
-	Backlog     []BacklogEntry
+	CustomerID         CustomerID
+	DisplayName        string
+	Sentiment          int
+	PaymentDelayRounds int
+	Backlog            []BacklogEntry
 }
 
 type BudgetTargets struct {
@@ -432,10 +433,11 @@ func (s PlantState) Clone() PlantState {
 
 func (s CustomerState) Clone() CustomerState {
 	return CustomerState{
-		CustomerID:  s.CustomerID,
-		DisplayName: s.DisplayName,
-		Sentiment:   s.Sentiment,
-		Backlog:     slices.Clone(s.Backlog),
+		CustomerID:         s.CustomerID,
+		DisplayName:        s.DisplayName,
+		Sentiment:          s.Sentiment,
+		PaymentDelayRounds: s.PaymentDelayRounds,
+		Backlog:            slices.Clone(s.Backlog),
 	}
 }
 

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -13,14 +13,18 @@ import (
 )
 
 type Options struct {
-	HistoryLimit        int
-	BacklogExpiryRounds int
-	ProcurementTerms    ProcurementTermsHook
-	ProductionBOM       ProductionBOMHook
-	ProductionRoute     ProductionRouteHook
-	ProductionCost      ProductionCostHook
-	InventoryCost       InventoryCarryingCostHook
-	WorldUpdate         WorldUpdateHook
+	HistoryLimit          int
+	BacklogExpiryRounds   int
+	ProcurementTerms      ProcurementTermsHook
+	ProductionBOM         ProductionBOMHook
+	ProductionRoute       ProductionRouteHook
+	ProductionCost        ProductionCostHook
+	InventoryCost         InventoryCarryingCostHook
+	ReceivableDelayRounds int
+	PayableDelayRounds    int
+	PayrollCycleRounds    int
+	PayrollPerCycle       domain.Money
+	WorldUpdate           WorldUpdateHook
 }
 
 // ProcurementTermsHook lets scenario data supply part cost, MOQ, and quantity-based pricing rules.
@@ -121,26 +125,34 @@ type Result struct {
 }
 
 type Resolver struct {
-	historyLimit        int
-	backlogExpiryRounds int
-	procurementTerms    ProcurementTermsHook
-	productionBOM       ProductionBOMHook
-	productionRoute     ProductionRouteHook
-	productionCost      ProductionCostHook
-	inventoryCost       InventoryCarryingCostHook
-	worldUpdate         WorldUpdateHook
+	historyLimit          int
+	backlogExpiryRounds   int
+	procurementTerms      ProcurementTermsHook
+	productionBOM         ProductionBOMHook
+	productionRoute       ProductionRouteHook
+	productionCost        ProductionCostHook
+	inventoryCost         InventoryCarryingCostHook
+	receivableDelayRounds int
+	payableDelayRounds    int
+	payrollCycleRounds    int
+	payrollPerCycle       domain.Money
+	worldUpdate           WorldUpdateHook
 }
 
 func NewResolver(options Options) *Resolver {
 	return &Resolver{
-		historyLimit:        normalizedHistoryLimit(options.HistoryLimit),
-		backlogExpiryRounds: normalizedBacklogExpiryRounds(options.BacklogExpiryRounds),
-		procurementTerms:    defaultProcurementTerms(options.ProcurementTerms),
-		productionBOM:       defaultProductionBOM(options.ProductionBOM),
-		productionRoute:     defaultProductionRoute(options.ProductionRoute),
-		productionCost:      defaultProductionCost(options.ProductionCost),
-		inventoryCost:       options.InventoryCost,
-		worldUpdate:         options.WorldUpdate,
+		historyLimit:          normalizedHistoryLimit(options.HistoryLimit),
+		backlogExpiryRounds:   normalizedBacklogExpiryRounds(options.BacklogExpiryRounds),
+		procurementTerms:      defaultProcurementTerms(options.ProcurementTerms),
+		productionBOM:         defaultProductionBOM(options.ProductionBOM),
+		productionRoute:       defaultProductionRoute(options.ProductionRoute),
+		productionCost:        defaultProductionCost(options.ProductionCost),
+		inventoryCost:         options.InventoryCost,
+		receivableDelayRounds: normalizedDelayRounds(options.ReceivableDelayRounds),
+		payableDelayRounds:    normalizedDelayRounds(options.PayableDelayRounds),
+		payrollCycleRounds:    normalizedCycleRounds(options.PayrollCycleRounds),
+		payrollPerCycle:       maxMoney(0, options.PayrollPerCycle),
+		worldUpdate:           options.WorldUpdate,
 	}
 }
 
@@ -167,17 +179,22 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 	}
 
 	phase := roundPhase{
-		state:               &nextState,
-		round:               &round,
-		currentRound:        state.CurrentRound,
-		stats:               &resolutionStats{},
-		backlogExpiryRounds: r.backlogExpiryRounds,
-		procurementTerms:    r.procurementTerms,
-		productionBOM:       r.productionBOM,
-		productionRoute:     r.productionRoute,
-		productionCost:      r.productionCost,
-		inventoryCost:       r.inventoryCost,
-		stressedStations:    map[domain.WorkstationID]bool{},
+		state:                 &nextState,
+		round:                 &round,
+		currentRound:          state.CurrentRound,
+		beginningCash:         state.Plant.Cash,
+		stats:                 &resolutionStats{},
+		backlogExpiryRounds:   r.backlogExpiryRounds,
+		procurementTerms:      r.procurementTerms,
+		productionBOM:         r.productionBOM,
+		productionRoute:       r.productionRoute,
+		productionCost:        r.productionCost,
+		inventoryCost:         r.inventoryCost,
+		receivableDelayRounds: r.receivableDelayRounds,
+		payableDelayRounds:    r.payableDelayRounds,
+		payrollCycleRounds:    r.payrollCycleRounds,
+		payrollPerCycle:       r.payrollPerCycle,
+		stressedStations:      map[domain.WorkstationID]bool{},
 	}
 
 	if nextState.ActiveTargets.EffectiveRound == state.CurrentRound {
@@ -223,29 +240,37 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 }
 
 type roundPhase struct {
-	state               *domain.MatchState
-	round               *domain.RoundRecord
-	currentRound        domain.RoundNumber
-	stats               *resolutionStats
-	backlogExpiryRounds int
-	procurementTerms    ProcurementTermsHook
-	productionBOM       ProductionBOMHook
-	productionRoute     ProductionRouteHook
-	productionCost      ProductionCostHook
-	inventoryCost       InventoryCarryingCostHook
-	eventSeq            int
-	stressedStations    map[domain.WorkstationID]bool
+	state                 *domain.MatchState
+	round                 *domain.RoundRecord
+	currentRound          domain.RoundNumber
+	beginningCash         domain.Money
+	stats                 *resolutionStats
+	backlogExpiryRounds   int
+	procurementTerms      ProcurementTermsHook
+	productionBOM         ProductionBOMHook
+	productionRoute       ProductionRouteHook
+	productionCost        ProductionCostHook
+	inventoryCost         InventoryCarryingCostHook
+	receivableDelayRounds int
+	payableDelayRounds    int
+	payrollCycleRounds    int
+	payrollPerCycle       domain.Money
+	eventSeq              int
+	stressedStations      map[domain.WorkstationID]bool
 }
 
 type resolutionStats struct {
-	revenue          domain.Money
-	procurementSpend domain.Money
-	productionSpend  domain.Money
-	holdingCost      domain.Money
-	debtServiceCost  domain.Money
-	shippedUnits     domain.Units
-	producedUnits    domain.Units
-	lostSalesUnits   domain.Units
+	revenue           domain.Money
+	procurementSpend  domain.Money
+	productionSpend   domain.Money
+	payrollExpense    domain.Money
+	holdingCost       domain.Money
+	debtServiceCost   domain.Money
+	shippedUnits      domain.Units
+	producedUnits     domain.Units
+	lostSalesUnits    domain.Units
+	cashReceipts      domain.Money
+	cashDisbursements domain.Money
 }
 
 func (p *roundPhase) resolveProcurement(action *domain.ActionSubmission) {
@@ -337,12 +362,7 @@ func (p *roundPhase) resolveProcurement(action *domain.ActionSubmission) {
 	}
 
 	if spendUsed > 0 {
-		p.applyCashDelta(-spendUsed)
-		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Procurement spending applied", map[string]any{
-			"delta": -int(spendUsed),
-			"cash":  int(p.state.Plant.Cash),
-			"debt":  int(p.state.Plant.Debt),
-		})
+		p.schedulePayable(spendUsed, fmt.Sprintf("procurement-r%d", p.currentRound))
 	}
 }
 
@@ -560,6 +580,7 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 
 	if spendUsed > 0 {
 		p.applyCashDelta(-spendUsed)
+		p.stats.cashDisbursements += spendUsed
 		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Production spending applied", map[string]any{
 			"delta": -int(spendUsed),
 			"cash":  int(p.state.Plant.Cash),
@@ -609,7 +630,7 @@ func (p *roundPhase) resolveSales(action *domain.ActionSubmission) {
 			revenue := domain.Money(shipped) * unitPrice
 			p.stats.revenue += revenue
 			p.stats.shippedUnits += shipped
-			p.applyCashDelta(revenue)
+			p.scheduleReceivable(revenue, fmt.Sprintf("%s-%s-r%d", entry.CustomerID, entry.ProductID, p.currentRound))
 
 			p.appendEvent(domain.EventShipmentCompleted, domain.ActorPlantSystem, fmt.Sprintf("Shipped %d %s to %s", shipped, entry.ProductID, entry.CustomerID), map[string]any{
 				"customer_id": string(entry.CustomerID),
@@ -622,14 +643,6 @@ func (p *roundPhase) resolveSales(action *domain.ActionSubmission) {
 		if entry.Quantity > 0 {
 			remaining = append(remaining, entry)
 		}
-	}
-
-	if p.stats.revenue > 0 {
-		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Shipment revenue applied", map[string]any{
-			"delta": int(p.stats.revenue),
-			"cash":  int(p.state.Plant.Cash),
-			"debt":  int(p.state.Plant.Debt),
-		})
 	}
 
 	p.state.Plant.Backlog = remaining
@@ -669,6 +682,10 @@ func (p *roundPhase) finalizeRound(action *domain.ActionSubmission) {
 		p.state.ActiveTargets = targets
 		p.state.Plant.DebtCeiling = targets.DebtCeilingTarget
 	}
+
+	p.collectReceivablesDue()
+	p.payPayablesDue()
+	p.applyPayrollIfDue()
 
 	holdingCost, debtCost := p.applyRoundOperatingCosts()
 	p.stats.holdingCost = holdingCost
@@ -715,8 +732,8 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 		capacityLossUnits += domain.Units(workstation.StressCapacityLoss)
 	}
 
-	operatingExpense := p.stats.procurementSpend + p.stats.productionSpend + p.stats.holdingCost + p.stats.debtServiceCost
-	netCashChange := p.stats.revenue - operatingExpense
+	operatingExpense := p.stats.procurementSpend + p.stats.productionSpend + p.stats.payrollExpense + p.stats.holdingCost + p.stats.debtServiceCost
+	netCashChange := p.state.Plant.Cash - p.beginningCash
 	demandUnits := p.stats.shippedUnits + backlogUnits + p.stats.lostSalesUnits
 	onTime := domain.Percentage(100)
 	if demandUnits > 0 {
@@ -728,10 +745,14 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 		OperatingExpense:      operatingExpense,
 		ProcurementSpend:      p.stats.procurementSpend,
 		ProductionSpend:       p.stats.productionSpend,
+		PayrollExpense:        p.stats.payrollExpense,
 		HoldingCost:           p.stats.holdingCost,
 		DebtServiceCost:       p.stats.debtServiceCost,
 		InventoryValue:        inventoryValue,
 		NetCashChange:         netCashChange,
+		CashReceipts:          p.stats.cashReceipts,
+		CashDisbursements:     p.stats.cashDisbursements,
+		EndingCash:            p.state.Plant.Cash,
 		RoundProfit:           p.stats.revenue - operatingExpense,
 		OnTimeShipmentRate:    onTime,
 		BacklogUnits:          backlogUnits,
@@ -782,6 +803,7 @@ func (p *roundPhase) applyRoundOperatingCosts() (domain.Money, domain.Money) {
 	total := holdingCost + debtCost
 	if total > 0 {
 		p.applyCashDelta(-total)
+		p.stats.cashDisbursements += total
 		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Round-end carrying costs applied", map[string]any{
 			"delta":             -int(total),
 			"cash":              int(p.state.Plant.Cash),
@@ -792,6 +814,164 @@ func (p *roundPhase) applyRoundOperatingCosts() (domain.Money, domain.Money) {
 	}
 
 	return holdingCost, debtCost
+}
+
+func (p *roundPhase) collectReceivablesDue() {
+	if len(p.state.Plant.Receivables) == 0 {
+		return
+	}
+
+	due := make([]domain.CashCommitment, 0, len(p.state.Plant.Receivables))
+	remaining := make([]domain.CashCommitment, 0, len(p.state.Plant.Receivables))
+	for _, item := range p.state.Plant.Receivables {
+		if item.DueRound <= p.currentRound {
+			due = append(due, item)
+			continue
+		}
+		remaining = append(remaining, item)
+	}
+	p.state.Plant.Receivables = remaining
+
+	collected := sumCommitments(due)
+	for _, item := range due {
+		p.applyCashDelta(item.Amount)
+		p.appendEvent(domain.EventReceivableCollected, domain.ActorPlantSystem, "Collected customer receivable", map[string]any{
+			"commitment_id": item.CommitmentID,
+			"amount":        int(item.Amount),
+			"due_round":     int(item.DueRound),
+			"cash":          int(p.state.Plant.Cash),
+			"debt":          int(p.state.Plant.Debt),
+		})
+	}
+	if collected > 0 {
+		p.stats.cashReceipts += collected
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Customer receipts collected", map[string]any{
+			"delta": int(collected),
+			"cash":  int(p.state.Plant.Cash),
+			"debt":  int(p.state.Plant.Debt),
+		})
+	}
+}
+
+func (p *roundPhase) payPayablesDue() {
+	if len(p.state.Plant.Payables) == 0 {
+		return
+	}
+
+	due := make([]domain.CashCommitment, 0, len(p.state.Plant.Payables))
+	remaining := make([]domain.CashCommitment, 0, len(p.state.Plant.Payables))
+	for _, item := range p.state.Plant.Payables {
+		if item.DueRound <= p.currentRound {
+			due = append(due, item)
+			continue
+		}
+		remaining = append(remaining, item)
+	}
+	p.state.Plant.Payables = remaining
+
+	disbursed := sumCommitments(due)
+	for _, item := range due {
+		p.applyCashDelta(-item.Amount)
+		p.appendEvent(domain.EventPayablePaid, domain.ActorPlantSystem, "Paid supplier payable", map[string]any{
+			"commitment_id": item.CommitmentID,
+			"amount":        int(item.Amount),
+			"due_round":     int(item.DueRound),
+			"cash":          int(p.state.Plant.Cash),
+			"debt":          int(p.state.Plant.Debt),
+		})
+	}
+	if disbursed > 0 {
+		p.stats.cashDisbursements += disbursed
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Supplier payments applied", map[string]any{
+			"delta": -int(disbursed),
+			"cash":  int(p.state.Plant.Cash),
+			"debt":  int(p.state.Plant.Debt),
+		})
+	}
+}
+
+func (p *roundPhase) applyPayrollIfDue() {
+	if p.payrollCycleRounds <= 0 || p.payrollPerCycle <= 0 || int(p.currentRound)%p.payrollCycleRounds != 0 {
+		return
+	}
+
+	p.applyCashDelta(-p.payrollPerCycle)
+	p.stats.payrollExpense += p.payrollPerCycle
+	p.stats.cashDisbursements += p.payrollPerCycle
+	p.appendEvent(domain.EventPayrollPaid, domain.ActorPlantSystem, "Payroll cadence applied", map[string]any{
+		"amount": int(p.payrollPerCycle),
+		"cash":   int(p.state.Plant.Cash),
+		"debt":   int(p.state.Plant.Debt),
+	})
+	p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Payroll cash applied", map[string]any{
+		"delta": -int(p.payrollPerCycle),
+		"cash":  int(p.state.Plant.Cash),
+		"debt":  int(p.state.Plant.Debt),
+	})
+}
+
+func (p *roundPhase) scheduleReceivable(amount domain.Money, referenceID string) {
+	if amount <= 0 {
+		return
+	}
+	if p.receivableDelayRounds == 0 {
+		p.applyCashDelta(amount)
+		p.stats.cashReceipts += amount
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Shipment revenue applied", map[string]any{
+			"delta": int(amount),
+			"cash":  int(p.state.Plant.Cash),
+			"debt":  int(p.state.Plant.Debt),
+		})
+		return
+	}
+
+	item := domain.CashCommitment{
+		CommitmentID: fmt.Sprintf("ar-r%d-%d", p.currentRound, len(p.state.Plant.Receivables)+1),
+		Kind:         domain.CashCommitmentReceivable,
+		Amount:       amount,
+		DueRound:     p.currentRound + domain.RoundNumber(p.receivableDelayRounds),
+		CreatedRound: p.currentRound,
+		ReferenceID:  referenceID,
+	}
+	p.state.Plant.Receivables = append(p.state.Plant.Receivables, item)
+	p.appendEvent(domain.EventReceivableScheduled, domain.ActorPlantSystem, "Scheduled customer receivable", map[string]any{
+		"commitment_id": item.CommitmentID,
+		"amount":        int(item.Amount),
+		"due_round":     int(item.DueRound),
+		"reference_id":  item.ReferenceID,
+	})
+}
+
+func (p *roundPhase) schedulePayable(amount domain.Money, referenceID string) {
+	if amount <= 0 {
+		return
+	}
+	if p.payableDelayRounds == 0 {
+		p.applyCashDelta(-amount)
+		p.stats.cashDisbursements += amount
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Procurement spending applied", map[string]any{
+			"delta": -int(amount),
+			"cash":  int(p.state.Plant.Cash),
+			"debt":  int(p.state.Plant.Debt),
+		})
+		return
+	}
+
+	item := domain.CashCommitment{
+		CommitmentID: fmt.Sprintf("ap-r%d-%d", p.currentRound, len(p.state.Plant.Payables)+1),
+		Kind:         domain.CashCommitmentPayable,
+		Amount:       amount,
+		DueRound:     p.currentRound + domain.RoundNumber(p.payableDelayRounds),
+		CreatedRound: p.currentRound,
+		ReferenceID:  referenceID,
+	}
+	p.state.Plant.Payables = append(p.state.Plant.Payables, item)
+	p.appendEvent(domain.EventPayableScheduled, domain.ActorPlantSystem, "Scheduled supplier payable", map[string]any{
+		"commitment_id": item.CommitmentID,
+		"amount":        int(item.Amount),
+		"due_round":     int(item.DueRound),
+		"reference_id":  item.ReferenceID,
+	})
 }
 
 func (p *roundPhase) syncCustomerBacklog(backlog []domain.BacklogEntry) {
@@ -1403,6 +1583,20 @@ func normalizedBacklogExpiryRounds(rounds int) int {
 	return rounds
 }
 
+func normalizedDelayRounds(rounds int) int {
+	if rounds < 0 {
+		return 0
+	}
+	return rounds
+}
+
+func normalizedCycleRounds(rounds int) int {
+	if rounds <= 0 {
+		return 0
+	}
+	return rounds
+}
+
 func minUnits(values ...domain.Units) domain.Units {
 	result := values[0]
 	for _, value := range values[1:] {
@@ -1504,4 +1698,19 @@ func minMoney(values ...domain.Money) domain.Money {
 		}
 	}
 	return result
+}
+
+func maxMoney(left, right domain.Money) domain.Money {
+	if left > right {
+		return left
+	}
+	return right
+}
+
+func sumCommitments(items []domain.CashCommitment) domain.Money {
+	total := domain.Money(0)
+	for _, item := range items {
+		total += item.Amount
+	}
+	return total
 }

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -22,8 +22,6 @@ type Options struct {
 	InventoryCost         InventoryCarryingCostHook
 	ReceivableDelayRounds int
 	PayableDelayRounds    int
-	PayrollCycleRounds    int
-	PayrollPerCycle       domain.Money
 	WorldUpdate           WorldUpdateHook
 }
 
@@ -134,8 +132,6 @@ type Resolver struct {
 	inventoryCost         InventoryCarryingCostHook
 	receivableDelayRounds int
 	payableDelayRounds    int
-	payrollCycleRounds    int
-	payrollPerCycle       domain.Money
 	worldUpdate           WorldUpdateHook
 }
 
@@ -150,8 +146,6 @@ func NewResolver(options Options) *Resolver {
 		inventoryCost:         options.InventoryCost,
 		receivableDelayRounds: normalizedDelayRounds(options.ReceivableDelayRounds),
 		payableDelayRounds:    normalizedDelayRounds(options.PayableDelayRounds),
-		payrollCycleRounds:    normalizedCycleRounds(options.PayrollCycleRounds),
-		payrollPerCycle:       maxMoney(0, options.PayrollPerCycle),
 		worldUpdate:           options.WorldUpdate,
 	}
 }
@@ -192,8 +186,6 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 		inventoryCost:         r.inventoryCost,
 		receivableDelayRounds: r.receivableDelayRounds,
 		payableDelayRounds:    r.payableDelayRounds,
-		payrollCycleRounds:    r.payrollCycleRounds,
-		payrollPerCycle:       r.payrollPerCycle,
 		stressedStations:      map[domain.WorkstationID]bool{},
 	}
 
@@ -253,8 +245,6 @@ type roundPhase struct {
 	inventoryCost         InventoryCarryingCostHook
 	receivableDelayRounds int
 	payableDelayRounds    int
-	payrollCycleRounds    int
-	payrollPerCycle       domain.Money
 	eventSeq              int
 	stressedStations      map[domain.WorkstationID]bool
 }
@@ -308,7 +298,7 @@ func (p *roundPhase) resolveProcurement(action *domain.ActionSubmission) {
 			}
 		}
 
-		affordable := availableSpendCapacity(p.state.Plant)
+		affordable := availableProjectedSpendCapacity(p.state.Plant)
 		if spendForQuantity(allowed, terms.UnitCost) > affordable {
 			allowed = affordableQuantity(affordable, terms.UnitCost)
 		}
@@ -630,7 +620,7 @@ func (p *roundPhase) resolveSales(action *domain.ActionSubmission) {
 			revenue := domain.Money(shipped) * unitPrice
 			p.stats.revenue += revenue
 			p.stats.shippedUnits += shipped
-			p.scheduleReceivable(revenue, fmt.Sprintf("%s-%s-r%d", entry.CustomerID, entry.ProductID, p.currentRound))
+			p.scheduleReceivable(revenue, fmt.Sprintf("%s-%s-r%d", entry.CustomerID, entry.ProductID, p.currentRound), p.customerPaymentDelay(entry.CustomerID))
 
 			p.appendEvent(domain.EventShipmentCompleted, domain.ActorPlantSystem, fmt.Sprintf("Shipped %d %s to %s", shipped, entry.ProductID, entry.CustomerID), map[string]any{
 				"customer_id": string(entry.CustomerID),
@@ -685,7 +675,6 @@ func (p *roundPhase) finalizeRound(action *domain.ActionSubmission) {
 
 	p.collectReceivablesDue()
 	p.payPayablesDue()
-	p.applyPayrollIfDue()
 
 	holdingCost, debtCost := p.applyRoundOperatingCosts()
 	p.stats.holdingCost = holdingCost
@@ -890,31 +879,12 @@ func (p *roundPhase) payPayablesDue() {
 	}
 }
 
-func (p *roundPhase) applyPayrollIfDue() {
-	if p.payrollCycleRounds <= 0 || p.payrollPerCycle <= 0 || int(p.currentRound)%p.payrollCycleRounds != 0 {
-		return
-	}
-
-	p.applyCashDelta(-p.payrollPerCycle)
-	p.stats.payrollExpense += p.payrollPerCycle
-	p.stats.cashDisbursements += p.payrollPerCycle
-	p.appendEvent(domain.EventPayrollPaid, domain.ActorPlantSystem, "Payroll cadence applied", map[string]any{
-		"amount": int(p.payrollPerCycle),
-		"cash":   int(p.state.Plant.Cash),
-		"debt":   int(p.state.Plant.Debt),
-	})
-	p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Payroll cash applied", map[string]any{
-		"delta": -int(p.payrollPerCycle),
-		"cash":  int(p.state.Plant.Cash),
-		"debt":  int(p.state.Plant.Debt),
-	})
-}
-
-func (p *roundPhase) scheduleReceivable(amount domain.Money, referenceID string) {
+func (p *roundPhase) scheduleReceivable(amount domain.Money, referenceID string, delayRounds int) {
 	if amount <= 0 {
 		return
 	}
-	if p.receivableDelayRounds == 0 {
+	delayRounds = max(0, delayRounds)
+	if delayRounds == 0 {
 		p.applyCashDelta(amount)
 		p.stats.cashReceipts += amount
 		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Shipment revenue applied", map[string]any{
@@ -929,7 +899,7 @@ func (p *roundPhase) scheduleReceivable(amount domain.Money, referenceID string)
 		CommitmentID: fmt.Sprintf("ar-r%d-%d", p.currentRound, len(p.state.Plant.Receivables)+1),
 		Kind:         domain.CashCommitmentReceivable,
 		Amount:       amount,
-		DueRound:     p.currentRound + domain.RoundNumber(p.receivableDelayRounds),
+		DueRound:     p.currentRound + domain.RoundNumber(delayRounds),
 		CreatedRound: p.currentRound,
 		ReferenceID:  referenceID,
 	}
@@ -940,6 +910,14 @@ func (p *roundPhase) scheduleReceivable(amount domain.Money, referenceID string)
 		"due_round":     int(item.DueRound),
 		"reference_id":  item.ReferenceID,
 	})
+}
+
+func (p *roundPhase) customerPaymentDelay(customerID domain.CustomerID) int {
+	customer := findCustomer(p.state.Customers, customerID)
+	if customer == nil || customer.PaymentDelayRounds <= 0 {
+		return p.receivableDelayRounds
+	}
+	return customer.PaymentDelayRounds
 }
 
 func (p *roundPhase) schedulePayable(amount domain.Money, referenceID string) {
@@ -1296,6 +1274,48 @@ func availableSpendCapacity(plant domain.PlantState) domain.Money {
 	return plant.Cash + max(plant.DebtCeiling-plant.Debt, 0)
 }
 
+func availableProjectedSpendCapacity(plant domain.PlantState) domain.Money {
+	projectedCash, projectedDebt := projectedPlantPositionAfterCommitments(plant)
+	if plant.DebtCeiling <= 0 {
+		return max(projectedCash, 0)
+	}
+	return max(projectedCash, 0) + max(plant.DebtCeiling-projectedDebt, 0)
+}
+
+func projectedPlantPositionAfterCommitments(plant domain.PlantState) (domain.Money, domain.Money) {
+	projectedCash := plant.Cash
+	projectedDebt := plant.Debt
+
+	for _, item := range plant.Payables {
+		projectedCash, projectedDebt = projectCashDelta(projectedCash, projectedDebt, -item.Amount)
+	}
+	for _, item := range plant.Receivables {
+		projectedCash, projectedDebt = projectCashDelta(projectedCash, projectedDebt, item.Amount)
+	}
+
+	return projectedCash, projectedDebt
+}
+
+func projectCashDelta(cash, debt, delta domain.Money) (domain.Money, domain.Money) {
+	if delta == 0 {
+		return cash, debt
+	}
+	if delta > 0 {
+		paydown := minMoney(delta, debt)
+		debt -= paydown
+		cash += delta - paydown
+		return cash, debt
+	}
+
+	spend := -delta
+	if cash >= spend {
+		return cash - spend, debt
+	}
+
+	deficit := spend - cash
+	return 0, debt + deficit
+}
+
 func cappedBudget(target domain.Money) domain.Money {
 	if target <= 0 {
 		return 0
@@ -1590,13 +1610,6 @@ func normalizedDelayRounds(rounds int) int {
 	return rounds
 }
 
-func normalizedCycleRounds(rounds int) int {
-	if rounds <= 0 {
-		return 0
-	}
-	return rounds
-}
-
 func minUnits(values ...domain.Units) domain.Units {
 	result := values[0]
 	for _, value := range values[1:] {
@@ -1698,13 +1711,6 @@ func minMoney(values ...domain.Money) domain.Money {
 		}
 	}
 	return result
-}
-
-func maxMoney(left, right domain.Money) domain.Money {
-	if left > right {
-		return left
-	}
-	return right
 }
 
 func sumCommitments(items []domain.CashCommitment) domain.Money {

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -638,22 +638,33 @@ func TestResolverTracksLostSalesAndDebtServiceInMetrics(t *testing.T) {
 	}
 }
 
-func TestResolverSchedulesReceivablesPayablesAndPayrollTiming(t *testing.T) {
+func TestResolverSchedulesReceivablesPayablesAndUsesProjectedDebtCapacity(t *testing.T) {
 	resolver := engine.NewResolver(engine.Options{
 		ProductionBOM:         widgetBOM,
 		ReceivableDelayRounds: 1,
 		PayableDelayRounds:    1,
-		PayrollCycleRounds:    2,
-		PayrollPerCycle:       5,
 	})
 
-	result, err := resolver.ResolveRound(fixtureState(), fixtureActions(), seeded.New(7))
+	state := fixtureState()
+	state.Customers[0].PaymentDelayRounds = 2
+	state.Plant.Payables = []domain.CashCommitment{
+		{
+			CommitmentID: "ap-1",
+			Kind:         domain.CashCommitmentPayable,
+			Amount:       12,
+			DueRound:     3,
+			CreatedRound: 2,
+			ReferenceID:  "legacy-procurement",
+		},
+	}
+
+	result, err := resolver.ResolveRound(state, fixtureActions(), seeded.New(7))
 	if err != nil {
 		t.Fatalf("ResolveRound() error = %v", err)
 	}
 
-	if got := result.NextState.Plant.Cash; got != 0 {
-		t.Fatalf("Plant.Cash = %d, want 0", got)
+	if got := result.NextState.Plant.Cash; got != 5 {
+		t.Fatalf("Plant.Cash = %d, want 5", got)
 	}
 	if got := result.NextState.Plant.Debt; got != 0 {
 		t.Fatalf("Plant.Debt = %d, want 0", got)
@@ -661,29 +672,32 @@ func TestResolverSchedulesReceivablesPayablesAndPayrollTiming(t *testing.T) {
 	if got := len(result.NextState.Plant.Receivables); got != 1 {
 		t.Fatalf("Receivables len = %d, want 1", got)
 	}
-	if got := len(result.NextState.Plant.Payables); got != 1 {
-		t.Fatalf("Payables len = %d, want 1", got)
+	if got := len(result.NextState.Plant.Payables); got != 2 {
+		t.Fatalf("Payables len = %d, want 2", got)
 	}
-	if got := result.NextState.Plant.Receivables[0].DueRound; got != 3 {
-		t.Fatalf("Receivable due round = %d, want 3", got)
+	if got := result.NextState.Plant.Receivables[0].DueRound; got != 4 {
+		t.Fatalf("Customer-specific receivable due round = %d, want 4", got)
 	}
-	if got := result.NextState.Plant.Payables[0].DueRound; got != 3 {
-		t.Fatalf("Payable due round = %d, want 3", got)
+	if got := result.NextState.Plant.Payables[1].DueRound; got != 3 {
+		t.Fatalf("Scheduled payable due round = %d, want 3", got)
 	}
-	if got := result.Round.Metrics.PayrollExpense; got != 5 {
-		t.Fatalf("PayrollExpense = %d, want 5", got)
+	if got := result.NextState.Plant.Payables[1].Amount; got != 3 {
+		t.Fatalf("Trimmed payable amount = %d, want 3", got)
 	}
 	if got := result.Round.Metrics.CashReceipts; got != 0 {
 		t.Fatalf("CashReceipts = %d, want 0", got)
 	}
-	if got := result.Round.Metrics.CashDisbursements; got != 10 {
-		t.Fatalf("CashDisbursements = %d, want 10", got)
+	if got := result.Round.Metrics.CashDisbursements; got != 5 {
+		t.Fatalf("CashDisbursements = %d, want 5", got)
 	}
-	if got := result.Round.Metrics.NetCashChange; got != -10 {
-		t.Fatalf("NetCashChange = %d, want -10", got)
+	if got := result.Round.Metrics.NetCashChange; got != -5 {
+		t.Fatalf("NetCashChange = %d, want -5", got)
 	}
-	if got := result.Round.Metrics.RoundProfit; got != 4 {
-		t.Fatalf("RoundProfit = %d, want 4", got)
+	if got := result.Round.Metrics.PayrollExpense; got != 0 {
+		t.Fatalf("PayrollExpense = %d, want 0", got)
+	}
+	if got := result.Round.Metrics.RoundProfit; got != 10 {
+		t.Fatalf("RoundProfit = %d, want 10", got)
 	}
 }
 

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -638,6 +638,55 @@ func TestResolverTracksLostSalesAndDebtServiceInMetrics(t *testing.T) {
 	}
 }
 
+func TestResolverSchedulesReceivablesPayablesAndPayrollTiming(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		ProductionBOM:         widgetBOM,
+		ReceivableDelayRounds: 1,
+		PayableDelayRounds:    1,
+		PayrollCycleRounds:    2,
+		PayrollPerCycle:       5,
+	})
+
+	result, err := resolver.ResolveRound(fixtureState(), fixtureActions(), seeded.New(7))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.NextState.Plant.Cash; got != 0 {
+		t.Fatalf("Plant.Cash = %d, want 0", got)
+	}
+	if got := result.NextState.Plant.Debt; got != 0 {
+		t.Fatalf("Plant.Debt = %d, want 0", got)
+	}
+	if got := len(result.NextState.Plant.Receivables); got != 1 {
+		t.Fatalf("Receivables len = %d, want 1", got)
+	}
+	if got := len(result.NextState.Plant.Payables); got != 1 {
+		t.Fatalf("Payables len = %d, want 1", got)
+	}
+	if got := result.NextState.Plant.Receivables[0].DueRound; got != 3 {
+		t.Fatalf("Receivable due round = %d, want 3", got)
+	}
+	if got := result.NextState.Plant.Payables[0].DueRound; got != 3 {
+		t.Fatalf("Payable due round = %d, want 3", got)
+	}
+	if got := result.Round.Metrics.PayrollExpense; got != 5 {
+		t.Fatalf("PayrollExpense = %d, want 5", got)
+	}
+	if got := result.Round.Metrics.CashReceipts; got != 0 {
+		t.Fatalf("CashReceipts = %d, want 0", got)
+	}
+	if got := result.Round.Metrics.CashDisbursements; got != 10 {
+		t.Fatalf("CashDisbursements = %d, want 10", got)
+	}
+	if got := result.Round.Metrics.NetCashChange; got != -10 {
+		t.Fatalf("NetCashChange = %d, want -10", got)
+	}
+	if got := result.Round.Metrics.RoundProfit; got != 4 {
+		t.Fatalf("RoundProfit = %d, want 4", got)
+	}
+}
+
 func TestResolverUsesConfiguredBacklogExpiryRounds(t *testing.T) {
 	resolver := engine.NewResolver(engine.Options{
 		BacklogExpiryRounds: 3,

--- a/internal/projection/role_report.go
+++ b/internal/projection/role_report.go
@@ -78,10 +78,14 @@ func buildDepartmentPerformanceReport(state domain.MatchState, viewerRoleID doma
 			KeyMetrics: []domain.MetricValue{
 				{MetricID: "margin", Value: int(state.Metrics.RoundProfit), DisplayUnit: "money"},
 				{MetricID: "cash_position", Value: int(state.Plant.Cash), DisplayUnit: "money"},
+				{MetricID: "cash_receipts", Value: int(state.Metrics.CashReceipts), DisplayUnit: "money"},
+				{MetricID: "cash_disbursements", Value: int(state.Metrics.CashDisbursements), DisplayUnit: "money"},
 			},
 			DetailLines: []string{
 				fmt.Sprintf("Current cash is %d against debt ceiling %d.", state.Plant.Cash, state.Plant.DebtCeiling),
 				fmt.Sprintf("Round profit most recently closed at %d.", state.Metrics.RoundProfit),
+				fmt.Sprintf("Open receivables total %d, with %d due next round.", sumCommitmentAmount(state.Plant.Receivables), sumCommitmentsDue(state.Plant.Receivables, state.CurrentRound)),
+				fmt.Sprintf("Open payables total %d, with %d due next round.", sumCommitmentAmount(state.Plant.Payables), sumCommitmentsDue(state.Plant.Payables, state.CurrentRound)),
 			},
 			BonusSummary: bonusReminder(viewerRoleID),
 		}
@@ -265,6 +269,24 @@ func stressSummaryLine(items []domain.WorkstationState) string {
 		return "No workstation lost effective capacity to congestion last round."
 	}
 	return fmt.Sprintf("%s lost %d unit(s) of effective capacity and closed at %d/%d.", worst.DisplayName, worst.StressCapacityLoss, worst.EffectiveCapacityPerRound, worst.CapacityPerRound)
+}
+
+func sumCommitmentAmount(items []domain.CashCommitment) domain.Money {
+	total := domain.Money(0)
+	for _, item := range items {
+		total += item.Amount
+	}
+	return total
+}
+
+func sumCommitmentsDue(items []domain.CashCommitment, round domain.RoundNumber) domain.Money {
+	total := domain.Money(0)
+	for _, item := range items {
+		if item.DueRound == round {
+			total += item.Amount
+		}
+	}
+	return total
 }
 
 func inventoryBucketTotal(items []domain.PartInventory) domain.Money {

--- a/internal/projection/role_report.go
+++ b/internal/projection/role_report.go
@@ -73,6 +73,7 @@ func buildDepartmentPerformanceReport(state domain.MatchState, viewerRoleID doma
 			BonusSummary: bonusReminder(viewerRoleID),
 		}
 	case domain.RoleFinanceController:
+		projectedCash, projectedDebt := projectedPositionAfterCommitments(state.Plant)
 		return domain.DepartmentPerformanceReport{
 			RoleID: viewerRoleID,
 			KeyMetrics: []domain.MetricValue{
@@ -84,6 +85,8 @@ func buildDepartmentPerformanceReport(state domain.MatchState, viewerRoleID doma
 			DetailLines: []string{
 				fmt.Sprintf("Current cash is %d against debt ceiling %d.", state.Plant.Cash, state.Plant.DebtCeiling),
 				fmt.Sprintf("Round profit most recently closed at %d.", state.Metrics.RoundProfit),
+				fmt.Sprintf("Projected cash after all open commitments is %d with projected debt %d.", projectedCash, projectedDebt),
+				fmt.Sprintf("Next-round maturities net to %d (%d receivable, %d payable).", nextRoundNetCash(state.Plant, state.CurrentRound), sumCommitmentsDue(state.Plant.Receivables, state.CurrentRound), sumCommitmentsDue(state.Plant.Payables, state.CurrentRound)),
 				fmt.Sprintf("Open receivables total %d, with %d due next round.", sumCommitmentAmount(state.Plant.Receivables), sumCommitmentsDue(state.Plant.Receivables, state.CurrentRound)),
 				fmt.Sprintf("Open payables total %d, with %d due next round.", sumCommitmentAmount(state.Plant.Payables), sumCommitmentsDue(state.Plant.Payables, state.CurrentRound)),
 			},
@@ -289,6 +292,43 @@ func sumCommitmentsDue(items []domain.CashCommitment, round domain.RoundNumber) 
 	return total
 }
 
+func nextRoundNetCash(plant domain.PlantState, round domain.RoundNumber) domain.Money {
+	return sumCommitmentsDue(plant.Receivables, round) - sumCommitmentsDue(plant.Payables, round)
+}
+
+func projectedPositionAfterCommitments(plant domain.PlantState) (domain.Money, domain.Money) {
+	cash := plant.Cash
+	debt := plant.Debt
+
+	for _, item := range plant.Payables {
+		cash, debt = applyProjectedCashDelta(cash, debt, -item.Amount)
+	}
+	for _, item := range plant.Receivables {
+		cash, debt = applyProjectedCashDelta(cash, debt, item.Amount)
+	}
+
+	return cash, debt
+}
+
+func applyProjectedCashDelta(cash, debt, delta domain.Money) (domain.Money, domain.Money) {
+	if delta == 0 {
+		return cash, debt
+	}
+	if delta > 0 {
+		paydown := minMoney(delta, debt)
+		debt -= paydown
+		cash += delta - paydown
+		return cash, debt
+	}
+
+	spend := -delta
+	if cash >= spend {
+		return cash - spend, debt
+	}
+
+	return 0, debt + (spend - cash)
+}
+
 func inventoryBucketTotal(items []domain.PartInventory) domain.Money {
 	total := domain.Money(0)
 	for _, item := range items {
@@ -335,4 +375,11 @@ func financialValues(items map[domain.ProductID]domain.ProductFinancialSummary) 
 		values = append(values, item)
 	}
 	return values
+}
+
+func minMoney(left, right domain.Money) domain.Money {
+	if left < right {
+		return left
+	}
+	return right
 }

--- a/internal/projection/role_report_test.go
+++ b/internal/projection/role_report_test.go
@@ -1,0 +1,43 @@
+package projection_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/projection"
+)
+
+func TestFinanceReportIncludesProjectedCashView(t *testing.T) {
+	state := domain.MatchState{
+		CurrentRound: 4,
+		Plant: domain.PlantState{
+			Cash:        6,
+			Debt:        2,
+			DebtCeiling: 12,
+			Receivables: []domain.CashCommitment{
+				{CommitmentID: "ar-1", Amount: 5, DueRound: 4},
+				{CommitmentID: "ar-2", Amount: 4, DueRound: 5},
+			},
+			Payables: []domain.CashCommitment{
+				{CommitmentID: "ap-1", Amount: 3, DueRound: 4},
+				{CommitmentID: "ap-2", Amount: 7, DueRound: 6},
+			},
+		},
+		Metrics: domain.PlantMetrics{
+			RoundProfit:       11,
+			CashReceipts:      5,
+			CashDisbursements: 3,
+		},
+	}
+
+	report := projection.BuildRoleRoundReport(state, domain.RoleFinanceController)
+	details := strings.Join(report.Department.DetailLines, "\n")
+
+	if !strings.Contains(details, "Projected cash after all open commitments is 3 with projected debt 0.") {
+		t.Fatalf("finance detail lines missing projected position: %q", details)
+	}
+	if !strings.Contains(details, "Next-round maturities net to 2 (5 receivable, 3 payable).") {
+		t.Fatalf("finance detail lines missing maturity summary: %q", details)
+	}
+}

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -17,6 +17,7 @@ type Definition struct {
 	StartingConditions  StartingConditions
 	MarketModel         MarketModel
 	ProductionModel     ProductionModel
+	FinanceModel        FinanceModel
 	DefaultHistoryLimit int
 }
 
@@ -100,11 +101,21 @@ type BottleneckAssumption struct {
 	Summary       string
 }
 
+type FinanceModel struct {
+	ID                    string
+	DisplayName           string
+	Description           string
+	ReceivableDelayRounds int
+	PayableDelayRounds    int
+	PayrollCycleRounds    int
+	PayrollPerCycle       domain.Money
+}
+
 type DemandAssumptions struct {
 	BacklogExpiryRounds int
 }
 
-func NewDefinition(id domain.ScenarioID, displayName, description string, setup MatchSetup, starting StartingConditions, market MarketModel, production ProductionModel) Definition {
+func NewDefinition(id domain.ScenarioID, displayName, description string, setup MatchSetup, starting StartingConditions, market MarketModel, production ProductionModel, finance FinanceModel) Definition {
 	return Definition{
 		ID:                  id,
 		DisplayName:         displayName,
@@ -113,6 +124,7 @@ func NewDefinition(id domain.ScenarioID, displayName, description string, setup 
 		StartingConditions:  starting,
 		MarketModel:         market,
 		ProductionModel:     production,
+		FinanceModel:        finance,
 		DefaultHistoryLimit: 10,
 	}
 }
@@ -193,6 +205,10 @@ func (d Definition) ResolverOptions() engine.Options {
 			}
 			return engine.ProductionCost{CostPerCapacityUnit: workstation.CostPerUnit}
 		},
+		ReceivableDelayRounds: d.FinanceModel.ReceivableDelayRounds,
+		PayableDelayRounds:    d.FinanceModel.PayableDelayRounds,
+		PayrollCycleRounds:    d.FinanceModel.PayrollCycleRounds,
+		PayrollPerCycle:       d.FinanceModel.PayrollPerCycle,
 		WorldUpdate: func(ctx *engine.WorldUpdateContext) error {
 			return d.applyDemand(ctx)
 		},
@@ -206,6 +222,7 @@ func (d Definition) SummaryLines() []string {
 		fmt.Sprintf("starting_conditions=%s", d.StartingConditions.ID),
 		fmt.Sprintf("market_model=%s", d.MarketModel.ID),
 		fmt.Sprintf("production_model=%s", d.ProductionModel.ID),
+		fmt.Sprintf("finance_model=%s", d.FinanceModel.ID),
 		fmt.Sprintf("bottleneck=%s", d.ProductionModel.Bottleneck.WorkstationID),
 		fmt.Sprintf("roles=%s", strings.Join(roleNames(d.Setup.RoleRoster), ", ")),
 	}

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -37,9 +37,10 @@ type StartingConditions struct {
 }
 
 type CustomerSeed struct {
-	ID          domain.CustomerID
-	DisplayName string
-	Sentiment   int
+	ID                 domain.CustomerID
+	DisplayName        string
+	Sentiment          int
+	PaymentDelayRounds int
 }
 
 type MarketModel struct {
@@ -107,8 +108,6 @@ type FinanceModel struct {
 	Description           string
 	ReceivableDelayRounds int
 	PayableDelayRounds    int
-	PayrollCycleRounds    int
-	PayrollPerCycle       domain.Money
 }
 
 type DemandAssumptions struct {
@@ -136,10 +135,11 @@ func (d Definition) InitialState(matchID domain.MatchID, roles []domain.RoleAssi
 	customers := make([]domain.CustomerState, 0, len(d.StartingConditions.Customers))
 	for _, customer := range d.StartingConditions.Customers {
 		customers = append(customers, domain.CustomerState{
-			CustomerID:  customer.ID,
-			DisplayName: customer.DisplayName,
-			Sentiment:   customer.Sentiment,
-			Backlog:     customerBacklog(plant.Backlog, customer.ID),
+			CustomerID:         customer.ID,
+			DisplayName:        customer.DisplayName,
+			Sentiment:          customer.Sentiment,
+			PaymentDelayRounds: customer.PaymentDelayRounds,
+			Backlog:            customerBacklog(plant.Backlog, customer.ID),
 		})
 	}
 
@@ -207,8 +207,6 @@ func (d Definition) ResolverOptions() engine.Options {
 		},
 		ReceivableDelayRounds: d.FinanceModel.ReceivableDelayRounds,
 		PayableDelayRounds:    d.FinanceModel.PayableDelayRounds,
-		PayrollCycleRounds:    d.FinanceModel.PayrollCycleRounds,
-		PayrollPerCycle:       d.FinanceModel.PayrollPerCycle,
 		WorldUpdate: func(ctx *engine.WorldUpdateContext) error {
 			return d.applyDemand(ctx)
 		},

--- a/internal/scenario/starter.go
+++ b/internal/scenario/starter.go
@@ -71,9 +71,9 @@ func StarterStartingConditions() StartingConditions {
 			},
 		},
 		Customers: []CustomerSeed{
-			{ID: "northbuild", DisplayName: "NorthBuild", Sentiment: 6},
-			{ID: "prairieflow", DisplayName: "PrairieFlow", Sentiment: 5},
-			{ID: "agriworks", DisplayName: "AgriWorks", Sentiment: 4},
+			{ID: "northbuild", DisplayName: "NorthBuild", Sentiment: 6, PaymentDelayRounds: 2},
+			{ID: "prairieflow", DisplayName: "PrairieFlow", Sentiment: 5, PaymentDelayRounds: 1},
+			{ID: "agriworks", DisplayName: "AgriWorks", Sentiment: 4, PaymentDelayRounds: 1},
 		},
 	}
 }
@@ -163,10 +163,8 @@ func StarterFinanceModel() FinanceModel {
 	return FinanceModel{
 		ID:                    "net30-lite-weekly",
 		DisplayName:           "Net-30 Lite Weekly Cash Timing",
-		Description:           "Customer receipts and supplier invoices settle one round later, while payroll hits every other round to keep near-term cash pressure visible.",
+		Description:           "Customer receipts settle on customer-specific terms, while supplier invoices settle one round later to keep near-term cash pressure visible.",
 		ReceivableDelayRounds: 1,
 		PayableDelayRounds:    1,
-		PayrollCycleRounds:    2,
-		PayrollPerCycle:       6,
 	}
 }

--- a/internal/scenario/starter.go
+++ b/internal/scenario/starter.go
@@ -20,6 +20,7 @@ func Starter() Definition {
 		StarterStartingConditions(),
 		StarterMarketModel(),
 		StarterProductionModel(),
+		StarterFinanceModel(),
 	)
 }
 
@@ -155,5 +156,17 @@ func StarterProductionModel() ProductionModel {
 			WorkstationID: "assembly",
 			Summary:       "Assembly is the chronic near-term bottleneck, so overselling or over-releasing work tends to inflate WIP and burn cash faster than throughput improves.",
 		},
+	}
+}
+
+func StarterFinanceModel() FinanceModel {
+	return FinanceModel{
+		ID:                    "net30-lite-weekly",
+		DisplayName:           "Net-30 Lite Weekly Cash Timing",
+		Description:           "Customer receipts and supplier invoices settle one round later, while payroll hits every other round to keep near-term cash pressure visible.",
+		ReceivableDelayRounds: 1,
+		PayableDelayRounds:    1,
+		PayrollCycleRounds:    2,
+		PayrollPerCycle:       6,
 	}
 }

--- a/internal/scenario/starter_test.go
+++ b/internal/scenario/starter_test.go
@@ -37,6 +37,12 @@ func TestStarterInitialStateProvidesKnownPlayableSetup(t *testing.T) {
 	if got := len(state.Customers); got != 3 {
 		t.Fatalf("Customers len = %d, want 3", got)
 	}
+	if got := state.Customers[0].PaymentDelayRounds; got != 2 {
+		t.Fatalf("NorthBuild payment delay = %d, want 2", got)
+	}
+	if got := state.Customers[1].PaymentDelayRounds; got != 1 {
+		t.Fatalf("PrairieFlow payment delay = %d, want 1", got)
+	}
 	if got := len(state.Plant.Backlog); got != 2 {
 		t.Fatalf("Backlog len = %d, want 2", got)
 	}

--- a/internal/scenario/starter_test.go
+++ b/internal/scenario/starter_test.go
@@ -58,6 +58,9 @@ func TestStarterInitialStateProvidesKnownPlayableSetup(t *testing.T) {
 	if got := starter.ProductionModel.ID; got != "two_stage_pump_valve_line" {
 		t.Fatalf("ProductionModel.ID = %q, want two_stage_pump_valve_line", got)
 	}
+	if got := starter.FinanceModel.ID; got != "net30-lite-weekly" {
+		t.Fatalf("FinanceModel.ID = %q, want net30-lite-weekly", got)
+	}
 }
 
 func TestStarterResolverOptionsApplyScenarioHooks(t *testing.T) {
@@ -166,6 +169,7 @@ func TestScenarioComponentsCanBeSelectedIndependently(t *testing.T) {
 		starting,
 		market,
 		production,
+		scenario.StarterFinanceModel(),
 	)
 
 	if got := definition.StartingConditions.ID; got != "cash_heavy_bootstrap" {


### PR DESCRIPTION
## Summary
- add starter-scenario cash timing with one-round receivables and payables plus biweekly payroll cadence
- extend the engine and plant state to track open cash commitments and realized cash receipts/disbursements
- surface the new timing pressure in finance-facing report details and regression tests

## What changed
- introduced `Receivables` and `Payables` on `PlantState` and timed cash-commitment support in the resolver
- changed starter scenario composition to include a finance model with delayed customer receipts, delayed supplier payment, and payroll cadence
- updated finance metrics to expose payroll expense, cash receipts, cash disbursements, ending cash, and actual net cash change
- added coverage for the new timing behavior and updated TUI expectations for the expanded event feed

## Local verification
- `gofmt -w ...`
- `go test ./...`
- `go vet ./...`
- `staticcheck ./...`

## Clarification Questions
1. Should supplier payables be enforced only when due, or should procurement also be blocked earlier by projected payable pressure beyond the current debt ceiling?
2. Is the intended baseline that customer receipts always arrive one round later, or do we want customer-specific payment terms in the near-term design?
3. Should payroll remain a fixed scenario cadence for now, or do you want it tied to future labor/overtime mechanics once that PR lands?
4. Do you want production spend to stay immediate cash while procurement is delayed, or should some production costs also move into accrued/payable timing later?
5. For finance-facing reports, is the current compact visibility enough for this PR, or do you want a follow-up on this branch to add a fuller projected cash table before merge?

## Follow-up candidates
- richer finance report presentation for open receivables/payables by due round
- customer-specific payment terms and supplier-specific payable terms
- tighter projected-cash validation for procurement commitments