### PR TITLE
Model workstation performance loss from congestion and operational stress

### DIFF
--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -110,10 +110,14 @@ type SupplyLot struct {
 }
 
 type WorkstationState struct {
-	WorkstationID    WorkstationID
-	DisplayName      string
-	CapacityPerRound CapacityUnits
-	CapacityUsed     CapacityUnits
+	WorkstationID              WorkstationID
+	DisplayName                string
+	CapacityPerRound           CapacityUnits
+	EffectiveCapacityPerRound  CapacityUnits
+	StressCapacityLoss         CapacityUnits
+	StressBufferUnits          CapacityUnits
+	StressPenaltyPerExcessUnit CapacityUnits
+	CapacityUsed               CapacityUnits
 }
 
 type ProductDefinition struct {
@@ -166,6 +170,7 @@ type PlantMetrics struct {
 	PartsOnHandUnits      Units
 	FinishedGoodsUnits    Units
 	ProductionOutputUnits Units
+	CapacityLossUnits     Units
 }
 
 type MetricValue struct {
@@ -324,6 +329,7 @@ const (
 	EventPurchaseOrderPlaced    RoundEventType = "purchase_order_placed"
 	EventSupplyArrived          RoundEventType = "supply_arrived"
 	EventProductionReleased     RoundEventType = "production_released"
+	EventWorkstationStressed    RoundEventType = "workstation_stressed"
 	EventWorkAdvanced           RoundEventType = "work_advanced"
 	EventFinishedGoodsProduced  RoundEventType = "finished_goods_produced"
 	EventDemandRealized         RoundEventType = "demand_realized"

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -177,6 +177,7 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 		productionRoute:     r.productionRoute,
 		productionCost:      r.productionCost,
 		inventoryCost:       r.inventoryCost,
+		stressedStations:    map[domain.WorkstationID]bool{},
 	}
 
 	if nextState.ActiveTargets.EffectiveRound == state.CurrentRound {
@@ -233,6 +234,7 @@ type roundPhase struct {
 	productionCost      ProductionCostHook
 	inventoryCost       InventoryCarryingCostHook
 	eventSeq            int
+	stressedStations    map[domain.WorkstationID]bool
 }
 
 type resolutionStats struct {
@@ -446,7 +448,18 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 			continue
 		}
 
-		remainingCapacity := p.state.Plant.Workstations[wsIndex].CapacityPerRound - p.state.Plant.Workstations[wsIndex].CapacityUsed
+		effectiveCapacity, capacityLoss := stressedCapacity(p.state.Plant.Workstations[wsIndex], wipUnitsAtWorkstation(p.state.Plant.WIPInventory, allocation.WorkstationID))
+		p.state.Plant.Workstations[wsIndex].EffectiveCapacityPerRound = effectiveCapacity
+		p.state.Plant.Workstations[wsIndex].StressCapacityLoss = capacityLoss
+		if capacityLoss > 0 && !p.stressedStations[allocation.WorkstationID] {
+			p.stressedStations[allocation.WorkstationID] = true
+			p.appendEvent(domain.EventWorkstationStressed, domain.ActorPlantSystem, fmt.Sprintf("%s lost effective capacity to congestion", allocation.WorkstationID), map[string]any{
+				"workstation_id":     string(allocation.WorkstationID),
+				"effective_capacity": int(effectiveCapacity),
+				"capacity_loss":      int(capacityLoss),
+			})
+		}
+		remainingCapacity := effectiveCapacity - p.state.Plant.Workstations[wsIndex].CapacityUsed
 		availableWIP := wipQuantity(p.state.Plant.WIPInventory, allocation.ProductID, allocation.WorkstationID)
 		advance := minCapacity(allocation.Capacity, remainingCapacity, domain.CapacityUnits(availableWIP))
 		costing := p.productionCost(ProductionCostContext{
@@ -475,6 +488,7 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 				"product_id":         string(allocation.ProductID),
 				"requested_capacity": int(allocation.Capacity),
 				"accepted_capacity":  int(advance),
+				"effective_capacity": int(effectiveCapacity),
 			})
 		}
 		if advance <= 0 {
@@ -696,6 +710,11 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 		inventoryValue += inventoryCost(item.OnHandQty, item.UnitCost)
 	}
 
+	capacityLossUnits := domain.Units(0)
+	for _, workstation := range p.state.Plant.Workstations {
+		capacityLossUnits += domain.Units(workstation.StressCapacityLoss)
+	}
+
 	operatingExpense := p.stats.procurementSpend + p.stats.productionSpend + p.stats.holdingCost + p.stats.debtServiceCost
 	netCashChange := p.stats.revenue - operatingExpense
 	demandUnits := p.stats.shippedUnits + backlogUnits + p.stats.lostSalesUnits
@@ -720,6 +739,7 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 		PartsOnHandUnits:      partsUnits,
 		FinishedGoodsUnits:    finishedUnits,
 		ProductionOutputUnits: p.stats.producedUnits,
+		CapacityLossUnits:     capacityLossUnits,
 	}
 }
 
@@ -1292,8 +1312,42 @@ func resetCapacityUsage(items []domain.WorkstationState) []domain.WorkstationSta
 	cloned := slices.Clone(items)
 	for index := range cloned {
 		cloned[index].CapacityUsed = 0
+		cloned[index].EffectiveCapacityPerRound = cloned[index].CapacityPerRound
+		cloned[index].StressCapacityLoss = 0
 	}
 	return cloned
+}
+
+func stressedCapacity(workstation domain.WorkstationState, wipUnits domain.Units) (domain.CapacityUnits, domain.CapacityUnits) {
+	nominal := workstation.CapacityPerRound
+	if nominal <= 0 {
+		return 0, 0
+	}
+	if workstation.StressPenaltyPerExcessUnit <= 0 {
+		return nominal, 0
+	}
+
+	threshold := domain.Units(nominal + workstation.StressBufferUnits)
+	if wipUnits <= threshold {
+		return nominal, 0
+	}
+
+	excess := domain.CapacityUnits(wipUnits - threshold)
+	loss := excess * workstation.StressPenaltyPerExcessUnit
+	if loss > nominal {
+		loss = nominal
+	}
+	return nominal - loss, loss
+}
+
+func wipUnitsAtWorkstation(items []domain.WIPInventory, workstationID domain.WorkstationID) domain.Units {
+	total := domain.Units(0)
+	for _, item := range items {
+		if item.WorkstationID == workstationID {
+			total += item.Quantity
+		}
+	}
+	return total
 }
 
 func findCustomer(customers []domain.CustomerState, customerID domain.CustomerID) *domain.CustomerState {

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -1332,6 +1332,8 @@ func stressedCapacity(workstation domain.WorkstationState, wipUnits domain.Units
 		return nominal, 0
 	}
 
+	// Start with a linear congestion penalty so players can see the effect of excess WIP
+	// before later mechanics add harsher stoppage, quality, or maintenance interactions.
 	excess := domain.CapacityUnits(wipUnits - threshold)
 	loss := excess * workstation.StressPenaltyPerExcessUnit
 	if loss > nominal {

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -313,6 +313,60 @@ func TestResolverUsesScenarioProductionAndInventoryCostHooks(t *testing.T) {
 	}
 }
 
+func TestResolverReducesEffectiveCapacityUnderCongestion(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		ProductionBOM: widgetBOM,
+	})
+	state := fixtureState()
+	state.Plant.Workstations = []domain.WorkstationState{
+		{
+			WorkstationID:              "fabrication",
+			DisplayName:                "Fabrication",
+			CapacityPerRound:           3,
+			EffectiveCapacityPerRound:  3,
+			StressBufferUnits:          0,
+			StressPenaltyPerExcessUnit: 1,
+		},
+		{
+			WorkstationID:              "assembly",
+			DisplayName:                "Assembly",
+			CapacityPerRound:           2,
+			EffectiveCapacityPerRound:  2,
+			StressBufferUnits:          0,
+			StressPenaltyPerExcessUnit: 0,
+		},
+	}
+	state.Plant.WIPInventory = []domain.WIPInventory{
+		{ProductID: "widget", WorkstationID: "fabrication", Quantity: 5, UnitCost: 1},
+	}
+	actions := fixtureActions()
+	actions[1].Action.Production.Releases = nil
+	actions[1].Action.Production.CapacityAllocation = []domain.CapacityAllocation{
+		{WorkstationID: "fabrication", ProductID: "widget", Capacity: 3},
+	}
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.NextState.Plant.Workstations[0].EffectiveCapacityPerRound; got != 1 {
+		t.Fatalf("fabrication effective capacity = %d, want 1", got)
+	}
+	if got := result.NextState.Plant.Workstations[0].StressCapacityLoss; got != 2 {
+		t.Fatalf("fabrication stress loss = %d, want 2", got)
+	}
+	if got := result.NextState.Plant.Workstations[0].CapacityUsed; got != 1 {
+		t.Fatalf("fabrication capacity used = %d, want 1", got)
+	}
+	if got := result.Round.Metrics.CapacityLossUnits; got != 2 {
+		t.Fatalf("CapacityLossUnits = %d, want 2", got)
+	}
+	if !containsEvent(result.Round.Events, domain.EventWorkstationStressed) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventWorkstationStressed, result.Round.Events)
+	}
+}
+
 func TestResolverRequiresExplicitRolePayload(t *testing.T) {
 	resolver := engine.NewResolver(engine.Options{})
 	actions := fixtureActions()
@@ -774,6 +828,15 @@ func wipQty(items []domain.WIPInventory, productID domain.ProductID, workstation
 		}
 	}
 	return 0
+}
+
+func containsEvent(events []domain.RoundEvent, eventType domain.RoundEventType) bool {
+	for _, event := range events {
+		if event.Type == eventType {
+			return true
+		}
+	}
+	return false
 }
 
 func widgetBOM(ctx engine.ProductionBOMContext) engine.ProductionBOM {

--- a/internal/projection/role_report.go
+++ b/internal/projection/role_report.go
@@ -50,10 +50,12 @@ func buildDepartmentPerformanceReport(state domain.MatchState, viewerRoleID doma
 			KeyMetrics: []domain.MetricValue{
 				{MetricID: "wip_units", Value: int(sumWIPUnits(state.Plant.WIPInventory)), DisplayUnit: "units"},
 				{MetricID: "output_units", Value: int(state.Metrics.ProductionOutputUnits), DisplayUnit: "units"},
+				{MetricID: "capacity_loss", Value: int(state.Metrics.CapacityLossUnits), DisplayUnit: "units"},
 			},
 			DetailLines: []string{
 				fmt.Sprintf("Current WIP totals %d units across active workstations.", sumWIPUnits(state.Plant.WIPInventory)),
 				fmt.Sprintf("Finished goods on hand total %d units.", state.Metrics.FinishedGoodsUnits),
+				stressSummaryLine(state.Plant.Workstations),
 			},
 			BonusSummary: bonusReminder(viewerRoleID),
 		}
@@ -245,6 +247,24 @@ func sumWIPUnits(items []domain.WIPInventory) domain.Units {
 		total += item.Quantity
 	}
 	return total
+}
+
+func stressSummaryLine(items []domain.WorkstationState) string {
+	if len(items) == 0 {
+		return "No workstation stress profile is currently active."
+	}
+
+	worst := items[0]
+	for _, item := range items[1:] {
+		if item.StressCapacityLoss > worst.StressCapacityLoss {
+			worst = item
+		}
+	}
+
+	if worst.StressCapacityLoss <= 0 {
+		return "No workstation lost effective capacity to congestion last round."
+	}
+	return fmt.Sprintf("%s lost %d unit(s) of effective capacity and closed at %d/%d.", worst.DisplayName, worst.StressCapacityLoss, worst.EffectiveCapacityPerRound, worst.CapacityPerRound)
 }
 
 func inventoryBucketTotal(items []domain.PartInventory) domain.Money {

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -87,10 +87,12 @@ type Part struct {
 }
 
 type Workstation struct {
-	ID               domain.WorkstationID
-	DisplayName      string
-	CapacityPerRound domain.CapacityUnits
-	CostPerUnit      domain.Money
+	ID                         domain.WorkstationID
+	DisplayName                string
+	CapacityPerRound           domain.CapacityUnits
+	CostPerUnit                domain.Money
+	StressBufferUnits          domain.CapacityUnits
+	StressPenaltyPerExcessUnit domain.CapacityUnits
 }
 
 type BottleneckAssumption struct {
@@ -245,9 +247,12 @@ func (d Definition) productionWorkstationState() []domain.WorkstationState {
 	items := make([]domain.WorkstationState, 0, len(d.ProductionModel.Workstations))
 	for _, workstation := range d.ProductionModel.Workstations {
 		items = append(items, domain.WorkstationState{
-			WorkstationID:    workstation.ID,
-			DisplayName:      workstation.DisplayName,
-			CapacityPerRound: workstation.CapacityPerRound,
+			WorkstationID:              workstation.ID,
+			DisplayName:                workstation.DisplayName,
+			CapacityPerRound:           workstation.CapacityPerRound,
+			EffectiveCapacityPerRound:  workstation.CapacityPerRound,
+			StressBufferUnits:          workstation.StressBufferUnits,
+			StressPenaltyPerExcessUnit: workstation.StressPenaltyPerExcessUnit,
 		})
 	}
 	return items

--- a/internal/scenario/starter.go
+++ b/internal/scenario/starter.go
@@ -148,8 +148,8 @@ func StarterProductionModel() ProductionModel {
 			},
 		},
 		Workstations: []Workstation{
-			{ID: "fabrication", DisplayName: "Fabrication", CapacityPerRound: 7, CostPerUnit: 2},
-			{ID: "assembly", DisplayName: "Assembly", CapacityPerRound: 4, CostPerUnit: 3},
+			{ID: "fabrication", DisplayName: "Fabrication", CapacityPerRound: 7, CostPerUnit: 2, StressBufferUnits: 2, StressPenaltyPerExcessUnit: 1},
+			{ID: "assembly", DisplayName: "Assembly", CapacityPerRound: 4, CostPerUnit: 3, StressBufferUnits: 1, StressPenaltyPerExcessUnit: 1},
 		},
 		Bottleneck: BottleneckAssumption{
 			WorkstationID: "assembly",

--- a/internal/scenario/starter_test.go
+++ b/internal/scenario/starter_test.go
@@ -43,6 +43,9 @@ func TestStarterInitialStateProvidesKnownPlayableSetup(t *testing.T) {
 	if got := state.Plant.Workstations[1].WorkstationID; got != "assembly" {
 		t.Fatalf("bottleneck workstation = %q, want assembly", got)
 	}
+	if got := state.Plant.Workstations[1].StressBufferUnits; got != 1 {
+		t.Fatalf("assembly stress buffer = %d, want 1", got)
+	}
 	if got := starter.ProductionModel.Bottleneck.WorkstationID; got != "assembly" {
 		t.Fatalf("ProductionModel.Bottleneck = %q, want assembly", got)
 	}


### PR DESCRIPTION
## Summary
- add deterministic congestion-driven effective capacity loss to workstation execution
- expose capacity loss in production reporting and plant metrics
- keep the starter scenario explainable with simple buffer and penalty stress rules plus regression coverage

## Testing
- go test ./...
- go vet ./...
- staticcheck ./...

## Clarification Questions
1. Should congestion pressure stay purely WIP-driven for now, or should a later branch also include overload history and minor stoppage effects?
2. Is the current linear capacity-loss rule the right first step, or do you want a harsher nonlinear penalty once players have learned the mechanic?
3. Should finance-facing reporting start quantifying congestion's margin impact later, or is production-facing visibility enough for this PR?
4. Do you want stressed operation to feed future quality or maintenance mechanics directly, or remain only a capacity penalty until those branches land?