### PR TITLE
[codex] Add payroll cadence to cash timing

### DIFF
--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -782,7 +782,7 @@ func TestModelRoundFeedShowsResolvedStarterHistory(t *testing.T) {
 	for _, want := range []string{
 		"Current phase: revealed round results",
 		"Recent resolved rounds (1 shown)",
-		"[R1] 22 events | 2 commentary",
+		"[R1] 23 events | 2 commentary",
 		"Sales Manager: Holding starter prices while we",
 		"clear inherited backlog.",
 		"Event: Shipped 2 pump to northbuild",

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -127,6 +127,7 @@ type CashCommitmentKind string
 const (
 	CashCommitmentReceivable CashCommitmentKind = "receivable"
 	CashCommitmentPayable    CashCommitmentKind = "payable"
+	CashCommitmentPayroll    CashCommitmentKind = "payroll"
 )
 
 type SupplierState struct {
@@ -382,6 +383,7 @@ const (
 	EventPurchaseOrderPlaced    RoundEventType = "purchase_order_placed"
 	EventPayableScheduled       RoundEventType = "payable_scheduled"
 	EventPayablePaid            RoundEventType = "payable_paid"
+	EventPayrollScheduled       RoundEventType = "payroll_scheduled"
 	EventSupplyArrived          RoundEventType = "supply_arrived"
 	EventSupplyDelayed          RoundEventType = "supply_delayed"
 	EventSupplierScoreChanged   RoundEventType = "supplier_score_changed"

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -22,6 +22,7 @@ type Options struct {
 	InventoryCost         InventoryCarryingCostHook
 	ReceivableDelayRounds int
 	PayableDelayRounds    int
+	PayrollDelayRounds    int
 	WorldUpdate           WorldUpdateHook
 }
 
@@ -136,6 +137,7 @@ type Resolver struct {
 	inventoryCost         InventoryCarryingCostHook
 	receivableDelayRounds int
 	payableDelayRounds    int
+	payrollDelayRounds    int
 	worldUpdate           WorldUpdateHook
 }
 
@@ -150,6 +152,7 @@ func NewResolver(options Options) *Resolver {
 		inventoryCost:         options.InventoryCost,
 		receivableDelayRounds: normalizedDelayRounds(options.ReceivableDelayRounds),
 		payableDelayRounds:    normalizedDelayRounds(options.PayableDelayRounds),
+		payrollDelayRounds:    normalizedDelayRounds(options.PayrollDelayRounds),
 		worldUpdate:           options.WorldUpdate,
 	}
 }
@@ -190,6 +193,7 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 		inventoryCost:         r.inventoryCost,
 		receivableDelayRounds: r.receivableDelayRounds,
 		payableDelayRounds:    r.payableDelayRounds,
+		payrollDelayRounds:    r.payrollDelayRounds,
 		random:                random,
 		stressedStations:      map[domain.WorkstationID]bool{},
 	}
@@ -250,6 +254,7 @@ type roundPhase struct {
 	inventoryCost         InventoryCarryingCostHook
 	receivableDelayRounds int
 	payableDelayRounds    int
+	payrollDelayRounds    int
 	random                ports.RandomSource
 	eventSeq              int
 	stressedStations      map[domain.WorkstationID]bool
@@ -797,7 +802,6 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 	}
 
 	operatingExpense := p.stats.procurementSpend + p.stats.productionSpend + p.stats.payrollExpense + p.stats.holdingCost + p.stats.debtServiceCost
-	operatingExpense += p.stats.laborCost + p.stats.overtimeCost
 	netCashChange := p.state.Plant.Cash - p.beginningCash
 	demandUnits := p.stats.shippedUnits + backlogUnits + p.stats.lostSalesUnits
 	onTime := domain.Percentage(100)
@@ -855,15 +859,23 @@ func (p *roundPhase) applyLaborCosts() (domain.Money, domain.Money) {
 
 	p.stats.idleLaborUnits = idleLabor
 	total := laborCost + overtimeCost
+	p.stats.payrollExpense = total
 	if total > 0 {
-		p.applyCashDelta(-total)
-		p.appendEvent(domain.EventLaborCostApplied, domain.ActorPlantSystem, "Applied labor and overtime costs", map[string]any{
+		payload := map[string]any{
 			"labor_cost":       int(laborCost),
 			"overtime_cost":    int(overtimeCost),
+			"payroll_expense":  int(total),
 			"idle_labor_units": int(idleLabor),
-			"cash":             int(p.state.Plant.Cash),
-			"debt":             int(p.state.Plant.Debt),
-		})
+		}
+		if dueRound, paidImmediately := p.schedulePayroll(total, fmt.Sprintf("payroll-r%d", p.currentRound)); paidImmediately {
+			payload["cash_applied"] = true
+			payload["cash"] = int(p.state.Plant.Cash)
+			payload["debt"] = int(p.state.Plant.Debt)
+		} else {
+			payload["cash_applied"] = false
+			payload["due_round"] = int(dueRound)
+		}
+		p.appendEvent(domain.EventLaborCostApplied, domain.ActorPlantSystem, "Applied labor and overtime costs", payload)
 	}
 
 	return laborCost, overtimeCost
@@ -977,17 +989,24 @@ func (p *roundPhase) payPayablesDue() {
 	disbursed := sumCommitments(due)
 	for _, item := range due {
 		p.applyCashDelta(-item.Amount)
-		p.appendEvent(domain.EventPayablePaid, domain.ActorPlantSystem, "Paid supplier payable", map[string]any{
+		eventType := domain.EventPayablePaid
+		summary := "Paid supplier payable"
+		if item.Kind == domain.CashCommitmentPayroll {
+			eventType = domain.EventPayrollPaid
+			summary = "Paid payroll commitment"
+		}
+		p.appendEvent(eventType, domain.ActorPlantSystem, summary, map[string]any{
 			"commitment_id": item.CommitmentID,
 			"amount":        int(item.Amount),
 			"due_round":     int(item.DueRound),
+			"kind":          string(item.Kind),
 			"cash":          int(p.state.Plant.Cash),
 			"debt":          int(p.state.Plant.Debt),
 		})
 	}
 	if disbursed > 0 {
 		p.stats.cashDisbursements += disbursed
-		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Supplier payments applied", map[string]any{
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Committed disbursements applied", map[string]any{
 			"delta": -int(disbursed),
 			"cash":  int(p.state.Plant.Cash),
 			"debt":  int(p.state.Plant.Debt),
@@ -1066,6 +1085,45 @@ func (p *roundPhase) schedulePayable(amount domain.Money, referenceID string) {
 		"due_round":     int(item.DueRound),
 		"reference_id":  item.ReferenceID,
 	})
+}
+
+func (p *roundPhase) schedulePayroll(amount domain.Money, referenceID string) (domain.RoundNumber, bool) {
+	if amount <= 0 {
+		return 0, false
+	}
+	if p.payrollDelayRounds == 0 {
+		p.applyCashDelta(-amount)
+		p.stats.cashDisbursements += amount
+		p.appendEvent(domain.EventPayrollPaid, domain.ActorPlantSystem, "Paid current-round payroll", map[string]any{
+			"amount":       int(amount),
+			"reference_id": referenceID,
+			"cash":         int(p.state.Plant.Cash),
+			"debt":         int(p.state.Plant.Debt),
+		})
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Payroll cash applied", map[string]any{
+			"delta": -int(amount),
+			"cash":  int(p.state.Plant.Cash),
+			"debt":  int(p.state.Plant.Debt),
+		})
+		return p.currentRound, true
+	}
+
+	item := domain.CashCommitment{
+		CommitmentID: fmt.Sprintf("payroll-r%d-%d", p.currentRound, len(p.state.Plant.Payables)+1),
+		Kind:         domain.CashCommitmentPayroll,
+		Amount:       amount,
+		DueRound:     p.currentRound + domain.RoundNumber(p.payrollDelayRounds),
+		CreatedRound: p.currentRound,
+		ReferenceID:  referenceID,
+	}
+	p.state.Plant.Payables = append(p.state.Plant.Payables, item)
+	p.appendEvent(domain.EventPayrollScheduled, domain.ActorPlantSystem, "Scheduled payroll commitment", map[string]any{
+		"commitment_id": item.CommitmentID,
+		"amount":        int(item.Amount),
+		"due_round":     int(item.DueRound),
+		"reference_id":  item.ReferenceID,
+	})
+	return item.DueRound, false
 }
 
 func (p *roundPhase) syncCustomerBacklog(backlog []domain.BacklogEntry) {

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -829,6 +829,112 @@ func TestResolverSchedulesReceivablesPayablesAndUsesProjectedDebtCapacity(t *tes
 	}
 }
 
+func TestResolverSchedulesPayrollAsAccruedExpenseWhenDelayed(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		PayrollDelayRounds: 1,
+	})
+
+	state := fixtureState()
+	state.Plant.PartsInventory = nil
+	state.Plant.WIPInventory = nil
+	state.Plant.FinishedInventory = nil
+	state.Plant.InTransitSupply = nil
+	state.Plant.Backlog = nil
+	state.Customers = nil
+	state.Plant.Workstations = []domain.WorkstationState{
+		{
+			WorkstationID:            "assembly",
+			DisplayName:              "Assembly",
+			CapacityPerRound:         2,
+			LaborCapacityPerRound:    2,
+			LaborCostPerCapacityUnit: 3,
+		},
+	}
+	actions := fixtureActions()
+	actions[0].Action.Procurement.Orders = nil
+	actions[1].Action.Production.Releases = nil
+	actions[1].Action.Production.CapacityAllocation = nil
+	actions[2].Action.Sales.ProductOffers = nil
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.Round.Metrics.PayrollExpense; got != 6 {
+		t.Fatalf("PayrollExpense = %d, want 6", got)
+	}
+	if got := result.Round.Metrics.LaborCost; got != 6 {
+		t.Fatalf("LaborCost = %d, want 6", got)
+	}
+	if got := result.Round.Metrics.CashDisbursements; got != 0 {
+		t.Fatalf("CashDisbursements = %d, want 0 before payroll is due", got)
+	}
+	if got := result.NextState.Plant.Cash; got != 10 {
+		t.Fatalf("Plant.Cash = %d, want 10 before delayed payroll payment", got)
+	}
+	if got := len(result.NextState.Plant.Payables); got != 1 {
+		t.Fatalf("Payables len = %d, want 1 payroll commitment", got)
+	}
+	if got := result.NextState.Plant.Payables[0].Kind; got != domain.CashCommitmentPayroll {
+		t.Fatalf("Payables[0].Kind = %q, want payroll", got)
+	}
+	if got := result.NextState.Plant.Payables[0].DueRound; got != 3 {
+		t.Fatalf("Payables[0].DueRound = %d, want 3", got)
+	}
+	if !containsEvent(result.Round.Events, domain.EventPayrollScheduled) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventPayrollScheduled, result.Round.Events)
+	}
+}
+
+func TestResolverPaysDuePayrollCommitments(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+
+	state := fixtureState()
+	state.Plant.PartsInventory = nil
+	state.Plant.WIPInventory = nil
+	state.Plant.FinishedInventory = nil
+	state.Plant.InTransitSupply = nil
+	state.Plant.Backlog = nil
+	state.Customers = nil
+	state.Plant.Workstations = []domain.WorkstationState{
+		{WorkstationID: "assembly", DisplayName: "Assembly", CapacityPerRound: 1},
+	}
+	state.Plant.Payables = []domain.CashCommitment{
+		{
+			CommitmentID: "payroll-r1-1",
+			Kind:         domain.CashCommitmentPayroll,
+			Amount:       4,
+			DueRound:     2,
+			CreatedRound: 1,
+			ReferenceID:  "payroll-r1",
+		},
+	}
+	actions := fixtureActions()
+	actions[0].Action.Procurement.Orders = nil
+	actions[1].Action.Production.Releases = nil
+	actions[1].Action.Production.CapacityAllocation = nil
+	actions[2].Action.Sales.ProductOffers = nil
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.NextState.Plant.Cash; got != 6 {
+		t.Fatalf("Plant.Cash = %d, want 6 after payroll payment", got)
+	}
+	if got := len(result.NextState.Plant.Payables); got != 0 {
+		t.Fatalf("Payables len = %d, want 0 after payroll payment", got)
+	}
+	if got := result.Round.Metrics.CashDisbursements; got != 4 {
+		t.Fatalf("CashDisbursements = %d, want 4", got)
+	}
+	if !containsEvent(result.Round.Events, domain.EventPayrollPaid) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventPayrollPaid, result.Round.Events)
+	}
+}
+
 func TestResolverUsesSupplierLeadTimeAndReliabilityTerms(t *testing.T) {
 	resolver := engine.NewResolver(engine.Options{
 		ProcurementTerms: func(ctx engine.ProcurementTermsContext) engine.ProcurementTerms {

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -143,6 +143,7 @@ type FinanceModel struct {
 	Description           string
 	ReceivableDelayRounds int
 	PayableDelayRounds    int
+	PayrollDelayRounds    int
 }
 
 type DemandAssumptions struct {
@@ -258,6 +259,7 @@ func (d Definition) ResolverOptions() engine.Options {
 		},
 		ReceivableDelayRounds: d.FinanceModel.ReceivableDelayRounds,
 		PayableDelayRounds:    d.FinanceModel.PayableDelayRounds,
+		PayrollDelayRounds:    d.FinanceModel.PayrollDelayRounds,
 		WorldUpdate: func(ctx *engine.WorldUpdateContext) error {
 			return d.applyDemand(ctx)
 		},

--- a/internal/scenario/starter.go
+++ b/internal/scenario/starter.go
@@ -266,8 +266,9 @@ func StarterFinanceModel() FinanceModel {
 	return FinanceModel{
 		ID:                    "net30-lite-weekly",
 		DisplayName:           "Net-30 Lite Weekly Cash Timing",
-		Description:           "Customer receipts settle on customer-specific terms, while supplier invoices settle one round later to keep near-term cash pressure visible.",
+		Description:           "Customer receipts settle on customer-specific terms, while supplier invoices and payroll settle one round later to keep near-term cash pressure visible.",
 		ReceivableDelayRounds: 1,
 		PayableDelayRounds:    1,
+		PayrollDelayRounds:    1,
 	}
 }

--- a/internal/scenario/starter_test.go
+++ b/internal/scenario/starter_test.go
@@ -76,6 +76,9 @@ func TestStarterInitialStateProvidesKnownPlayableSetup(t *testing.T) {
 	if got := starter.FinanceModel.ID; got != "net30-lite-weekly" {
 		t.Fatalf("FinanceModel.ID = %q, want net30-lite-weekly", got)
 	}
+	if got := starter.FinanceModel.PayrollDelayRounds; got != 1 {
+		t.Fatalf("FinanceModel.PayrollDelayRounds = %d, want 1", got)
+	}
 }
 
 func TestStarterResolverOptionsApplyScenarioHooks(t *testing.T) {


### PR DESCRIPTION
## Summary
- add configurable payroll timing to the finance model and resolver options
- accrue payroll expense each round while scheduling payroll cash outflows as delayed commitments
- distinguish payroll scheduling/payment events and cover the new behavior with engine and scenario tests

## Why
Issue #134 is only partially addressed in the current branch state: receivables and supplier payables are delayed, but payroll still hits cash immediately at round close. That keeps finance decisions in immediate-cash bookkeeping instead of modeling a real payroll cycle.

## Impact
Finance decisions now separate expense recognition from cash movement for labor. Starter scenario payroll settles one round later, so cash pressure stays visible without erasing labor expense from round profit.

## Validation
- `go test ./...`

Refs #134