### PR TITLE
Codex/issue 131 quality outcomes

### DIFF
--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -782,7 +782,7 @@ func TestModelRoundFeedShowsResolvedStarterHistory(t *testing.T) {
 	for _, want := range []string{
 		"Current phase: revealed round results",
 		"Recent resolved rounds (1 shown)",
-		"[R1] 22 events | 2 commentary",
+		"[R1] 23 events | 2 commentary",
 		"Sales Manager: Holding starter prices while we",
 		"clear inherited backlog.",
 		"Event: Shipped 2 pump to northbuild",

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -127,6 +127,7 @@ type CashCommitmentKind string
 const (
 	CashCommitmentReceivable CashCommitmentKind = "receivable"
 	CashCommitmentPayable    CashCommitmentKind = "payable"
+	CashCommitmentPayroll    CashCommitmentKind = "payroll"
 )
 
 type SupplierState struct {
@@ -382,6 +383,7 @@ const (
 	EventPurchaseOrderPlaced    RoundEventType = "purchase_order_placed"
 	EventPayableScheduled       RoundEventType = "payable_scheduled"
 	EventPayablePaid            RoundEventType = "payable_paid"
+	EventPayrollScheduled       RoundEventType = "payroll_scheduled"
 	EventSupplyArrived          RoundEventType = "supply_arrived"
 	EventSupplyDelayed          RoundEventType = "supply_delayed"
 	EventSupplierScoreChanged   RoundEventType = "supplier_score_changed"

--- a/internal/domain/model.go
+++ b/internal/domain/model.go
@@ -76,7 +76,9 @@ type PlantState struct {
 	PartsInventory    []PartInventory
 	WIPInventory      []WIPInventory
 	FinishedInventory []FinishedInventory
+	InspectionHolds   []InspectionHoldInventory
 	InTransitSupply   []SupplyLot
+	PendingReturns    []CustomerReturnCommitment
 	Receivables       []CashCommitment
 	Payables          []CashCommitment
 	Workstations      []WorkstationState
@@ -100,6 +102,25 @@ type FinishedInventory struct {
 	ProductID ProductID
 	OnHandQty Units
 	UnitCost  Money
+}
+
+type InspectionHoldInventory struct {
+	ProductID    ProductID
+	Quantity     Units
+	UnitCost     Money
+	HoldRound    RoundNumber
+	ReleaseRound RoundNumber
+	Reason       string
+}
+
+type CustomerReturnCommitment struct {
+	ReturnID     string
+	CustomerID   CustomerID
+	ProductID    ProductID
+	Quantity     Units
+	UnitCost     Money
+	DueRound     RoundNumber
+	CreatedRound RoundNumber
 }
 
 type SupplyLot struct {
@@ -214,10 +235,14 @@ type PlantMetrics struct {
 	LostSalesUnits        Units
 	PartsOnHandUnits      Units
 	FinishedGoodsUnits    Units
+	InspectionHoldUnits   Units
 	ProductionOutputUnits Units
 	CapacityLossUnits     Units
 	IdleLaborUnits        Units
 	OvertimeUnits         Units
+	ScrapUnits            Units
+	ReworkUnits           Units
+	CustomerReturnUnits   Units
 	SupplierReliability   Percentage
 }
 
@@ -379,31 +404,37 @@ type RoundEvent struct {
 type RoundEventType string
 
 const (
-	EventBudgetActivated        RoundEventType = "budget_activated"
-	EventPurchaseOrderPlaced    RoundEventType = "purchase_order_placed"
-	EventPayableScheduled       RoundEventType = "payable_scheduled"
-	EventPayablePaid            RoundEventType = "payable_paid"
-	EventPayrollScheduled       RoundEventType = "payroll_scheduled"
-	EventSupplyArrived          RoundEventType = "supply_arrived"
-	EventSupplyDelayed          RoundEventType = "supply_delayed"
-	EventSupplierScoreChanged   RoundEventType = "supplier_score_changed"
-	EventProductionReleased     RoundEventType = "production_released"
-	EventWorkstationStressed    RoundEventType = "workstation_stressed"
-	EventWorkAdvanced           RoundEventType = "work_advanced"
-	EventOvertimeApplied        RoundEventType = "overtime_applied"
-	EventLaborCostApplied       RoundEventType = "labor_cost_applied"
-	EventFinishedGoodsProduced  RoundEventType = "finished_goods_produced"
-	EventDemandRealized         RoundEventType = "demand_realized"
-	EventShipmentCompleted      RoundEventType = "shipment_completed"
-	EventReceivableScheduled    RoundEventType = "receivable_scheduled"
-	EventReceivableCollected    RoundEventType = "receivable_collected"
-	EventBacklogCreated         RoundEventType = "backlog_created"
-	EventBacklogExpired         RoundEventType = "backlog_expired"
-	EventCustomerSentimentMoved RoundEventType = "customer_sentiment_moved"
-	EventCashChanged            RoundEventType = "cash_changed"
-	EventPayrollPaid            RoundEventType = "payroll_paid"
-	EventMetricSnapshot         RoundEventType = "metric_snapshot"
-	EventRuleAdjustment         RoundEventType = "rule_adjustment"
+	EventBudgetActivated         RoundEventType = "budget_activated"
+	EventPurchaseOrderPlaced     RoundEventType = "purchase_order_placed"
+	EventPayableScheduled        RoundEventType = "payable_scheduled"
+	EventPayablePaid             RoundEventType = "payable_paid"
+	EventPayrollScheduled        RoundEventType = "payroll_scheduled"
+	EventSupplyArrived           RoundEventType = "supply_arrived"
+	EventSupplyDelayed           RoundEventType = "supply_delayed"
+	EventSupplierScoreChanged    RoundEventType = "supplier_score_changed"
+	EventProductionReleased      RoundEventType = "production_released"
+	EventWorkstationStressed     RoundEventType = "workstation_stressed"
+	EventWorkAdvanced            RoundEventType = "work_advanced"
+	EventOvertimeApplied         RoundEventType = "overtime_applied"
+	EventLaborCostApplied        RoundEventType = "labor_cost_applied"
+	EventFinishedGoodsProduced   RoundEventType = "finished_goods_produced"
+	EventQualityScrapped         RoundEventType = "quality_scrapped"
+	EventQualityReworkCreated    RoundEventType = "quality_rework_created"
+	EventInspectionHoldPlaced    RoundEventType = "inspection_hold_placed"
+	EventInspectionHoldReleased  RoundEventType = "inspection_hold_released"
+	EventDemandRealized          RoundEventType = "demand_realized"
+	EventShipmentCompleted       RoundEventType = "shipment_completed"
+	EventCustomerReturnScheduled RoundEventType = "customer_return_scheduled"
+	EventCustomerReturnReceived  RoundEventType = "customer_return_received"
+	EventReceivableScheduled     RoundEventType = "receivable_scheduled"
+	EventReceivableCollected     RoundEventType = "receivable_collected"
+	EventBacklogCreated          RoundEventType = "backlog_created"
+	EventBacklogExpired          RoundEventType = "backlog_expired"
+	EventCustomerSentimentMoved  RoundEventType = "customer_sentiment_moved"
+	EventCashChanged             RoundEventType = "cash_changed"
+	EventPayrollPaid             RoundEventType = "payroll_paid"
+	EventMetricSnapshot          RoundEventType = "metric_snapshot"
+	EventRuleAdjustment          RoundEventType = "rule_adjustment"
 )
 
 type RoundView struct {
@@ -461,7 +492,9 @@ func (s PlantState) Clone() PlantState {
 		PartsInventory:    slices.Clone(s.PartsInventory),
 		WIPInventory:      slices.Clone(s.WIPInventory),
 		FinishedInventory: slices.Clone(s.FinishedInventory),
+		InspectionHolds:   slices.Clone(s.InspectionHolds),
 		InTransitSupply:   slices.Clone(s.InTransitSupply),
+		PendingReturns:    slices.Clone(s.PendingReturns),
 		Receivables:       slices.Clone(s.Receivables),
 		Payables:          slices.Clone(s.Payables),
 		Workstations:      slices.Clone(s.Workstations),

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -22,6 +22,7 @@ type Options struct {
 	InventoryCost         InventoryCarryingCostHook
 	ReceivableDelayRounds int
 	PayableDelayRounds    int
+	PayrollDelayRounds    int
 	WorldUpdate           WorldUpdateHook
 }
 
@@ -136,6 +137,7 @@ type Resolver struct {
 	inventoryCost         InventoryCarryingCostHook
 	receivableDelayRounds int
 	payableDelayRounds    int
+	payrollDelayRounds    int
 	worldUpdate           WorldUpdateHook
 }
 
@@ -150,6 +152,7 @@ func NewResolver(options Options) *Resolver {
 		inventoryCost:         options.InventoryCost,
 		receivableDelayRounds: normalizedDelayRounds(options.ReceivableDelayRounds),
 		payableDelayRounds:    normalizedDelayRounds(options.PayableDelayRounds),
+		payrollDelayRounds:    normalizedDelayRounds(options.PayrollDelayRounds),
 		worldUpdate:           options.WorldUpdate,
 	}
 }
@@ -190,6 +193,7 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 		inventoryCost:         r.inventoryCost,
 		receivableDelayRounds: r.receivableDelayRounds,
 		payableDelayRounds:    r.payableDelayRounds,
+		payrollDelayRounds:    r.payrollDelayRounds,
 		random:                random,
 		stressedStations:      map[domain.WorkstationID]bool{},
 	}
@@ -250,6 +254,7 @@ type roundPhase struct {
 	inventoryCost         InventoryCarryingCostHook
 	receivableDelayRounds int
 	payableDelayRounds    int
+	payrollDelayRounds    int
 	random                ports.RandomSource
 	eventSeq              int
 	stressedStations      map[domain.WorkstationID]bool
@@ -797,7 +802,6 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 	}
 
 	operatingExpense := p.stats.procurementSpend + p.stats.productionSpend + p.stats.payrollExpense + p.stats.holdingCost + p.stats.debtServiceCost
-	operatingExpense += p.stats.laborCost + p.stats.overtimeCost
 	netCashChange := p.state.Plant.Cash - p.beginningCash
 	demandUnits := p.stats.shippedUnits + backlogUnits + p.stats.lostSalesUnits
 	onTime := domain.Percentage(100)
@@ -855,15 +859,23 @@ func (p *roundPhase) applyLaborCosts() (domain.Money, domain.Money) {
 
 	p.stats.idleLaborUnits = idleLabor
 	total := laborCost + overtimeCost
+	p.stats.payrollExpense = total
 	if total > 0 {
-		p.applyCashDelta(-total)
-		p.appendEvent(domain.EventLaborCostApplied, domain.ActorPlantSystem, "Applied labor and overtime costs", map[string]any{
+		payload := map[string]any{
 			"labor_cost":       int(laborCost),
 			"overtime_cost":    int(overtimeCost),
+			"payroll_expense":  int(total),
 			"idle_labor_units": int(idleLabor),
-			"cash":             int(p.state.Plant.Cash),
-			"debt":             int(p.state.Plant.Debt),
-		})
+		}
+		if dueRound, paidImmediately := p.schedulePayroll(total, fmt.Sprintf("payroll-r%d", p.currentRound)); paidImmediately {
+			payload["cash_applied"] = true
+			payload["cash"] = int(p.state.Plant.Cash)
+			payload["debt"] = int(p.state.Plant.Debt)
+		} else {
+			payload["cash_applied"] = false
+			payload["due_round"] = int(dueRound)
+		}
+		p.appendEvent(domain.EventLaborCostApplied, domain.ActorPlantSystem, "Applied labor and overtime costs", payload)
 	}
 
 	return laborCost, overtimeCost
@@ -977,17 +989,24 @@ func (p *roundPhase) payPayablesDue() {
 	disbursed := sumCommitments(due)
 	for _, item := range due {
 		p.applyCashDelta(-item.Amount)
-		p.appendEvent(domain.EventPayablePaid, domain.ActorPlantSystem, "Paid supplier payable", map[string]any{
+		eventType := domain.EventPayablePaid
+		summary := "Paid supplier payable"
+		if item.Kind == domain.CashCommitmentPayroll {
+			eventType = domain.EventPayrollPaid
+			summary = "Paid payroll commitment"
+		}
+		p.appendEvent(eventType, domain.ActorPlantSystem, summary, map[string]any{
 			"commitment_id": item.CommitmentID,
 			"amount":        int(item.Amount),
 			"due_round":     int(item.DueRound),
+			"kind":          string(item.Kind),
 			"cash":          int(p.state.Plant.Cash),
 			"debt":          int(p.state.Plant.Debt),
 		})
 	}
 	if disbursed > 0 {
 		p.stats.cashDisbursements += disbursed
-		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Supplier payments applied", map[string]any{
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Committed disbursements applied", map[string]any{
 			"delta": -int(disbursed),
 			"cash":  int(p.state.Plant.Cash),
 			"debt":  int(p.state.Plant.Debt),
@@ -1066,6 +1085,45 @@ func (p *roundPhase) schedulePayable(amount domain.Money, referenceID string) {
 		"due_round":     int(item.DueRound),
 		"reference_id":  item.ReferenceID,
 	})
+}
+
+func (p *roundPhase) schedulePayroll(amount domain.Money, referenceID string) (domain.RoundNumber, bool) {
+	if amount <= 0 {
+		return 0, false
+	}
+	if p.payrollDelayRounds == 0 {
+		p.applyCashDelta(-amount)
+		p.stats.cashDisbursements += amount
+		p.appendEvent(domain.EventPayrollPaid, domain.ActorPlantSystem, "Paid current-round payroll", map[string]any{
+			"amount":       int(amount),
+			"reference_id": referenceID,
+			"cash":         int(p.state.Plant.Cash),
+			"debt":         int(p.state.Plant.Debt),
+		})
+		p.appendEvent(domain.EventCashChanged, domain.ActorPlantSystem, "Payroll cash applied", map[string]any{
+			"delta": -int(amount),
+			"cash":  int(p.state.Plant.Cash),
+			"debt":  int(p.state.Plant.Debt),
+		})
+		return p.currentRound, true
+	}
+
+	item := domain.CashCommitment{
+		CommitmentID: fmt.Sprintf("payroll-r%d-%d", p.currentRound, len(p.state.Plant.Payables)+1),
+		Kind:         domain.CashCommitmentPayroll,
+		Amount:       amount,
+		DueRound:     p.currentRound + domain.RoundNumber(p.payrollDelayRounds),
+		CreatedRound: p.currentRound,
+		ReferenceID:  referenceID,
+	}
+	p.state.Plant.Payables = append(p.state.Plant.Payables, item)
+	p.appendEvent(domain.EventPayrollScheduled, domain.ActorPlantSystem, "Scheduled payroll commitment", map[string]any{
+		"commitment_id": item.CommitmentID,
+		"amount":        int(item.Amount),
+		"due_round":     int(item.DueRound),
+		"reference_id":  item.ReferenceID,
+	})
+	return item.DueRound, false
 }
 
 func (p *roundPhase) syncCustomerBacklog(backlog []domain.BacklogEntry) {

--- a/internal/engine/resolver.go
+++ b/internal/engine/resolver.go
@@ -19,6 +19,7 @@ type Options struct {
 	ProductionBOM         ProductionBOMHook
 	ProductionRoute       ProductionRouteHook
 	ProductionCost        ProductionCostHook
+	QualityProfile        QualityProfileHook
 	InventoryCost         InventoryCarryingCostHook
 	ReceivableDelayRounds int
 	PayableDelayRounds    int
@@ -92,6 +93,38 @@ type ProductionCost struct {
 	CostPerCapacityUnit domain.Money
 }
 
+// QualityProfileHook lets scenario data define product quality risks for final production
+// output and shipped units. The default implementation emits no quality losses.
+type QualityProfileHook func(QualityProfileContext) QualityProfile
+
+type QualityProfileContext struct {
+	State         domain.MatchState
+	CurrentRound  domain.RoundNumber
+	Phase         QualityPhase
+	ProductID     domain.ProductID
+	WorkstationID domain.WorkstationID
+	CustomerID    domain.CustomerID
+	Quantity      domain.Units
+	Stressed      bool
+	OvertimeUsed  bool
+}
+
+type QualityPhase string
+
+const (
+	QualityPhaseProductionFinal QualityPhase = "production_final"
+	QualityPhaseShipment        QualityPhase = "shipment"
+)
+
+type QualityProfile struct {
+	ScrapRatePct          int
+	ReworkRatePct         int
+	InspectionHoldRatePct int
+	CustomerReturnRatePct int
+	InspectionHoldRounds  int
+	ReturnDelayRounds     int
+}
+
 // InventoryCarryingCostHook lets scenario data define carrying cost by inventory class.
 // The default implementation charges a flat 10% round-end carrying cost with a minimum of 1.
 type InventoryCarryingCostHook func(InventoryCarryingCostContext) domain.Money
@@ -134,6 +167,7 @@ type Resolver struct {
 	productionBOM         ProductionBOMHook
 	productionRoute       ProductionRouteHook
 	productionCost        ProductionCostHook
+	qualityProfile        QualityProfileHook
 	inventoryCost         InventoryCarryingCostHook
 	receivableDelayRounds int
 	payableDelayRounds    int
@@ -149,6 +183,7 @@ func NewResolver(options Options) *Resolver {
 		productionBOM:         defaultProductionBOM(options.ProductionBOM),
 		productionRoute:       defaultProductionRoute(options.ProductionRoute),
 		productionCost:        defaultProductionCost(options.ProductionCost),
+		qualityProfile:        defaultQualityProfile(options.QualityProfile),
 		inventoryCost:         options.InventoryCost,
 		receivableDelayRounds: normalizedDelayRounds(options.ReceivableDelayRounds),
 		payableDelayRounds:    normalizedDelayRounds(options.PayableDelayRounds),
@@ -190,6 +225,7 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 		productionBOM:         r.productionBOM,
 		productionRoute:       r.productionRoute,
 		productionCost:        r.productionCost,
+		qualityProfile:        r.qualityProfile,
 		inventoryCost:         r.inventoryCost,
 		receivableDelayRounds: r.receivableDelayRounds,
 		payableDelayRounds:    r.payableDelayRounds,
@@ -211,6 +247,8 @@ func (r *Resolver) ResolveRound(state domain.MatchState, actions []domain.Action
 
 	phase.resolveProcurement(actionForRole(orderedActions, domain.RoleProcurementManager))
 	phase.receiveSupply()
+	phase.releaseInspectionHolds()
+	phase.processCustomerReturns()
 	phase.resolveProduction(actionForRole(orderedActions, domain.RoleProductionManager))
 	phase.resolveSales(actionForRole(orderedActions, domain.RoleSalesManager))
 
@@ -251,6 +289,7 @@ type roundPhase struct {
 	productionBOM         ProductionBOMHook
 	productionRoute       ProductionRouteHook
 	productionCost        ProductionCostHook
+	qualityProfile        QualityProfileHook
 	inventoryCost         InventoryCarryingCostHook
 	receivableDelayRounds int
 	payableDelayRounds    int
@@ -261,21 +300,24 @@ type roundPhase struct {
 }
 
 type resolutionStats struct {
-	revenue           domain.Money
-	procurementSpend  domain.Money
-	productionSpend   domain.Money
-	payrollExpense    domain.Money
-	laborCost         domain.Money
-	overtimeCost      domain.Money
-	holdingCost       domain.Money
-	debtServiceCost   domain.Money
-	shippedUnits      domain.Units
-	producedUnits     domain.Units
-	lostSalesUnits    domain.Units
-	cashReceipts      domain.Money
-	cashDisbursements domain.Money
-	idleLaborUnits    domain.Units
-	overtimeUnits     domain.Units
+	revenue             domain.Money
+	procurementSpend    domain.Money
+	productionSpend     domain.Money
+	payrollExpense      domain.Money
+	laborCost           domain.Money
+	overtimeCost        domain.Money
+	holdingCost         domain.Money
+	debtServiceCost     domain.Money
+	shippedUnits        domain.Units
+	producedUnits       domain.Units
+	lostSalesUnits      domain.Units
+	cashReceipts        domain.Money
+	cashDisbursements   domain.Money
+	idleLaborUnits      domain.Units
+	overtimeUnits       domain.Units
+	scrapUnits          domain.Units
+	reworkUnits         domain.Units
+	customerReturnUnits domain.Units
 }
 
 func (p *roundPhase) resolveProcurement(action *domain.ActionSubmission) {
@@ -439,6 +481,180 @@ func (p *roundPhase) receiveSupply() {
 	}
 }
 
+func (p *roundPhase) releaseInspectionHolds() {
+	if len(p.state.Plant.InspectionHolds) == 0 {
+		return
+	}
+
+	remaining := make([]domain.InspectionHoldInventory, 0, len(p.state.Plant.InspectionHolds))
+	for _, item := range p.state.Plant.InspectionHolds {
+		if item.ReleaseRound > p.currentRound {
+			remaining = append(remaining, item)
+			continue
+		}
+		addFinishedInventory(&p.state.Plant.FinishedInventory, item.ProductID, item.Quantity, item.UnitCost)
+		p.appendEvent(domain.EventInspectionHoldReleased, domain.ActorPlantSystem, fmt.Sprintf("Released %d %s from inspection hold", item.Quantity, item.ProductID), map[string]any{
+			"product_id":    string(item.ProductID),
+			"quantity":      int(item.Quantity),
+			"reason":        item.Reason,
+			"release_round": int(item.ReleaseRound),
+		})
+	}
+	p.state.Plant.InspectionHolds = remaining
+}
+
+func (p *roundPhase) processCustomerReturns() {
+	if len(p.state.Plant.PendingReturns) == 0 {
+		return
+	}
+
+	due := make([]domain.CustomerReturnCommitment, 0, len(p.state.Plant.PendingReturns))
+	remaining := make([]domain.CustomerReturnCommitment, 0, len(p.state.Plant.PendingReturns))
+	for _, item := range p.state.Plant.PendingReturns {
+		if item.DueRound <= p.currentRound {
+			due = append(due, item)
+			continue
+		}
+		remaining = append(remaining, item)
+	}
+	p.state.Plant.PendingReturns = remaining
+
+	for _, item := range due {
+		p.stats.customerReturnUnits += item.Quantity
+		addInspectionHoldInventory(&p.state.Plant.InspectionHolds, item.ProductID, item.Quantity, item.UnitCost, p.currentRound, p.currentRound+1, "customer_return")
+		p.appendEvent(domain.EventInspectionHoldPlaced, domain.ActorPlantSystem, fmt.Sprintf("Placed %d returned %s on inspection hold", item.Quantity, item.ProductID), map[string]any{
+			"product_id":    string(item.ProductID),
+			"quantity":      int(item.Quantity),
+			"reason":        "customer_return",
+			"release_round": int(p.currentRound + 1),
+		})
+		p.state.Plant.Backlog = append(p.state.Plant.Backlog, domain.BacklogEntry{
+			CustomerID:  item.CustomerID,
+			ProductID:   item.ProductID,
+			Quantity:    item.Quantity,
+			OriginRound: p.currentRound,
+		})
+		if customer := findCustomer(p.state.Customers, item.CustomerID); customer != nil {
+			customer.Sentiment--
+			p.appendEvent(domain.EventCustomerSentimentMoved, domain.ActorPlantSystem, fmt.Sprintf("Customer %s sentiment decreased after return", item.CustomerID), map[string]any{
+				"customer_id": string(item.CustomerID),
+				"sentiment":   customer.Sentiment,
+			})
+		}
+		p.appendEvent(domain.EventCustomerReturnReceived, domain.ActorPlantSystem, fmt.Sprintf("Received %d returned %s from %s", item.Quantity, item.ProductID, item.CustomerID), map[string]any{
+			"return_id":     item.ReturnID,
+			"customer_id":   string(item.CustomerID),
+			"product_id":    string(item.ProductID),
+			"quantity":      int(item.Quantity),
+			"release_round": int(p.currentRound + 1),
+		})
+		p.appendEvent(domain.EventBacklogCreated, domain.ActorPlantSystem, fmt.Sprintf("Booked %d replacement units of %s backlog for %s", item.Quantity, item.ProductID, item.CustomerID), map[string]any{
+			"customer_id": string(item.CustomerID),
+			"product_id":  string(item.ProductID),
+			"quantity":    int(item.Quantity),
+			"reason":      "customer_return",
+		})
+	}
+	if len(due) > 0 {
+		p.syncCustomerBacklog(p.state.Plant.Backlog)
+	}
+}
+
+func (p *roundPhase) completeFinishedUnits(productID domain.ProductID, workstationID domain.WorkstationID, quantity domain.Units, unitCost domain.Money, overtimeUsed bool) {
+	if quantity <= 0 {
+		return
+	}
+
+	profile := normalizedQualityProfile(p.qualityProfile(QualityProfileContext{
+		State:         p.state.Clone(),
+		CurrentRound:  p.currentRound,
+		Phase:         QualityPhaseProductionFinal,
+		ProductID:     productID,
+		WorkstationID: workstationID,
+		Quantity:      quantity,
+		Stressed:      p.stressedStations[workstationID],
+		OvertimeUsed:  overtimeUsed,
+	}))
+	scrapQty, reworkQty, holdQty := resolveFinishedQuality(quantity, profile, p.random)
+	goodQty := max(quantity-scrapQty-reworkQty-holdQty, 0)
+
+	if scrapQty > 0 {
+		p.stats.scrapUnits += scrapQty
+		p.appendEvent(domain.EventQualityScrapped, domain.ActorPlantSystem, fmt.Sprintf("Scrapped %d %s during final inspection", scrapQty, productID), map[string]any{
+			"product_id":     string(productID),
+			"quantity":       int(scrapQty),
+			"workstation_id": string(workstationID),
+		})
+	}
+	if reworkQty > 0 {
+		p.stats.reworkUnits += reworkQty
+		addWIPInventory(&p.state.Plant.WIPInventory, productID, workstationID, reworkQty, unitCost)
+		p.appendEvent(domain.EventQualityReworkCreated, domain.ActorPlantSystem, fmt.Sprintf("Sent %d %s back for rework", reworkQty, productID), map[string]any{
+			"product_id":     string(productID),
+			"quantity":       int(reworkQty),
+			"workstation_id": string(workstationID),
+		})
+	}
+	if holdQty > 0 {
+		releaseRound := p.currentRound + domain.RoundNumber(max(profile.InspectionHoldRounds, 1))
+		addInspectionHoldInventory(&p.state.Plant.InspectionHolds, productID, holdQty, unitCost, p.currentRound, releaseRound, "production_quality")
+		p.appendEvent(domain.EventInspectionHoldPlaced, domain.ActorPlantSystem, fmt.Sprintf("Placed %d %s on inspection hold", holdQty, productID), map[string]any{
+			"product_id":     string(productID),
+			"quantity":       int(holdQty),
+			"workstation_id": string(workstationID),
+			"release_round":  int(releaseRound),
+		})
+	}
+	if goodQty > 0 {
+		addFinishedInventory(&p.state.Plant.FinishedInventory, productID, goodQty, unitCost)
+		p.stats.producedUnits += goodQty
+		p.appendEvent(domain.EventFinishedGoodsProduced, domain.ActorPlantSystem, fmt.Sprintf("Finished %d %s", goodQty, productID), map[string]any{
+			"product_id":     string(productID),
+			"quantity":       int(goodQty),
+			"workstation_id": string(workstationID),
+			"inventory_cost": int(inventoryCost(goodQty, unitCost)),
+		})
+	}
+}
+
+func (p *roundPhase) scheduleCustomerReturns(customerID domain.CustomerID, productID domain.ProductID, quantity domain.Units, unitCost domain.Money) {
+	if quantity <= 0 {
+		return
+	}
+
+	profile := normalizedQualityProfile(p.qualityProfile(QualityProfileContext{
+		State:        p.state.Clone(),
+		CurrentRound: p.currentRound,
+		Phase:        QualityPhaseShipment,
+		ProductID:    productID,
+		CustomerID:   customerID,
+		Quantity:     quantity,
+	}))
+	returnQty := resolveReturnQuantity(quantity, profile.CustomerReturnRatePct, p.random)
+	if returnQty <= 0 {
+		return
+	}
+
+	delayRounds := max(profile.ReturnDelayRounds, 1)
+	item := domain.CustomerReturnCommitment{
+		ReturnID:     fmt.Sprintf("return-r%d-%d", p.currentRound, len(p.state.Plant.PendingReturns)+1),
+		CustomerID:   customerID,
+		ProductID:    productID,
+		Quantity:     returnQty,
+		UnitCost:     unitCost,
+		DueRound:     p.currentRound + domain.RoundNumber(delayRounds),
+		CreatedRound: p.currentRound,
+	}
+	p.state.Plant.PendingReturns = append(p.state.Plant.PendingReturns, item)
+	p.appendEvent(domain.EventCustomerReturnScheduled, domain.ActorPlantSystem, fmt.Sprintf("Scheduled %d %s customer return(s) from %s", returnQty, productID, customerID), map[string]any{
+		"return_id":   item.ReturnID,
+		"customer_id": string(customerID),
+		"product_id":  string(productID),
+		"quantity":    int(returnQty),
+		"due_round":   int(item.DueRound),
+	})
+}
+
 func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 	if action == nil || action.Action.Production == nil {
 		return
@@ -596,14 +812,7 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 				CurrentStationID: allocation.WorkstationID,
 			})
 			if route.Finished {
-				addFinishedInventory(&p.state.Plant.FinishedInventory, allocation.ProductID, domain.Units(advance), perUnitCost(advancedCost, domain.Units(advance)))
-				p.stats.producedUnits += domain.Units(advance)
-				p.appendEvent(domain.EventFinishedGoodsProduced, domain.ActorPlantSystem, fmt.Sprintf("Finished %d %s", advance, allocation.ProductID), map[string]any{
-					"product_id":     string(allocation.ProductID),
-					"quantity":       int(advance),
-					"workstation_id": string(allocation.WorkstationID),
-					"inventory_cost": int(advancedCost),
-				})
+				p.completeFinishedUnits(allocation.ProductID, allocation.WorkstationID, domain.Units(advance), perUnitCost(advancedCost, domain.Units(advance)), overtimeUsed > 0)
 				continue
 			}
 		}
@@ -615,14 +824,7 @@ func (p *roundPhase) resolveProduction(action *domain.ActionSubmission) {
 			CurrentStationID: allocation.WorkstationID,
 		})
 		if route.Finished {
-			addFinishedInventory(&p.state.Plant.FinishedInventory, allocation.ProductID, domain.Units(advance), perUnitCost(advancedCost, domain.Units(advance)))
-			p.stats.producedUnits += domain.Units(advance)
-			p.appendEvent(domain.EventFinishedGoodsProduced, domain.ActorPlantSystem, fmt.Sprintf("Finished %d %s", advance, allocation.ProductID), map[string]any{
-				"product_id":     string(allocation.ProductID),
-				"quantity":       int(advance),
-				"workstation_id": string(allocation.WorkstationID),
-				"inventory_cost": int(advancedCost),
-			})
+			p.completeFinishedUnits(allocation.ProductID, allocation.WorkstationID, domain.Units(advance), perUnitCost(advancedCost, domain.Units(advance)), overtimeUsed > 0)
 			continue
 		}
 
@@ -687,6 +889,7 @@ func (p *roundPhase) resolveSales(action *domain.ActionSubmission) {
 		onHand := finishedQuantity(p.state.Plant.FinishedInventory, entry.ProductID)
 		shipped := minUnits(entry.Quantity, onHand)
 		if shipped > 0 {
+			unitCost := finishedUnitCost(p.state.Plant.FinishedInventory, entry.ProductID)
 			takeFinishedInventory(&p.state.Plant.FinishedInventory, entry.ProductID, shipped)
 			entry.Quantity -= shipped
 
@@ -705,6 +908,7 @@ func (p *roundPhase) resolveSales(action *domain.ActionSubmission) {
 				"quantity":    int(shipped),
 				"unit_price":  int(unitPrice),
 			})
+			p.scheduleCustomerReturns(entry.CustomerID, entry.ProductID, shipped, unitCost)
 		}
 
 		if entry.Quantity > 0 {
@@ -796,6 +1000,12 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 		inventoryValue += inventoryCost(item.OnHandQty, item.UnitCost)
 	}
 
+	inspectionHoldUnits := domain.Units(0)
+	for _, item := range p.state.Plant.InspectionHolds {
+		inspectionHoldUnits += item.Quantity
+		inventoryValue += inventoryCost(item.Quantity, item.UnitCost)
+	}
+
 	capacityLossUnits := domain.Units(0)
 	for _, workstation := range p.state.Plant.Workstations {
 		capacityLossUnits += domain.Units(workstation.StressCapacityLoss)
@@ -830,10 +1040,14 @@ func (p *roundPhase) computeMetrics() domain.PlantMetrics {
 		LostSalesUnits:        p.stats.lostSalesUnits,
 		PartsOnHandUnits:      partsUnits,
 		FinishedGoodsUnits:    finishedUnits,
+		InspectionHoldUnits:   inspectionHoldUnits,
 		ProductionOutputUnits: p.stats.producedUnits,
 		CapacityLossUnits:     capacityLossUnits,
 		IdleLaborUnits:        p.stats.idleLaborUnits,
 		OvertimeUnits:         p.stats.overtimeUnits,
+		ScrapUnits:            p.stats.scrapUnits,
+		ReworkUnits:           p.stats.reworkUnits,
+		CustomerReturnUnits:   p.stats.customerReturnUnits,
 		SupplierReliability:   averageSupplierReliability(p.state.Suppliers),
 	}
 }
@@ -1659,10 +1873,43 @@ func addFinishedInventory(items *[]domain.FinishedInventory, productID domain.Pr
 	*items = append(*items, domain.FinishedInventory{ProductID: productID, OnHandQty: quantity, UnitCost: unitCost})
 }
 
+func addInspectionHoldInventory(items *[]domain.InspectionHoldInventory, productID domain.ProductID, quantity domain.Units, unitCost domain.Money, holdRound, releaseRound domain.RoundNumber, reason string) {
+	if quantity <= 0 {
+		return
+	}
+
+	for index := range *items {
+		if (*items)[index].ProductID == productID && (*items)[index].ReleaseRound == releaseRound && (*items)[index].Reason == reason {
+			(*items)[index].Quantity += quantity
+			if (*items)[index].UnitCost <= 0 {
+				(*items)[index].UnitCost = unitCost
+			}
+			return
+		}
+	}
+	*items = append(*items, domain.InspectionHoldInventory{
+		ProductID:    productID,
+		Quantity:     quantity,
+		UnitCost:     unitCost,
+		HoldRound:    holdRound,
+		ReleaseRound: releaseRound,
+		Reason:       reason,
+	})
+}
+
 func finishedQuantity(items []domain.FinishedInventory, productID domain.ProductID) domain.Units {
 	for _, item := range items {
 		if item.ProductID == productID {
 			return item.OnHandQty
+		}
+	}
+	return 0
+}
+
+func finishedUnitCost(items []domain.FinishedInventory, productID domain.ProductID) domain.Money {
+	for _, item := range items {
+		if item.ProductID == productID {
+			return item.UnitCost
 		}
 	}
 	return 0
@@ -1992,6 +2239,16 @@ func defaultProductionCost(hook ProductionCostHook) ProductionCostHook {
 	}
 }
 
+func defaultQualityProfile(hook QualityProfileHook) QualityProfileHook {
+	if hook != nil {
+		return hook
+	}
+
+	return func(_ QualityProfileContext) QualityProfile {
+		return QualityProfile{}
+	}
+}
+
 func spendForQuantity(quantity domain.Units, unitCost domain.Money) domain.Money {
 	return domain.Money(quantity) * unitCost
 }
@@ -2019,6 +2276,80 @@ func carryingCost(amount domain.Money) domain.Money {
 		return 0
 	}
 	return max(1, (amount+9)/10)
+}
+
+func normalizedQualityProfile(profile QualityProfile) QualityProfile {
+	profile.ScrapRatePct = clampPct(profile.ScrapRatePct)
+	profile.ReworkRatePct = clampPct(profile.ReworkRatePct)
+	profile.InspectionHoldRatePct = clampPct(profile.InspectionHoldRatePct)
+	profile.CustomerReturnRatePct = clampPct(profile.CustomerReturnRatePct)
+	if total := profile.ScrapRatePct + profile.ReworkRatePct + profile.InspectionHoldRatePct; total > 100 {
+		profile.InspectionHoldRatePct = max(0, profile.InspectionHoldRatePct-(total-100))
+	}
+	if profile.InspectionHoldRounds < 0 {
+		profile.InspectionHoldRounds = 0
+	}
+	if profile.ReturnDelayRounds < 0 {
+		profile.ReturnDelayRounds = 0
+	}
+	return profile
+}
+
+func resolveFinishedQuality(quantity domain.Units, profile QualityProfile, random ports.RandomSource) (domain.Units, domain.Units, domain.Units) {
+	scrap := domain.Units(0)
+	rework := domain.Units(0)
+	hold := domain.Units(0)
+	for unit := domain.Units(0); unit < quantity; unit++ {
+		roll := qualityRoll(random)
+		switch {
+		case roll < profile.ScrapRatePct:
+			scrap++
+		case roll < profile.ScrapRatePct+profile.ReworkRatePct:
+			rework++
+		case roll < profile.ScrapRatePct+profile.ReworkRatePct+profile.InspectionHoldRatePct:
+			hold++
+		}
+	}
+	if random == nil {
+		scrap = countByPct(quantity, profile.ScrapRatePct)
+		rework = countByPct(max(quantity-scrap, 0), profile.ReworkRatePct)
+		hold = countByPct(max(quantity-scrap-rework, 0), profile.InspectionHoldRatePct)
+	}
+	return scrap, rework, hold
+}
+
+func resolveReturnQuantity(quantity domain.Units, pct int, random ports.RandomSource) domain.Units {
+	if pct <= 0 || quantity <= 0 {
+		return 0
+	}
+	if random == nil {
+		return countByPct(quantity, pct)
+	}
+	returned := domain.Units(0)
+	for unit := domain.Units(0); unit < quantity; unit++ {
+		if qualityRoll(random) < pct {
+			returned++
+		}
+	}
+	return returned
+}
+
+func qualityRoll(random ports.RandomSource) int {
+	if random == nil {
+		return 100
+	}
+	return random.IntN(100)
+}
+
+func countByPct(quantity domain.Units, pct int) domain.Units {
+	if quantity <= 0 || pct <= 0 {
+		return 0
+	}
+	return domain.Units((int(quantity) * pct) / 100)
+}
+
+func clampPct(pct int) int {
+	return min(100, max(0, pct))
 }
 
 func minCapacity(values ...domain.CapacityUnits) domain.CapacityUnits {

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -829,6 +829,112 @@ func TestResolverSchedulesReceivablesPayablesAndUsesProjectedDebtCapacity(t *tes
 	}
 }
 
+func TestResolverSchedulesPayrollAsAccruedExpenseWhenDelayed(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		PayrollDelayRounds: 1,
+	})
+
+	state := fixtureState()
+	state.Plant.PartsInventory = nil
+	state.Plant.WIPInventory = nil
+	state.Plant.FinishedInventory = nil
+	state.Plant.InTransitSupply = nil
+	state.Plant.Backlog = nil
+	state.Customers = nil
+	state.Plant.Workstations = []domain.WorkstationState{
+		{
+			WorkstationID:            "assembly",
+			DisplayName:              "Assembly",
+			CapacityPerRound:         2,
+			LaborCapacityPerRound:    2,
+			LaborCostPerCapacityUnit: 3,
+		},
+	}
+	actions := fixtureActions()
+	actions[0].Action.Procurement.Orders = nil
+	actions[1].Action.Production.Releases = nil
+	actions[1].Action.Production.CapacityAllocation = nil
+	actions[2].Action.Sales.ProductOffers = nil
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.Round.Metrics.PayrollExpense; got != 6 {
+		t.Fatalf("PayrollExpense = %d, want 6", got)
+	}
+	if got := result.Round.Metrics.LaborCost; got != 6 {
+		t.Fatalf("LaborCost = %d, want 6", got)
+	}
+	if got := result.Round.Metrics.CashDisbursements; got != 0 {
+		t.Fatalf("CashDisbursements = %d, want 0 before payroll is due", got)
+	}
+	if got := result.NextState.Plant.Cash; got != 10 {
+		t.Fatalf("Plant.Cash = %d, want 10 before delayed payroll payment", got)
+	}
+	if got := len(result.NextState.Plant.Payables); got != 1 {
+		t.Fatalf("Payables len = %d, want 1 payroll commitment", got)
+	}
+	if got := result.NextState.Plant.Payables[0].Kind; got != domain.CashCommitmentPayroll {
+		t.Fatalf("Payables[0].Kind = %q, want payroll", got)
+	}
+	if got := result.NextState.Plant.Payables[0].DueRound; got != 3 {
+		t.Fatalf("Payables[0].DueRound = %d, want 3", got)
+	}
+	if !containsEvent(result.Round.Events, domain.EventPayrollScheduled) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventPayrollScheduled, result.Round.Events)
+	}
+}
+
+func TestResolverPaysDuePayrollCommitments(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{})
+
+	state := fixtureState()
+	state.Plant.PartsInventory = nil
+	state.Plant.WIPInventory = nil
+	state.Plant.FinishedInventory = nil
+	state.Plant.InTransitSupply = nil
+	state.Plant.Backlog = nil
+	state.Customers = nil
+	state.Plant.Workstations = []domain.WorkstationState{
+		{WorkstationID: "assembly", DisplayName: "Assembly", CapacityPerRound: 1},
+	}
+	state.Plant.Payables = []domain.CashCommitment{
+		{
+			CommitmentID: "payroll-r1-1",
+			Kind:         domain.CashCommitmentPayroll,
+			Amount:       4,
+			DueRound:     2,
+			CreatedRound: 1,
+			ReferenceID:  "payroll-r1",
+		},
+	}
+	actions := fixtureActions()
+	actions[0].Action.Procurement.Orders = nil
+	actions[1].Action.Production.Releases = nil
+	actions[1].Action.Production.CapacityAllocation = nil
+	actions[2].Action.Sales.ProductOffers = nil
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := result.NextState.Plant.Cash; got != 6 {
+		t.Fatalf("Plant.Cash = %d, want 6 after payroll payment", got)
+	}
+	if got := len(result.NextState.Plant.Payables); got != 0 {
+		t.Fatalf("Payables len = %d, want 0 after payroll payment", got)
+	}
+	if got := result.Round.Metrics.CashDisbursements; got != 4 {
+		t.Fatalf("CashDisbursements = %d, want 4", got)
+	}
+	if !containsEvent(result.Round.Events, domain.EventPayrollPaid) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventPayrollPaid, result.Round.Events)
+	}
+}
+
 func TestResolverUsesSupplierLeadTimeAndReliabilityTerms(t *testing.T) {
 	resolver := engine.NewResolver(engine.Options{
 		ProcurementTerms: func(ctx engine.ProcurementTermsContext) engine.ProcurementTerms {

--- a/internal/engine/resolver_test.go
+++ b/internal/engine/resolver_test.go
@@ -1015,6 +1015,162 @@ func TestResolverUsesSupplierLeadTimeAndReliabilityTerms(t *testing.T) {
 	}
 }
 
+func TestResolverScrapsFinishedUnitsOnQualityFailure(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		QualityProfile: func(ctx engine.QualityProfileContext) engine.QualityProfile {
+			if ctx.Phase == engine.QualityPhaseProductionFinal {
+				return engine.QualityProfile{ScrapRatePct: 100}
+			}
+			return engine.QualityProfile{}
+		},
+	})
+
+	state := qualityFixtureState()
+	actions := qualityFixtureActions()
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := finishedQty(result.NextState.Plant.FinishedInventory, "widget"); got != 0 {
+		t.Fatalf("FinishedInventory(widget) = %d, want 0", got)
+	}
+	if got := result.Round.Metrics.ScrapUnits; got != 1 {
+		t.Fatalf("ScrapUnits = %d, want 1", got)
+	}
+	if !containsEvent(result.Round.Events, domain.EventQualityScrapped) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventQualityScrapped, result.Round.Events)
+	}
+}
+
+func TestResolverRoutesFinishedUnitsToRework(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		QualityProfile: func(ctx engine.QualityProfileContext) engine.QualityProfile {
+			if ctx.Phase == engine.QualityPhaseProductionFinal {
+				return engine.QualityProfile{ReworkRatePct: 100}
+			}
+			return engine.QualityProfile{}
+		},
+	})
+
+	state := qualityFixtureState()
+	actions := qualityFixtureActions()
+
+	result, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() error = %v", err)
+	}
+
+	if got := wipQty(result.NextState.Plant.WIPInventory, "widget", "assembly"); got != 1 {
+		t.Fatalf("WIP(widget/assembly) = %d, want 1 returned for rework", got)
+	}
+	if got := result.Round.Metrics.ReworkUnits; got != 1 {
+		t.Fatalf("ReworkUnits = %d, want 1", got)
+	}
+	if !containsEvent(result.Round.Events, domain.EventQualityReworkCreated) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventQualityReworkCreated, result.Round.Events)
+	}
+}
+
+func TestResolverPlacesAndReleasesInspectionHolds(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		QualityProfile: func(ctx engine.QualityProfileContext) engine.QualityProfile {
+			if ctx.Phase == engine.QualityPhaseProductionFinal {
+				return engine.QualityProfile{InspectionHoldRatePct: 100, InspectionHoldRounds: 1}
+			}
+			return engine.QualityProfile{}
+		},
+	})
+
+	state := qualityFixtureState()
+	actions := qualityFixtureActions()
+
+	first, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() first error = %v", err)
+	}
+	if got := len(first.NextState.Plant.InspectionHolds); got != 1 {
+		t.Fatalf("InspectionHolds len = %d, want 1", got)
+	}
+	if got := first.Round.Metrics.InspectionHoldUnits; got != 1 {
+		t.Fatalf("InspectionHoldUnits = %d, want 1", got)
+	}
+	if !containsEvent(first.Round.Events, domain.EventInspectionHoldPlaced) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventInspectionHoldPlaced, first.Round.Events)
+	}
+
+	second, err := resolver.ResolveRound(first.NextState, nil, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() second error = %v", err)
+	}
+	if got := finishedQty(second.NextState.Plant.FinishedInventory, "widget"); got != 1 {
+		t.Fatalf("FinishedInventory(widget) after release = %d, want 1", got)
+	}
+	if !containsEvent(second.Round.Events, domain.EventInspectionHoldReleased) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventInspectionHoldReleased, second.Round.Events)
+	}
+}
+
+func TestResolverSchedulesAndProcessesCustomerReturns(t *testing.T) {
+	resolver := engine.NewResolver(engine.Options{
+		QualityProfile: func(ctx engine.QualityProfileContext) engine.QualityProfile {
+			if ctx.Phase == engine.QualityPhaseShipment {
+				return engine.QualityProfile{CustomerReturnRatePct: 100, ReturnDelayRounds: 1}
+			}
+			return engine.QualityProfile{}
+		},
+	})
+
+	state := fixtureState()
+	state.Plant.PartsInventory = nil
+	state.Plant.WIPInventory = nil
+	state.Plant.FinishedInventory = []domain.FinishedInventory{{ProductID: "widget", OnHandQty: 1, UnitCost: 2}}
+	state.Plant.InTransitSupply = nil
+	state.Plant.Backlog = []domain.BacklogEntry{{CustomerID: "cust-1", ProductID: "widget", Quantity: 1, OriginRound: 1}}
+	for index := range state.Customers {
+		state.Customers[index].Backlog = nil
+	}
+	actions := fixtureActions()
+	actions[0].Action.Procurement.Orders = nil
+	actions[1].Action.Production.Releases = nil
+	actions[1].Action.Production.CapacityAllocation = nil
+
+	first, err := resolver.ResolveRound(state, actions, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() first error = %v", err)
+	}
+	if got := len(first.NextState.Plant.PendingReturns); got != 1 {
+		t.Fatalf("PendingReturns len = %d, want 1", got)
+	}
+	if !containsEvent(first.Round.Events, domain.EventCustomerReturnScheduled) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventCustomerReturnScheduled, first.Round.Events)
+	}
+
+	second, err := resolver.ResolveRound(first.NextState, nil, seeded.New(1))
+	if err != nil {
+		t.Fatalf("ResolveRound() second error = %v", err)
+	}
+	if got := len(second.NextState.Plant.PendingReturns); got != 0 {
+		t.Fatalf("PendingReturns len after receipt = %d, want 0", got)
+	}
+	if got := len(second.NextState.Plant.InspectionHolds); got != 1 {
+		t.Fatalf("InspectionHolds len after return = %d, want 1", got)
+	}
+	if got := backlogQty(second.NextState.Plant.Backlog, "cust-1", "widget"); got != 1 {
+		t.Fatalf("Backlog(cust-1/widget) after return = %d, want 1", got)
+	}
+	if got := second.NextState.Customers[0].Sentiment; got != 4 {
+		t.Fatalf("Customer sentiment after return = %d, want 4", got)
+	}
+	if got := second.Round.Metrics.CustomerReturnUnits; got != 1 {
+		t.Fatalf("CustomerReturnUnits = %d, want 1", got)
+	}
+	if !containsEvent(second.Round.Events, domain.EventCustomerReturnReceived) {
+		t.Fatalf("Round.Events missing %q: %#v", domain.EventCustomerReturnReceived, second.Round.Events)
+	}
+}
+
 func TestResolverUsesConfiguredBacklogExpiryRounds(t *testing.T) {
 	resolver := engine.NewResolver(engine.Options{
 		BacklogExpiryRounds: 3,
@@ -1210,6 +1366,33 @@ func wipQty(items []domain.WIPInventory, productID domain.ProductID, workstation
 		}
 	}
 	return 0
+}
+
+func qualityFixtureState() domain.MatchState {
+	state := fixtureState()
+	state.Plant.PartsInventory = nil
+	state.Plant.WIPInventory = []domain.WIPInventory{
+		{ProductID: "widget", WorkstationID: "assembly", Quantity: 1, UnitCost: 2},
+	}
+	state.Plant.FinishedInventory = nil
+	state.Plant.InTransitSupply = nil
+	state.Plant.Backlog = nil
+	state.Customers = nil
+	state.Plant.Workstations = []domain.WorkstationState{
+		{WorkstationID: "assembly", DisplayName: "Assembly", CapacityPerRound: 1, EffectiveCapacityPerRound: 1},
+	}
+	return state
+}
+
+func qualityFixtureActions() []domain.ActionSubmission {
+	actions := fixtureActions()
+	actions[0].Action.Procurement.Orders = nil
+	actions[1].Action.Production.Releases = nil
+	actions[1].Action.Production.CapacityAllocation = []domain.CapacityAllocation{
+		{WorkstationID: "assembly", ProductID: "widget", Capacity: 1},
+	}
+	actions[2].Action.Sales.ProductOffers = nil
+	return actions
 }
 
 func supplierScore(items []domain.SupplierState, supplierID domain.SupplierID) int {

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -76,11 +76,17 @@ type ProductionModel struct {
 }
 
 type Product struct {
-	ID           domain.ProductID
-	DisplayName  string
-	BOM          []domain.BOMLine
-	Route        []domain.WorkstationID
-	BaseUnitCost domain.Money
+	ID                        domain.ProductID
+	DisplayName               string
+	BOM                       []domain.BOMLine
+	Route                     []domain.WorkstationID
+	BaseUnitCost              domain.Money
+	ScrapRatePct              int
+	ReworkRatePct             int
+	InspectionHoldRatePct     int
+	CustomerReturnRatePct     int
+	InspectionHoldRounds      int
+	CustomerReturnDelayRounds int
 }
 
 type Part struct {
@@ -256,6 +262,30 @@ func (d Definition) ResolverOptions() engine.Options {
 				return engine.ProductionCost{CostPerCapacityUnit: 1}
 			}
 			return engine.ProductionCost{CostPerCapacityUnit: workstation.CostPerUnit}
+		},
+		QualityProfile: func(ctx engine.QualityProfileContext) engine.QualityProfile {
+			product, ok := productByID[ctx.ProductID]
+			if !ok {
+				return engine.QualityProfile{}
+			}
+			profile := engine.QualityProfile{
+				ScrapRatePct:          product.ScrapRatePct,
+				ReworkRatePct:         product.ReworkRatePct,
+				InspectionHoldRatePct: product.InspectionHoldRatePct,
+				CustomerReturnRatePct: product.CustomerReturnRatePct,
+				InspectionHoldRounds:  product.InspectionHoldRounds,
+				ReturnDelayRounds:     product.CustomerReturnDelayRounds,
+			}
+			if ctx.Phase == engine.QualityPhaseProductionFinal {
+				if ctx.Stressed {
+					profile.ScrapRatePct += 10
+					profile.ReworkRatePct += 10
+				}
+				if ctx.OvertimeUsed {
+					profile.InspectionHoldRatePct += 10
+				}
+			}
+			return profile
 		},
 		ReceivableDelayRounds: d.FinanceModel.ReceivableDelayRounds,
 		PayableDelayRounds:    d.FinanceModel.PayableDelayRounds,

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -143,6 +143,7 @@ type FinanceModel struct {
 	Description           string
 	ReceivableDelayRounds int
 	PayableDelayRounds    int
+	PayrollDelayRounds    int
 }
 
 type DemandAssumptions struct {
@@ -258,6 +259,7 @@ func (d Definition) ResolverOptions() engine.Options {
 		},
 		ReceivableDelayRounds: d.FinanceModel.ReceivableDelayRounds,
 		PayableDelayRounds:    d.FinanceModel.PayableDelayRounds,
+		PayrollDelayRounds:    d.FinanceModel.PayrollDelayRounds,
 		WorldUpdate: func(ctx *engine.WorldUpdateContext) error {
 			return d.applyDemand(ctx)
 		},

--- a/internal/scenario/starter.go
+++ b/internal/scenario/starter.go
@@ -266,8 +266,9 @@ func StarterFinanceModel() FinanceModel {
 	return FinanceModel{
 		ID:                    "net30-lite-weekly",
 		DisplayName:           "Net-30 Lite Weekly Cash Timing",
-		Description:           "Customer receipts settle on customer-specific terms, while supplier invoices settle one round later to keep near-term cash pressure visible.",
+		Description:           "Customer receipts settle on customer-specific terms, while supplier invoices and payroll settle one round later to keep near-term cash pressure visible.",
 		ReceivableDelayRounds: 1,
 		PayableDelayRounds:    1,
+		PayrollDelayRounds:    1,
 	}
 }

--- a/internal/scenario/starter_test.go
+++ b/internal/scenario/starter_test.go
@@ -76,6 +76,9 @@ func TestStarterInitialStateProvidesKnownPlayableSetup(t *testing.T) {
 	if got := starter.FinanceModel.ID; got != "net30-lite-weekly" {
 		t.Fatalf("FinanceModel.ID = %q, want net30-lite-weekly", got)
 	}
+	if got := starter.FinanceModel.PayrollDelayRounds; got != 1 {
+		t.Fatalf("FinanceModel.PayrollDelayRounds = %d, want 1", got)
+	}
 }
 
 func TestStarterResolverOptionsApplyScenarioHooks(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a first quality subsystem with scrap, rework, inspection holds, and customer returns
- store quality-related plant state and expose quality events and metrics in the resolver
- add scenario-facing quality profile hooks so products can express quality behavior cleanly
- cover the new mechanics with targeted engine tests and keep the full test suite green

## Why
Issue #131 identified one of the clearest realism gaps in the plant model: production and shipment outcomes had no quality layer, so there was no way for throughput, backlog, and customer sentiment to reflect scrap, rework, inspection holds, or returns.

## What Changed
- added plant state for inspection holds and pending customer returns
- added quality metrics for scrap, rework, inspection hold units, and customer return units
- added quality events for:
  - scrap
  - rework creation
  - inspection hold placement/release
  - customer return scheduling/receipt
- added a resolver quality hook so scenarios can define product quality behavior
- applied quality outcomes at finished-goods completion and after shipment returns
- added regression tests for:
  - scrap
  - rework
  - inspection hold placement/release
  - customer returns affecting backlog and sentiment

## Impact
Production completion can now divert units into scrap, rework, or temporary inspection holds, and shipped units can create delayed customer returns that feed back into backlog and customer sentiment.

The default quality profile remains effectively off unless a scenario provides quality behavior, so this adds a foundation for future Quality Manager gameplay without forcing every scenario into the mechanic immediately.

## Validation
- `go test ./...`

Closes #131
