### PR TITLE
[codex] Implement typed role report sections for issue #118

### DIFF
--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -350,8 +350,11 @@ func (m Model) renderDepartmentsPane(width, height int) string {
 	if report.BonusReminder != "" {
 		lines = append(lines, "", wrapLine("Bonus: "+report.BonusReminder, paneTextWidth(width)))
 	}
-	for _, detail := range report.Department.DetailLines {
-		lines = append(lines, wrapLine("- "+detail, paneTextWidth(width)))
+	if report.Department.FocusQuestion != "" {
+		lines = append(lines, "", wrapLine("Focus: "+report.Department.FocusQuestion, paneTextWidth(width)))
+	}
+	for _, line := range departmentPaneLines(report.Department) {
+		lines = append(lines, wrapLine("- "+line, paneTextWidth(width)))
 	}
 
 	return renderPane("Departments", lines, width, height, m.focusedPane == paneDepartments)
@@ -414,28 +417,24 @@ func (m Model) renderRoleReportWorkspace(width int) []string {
 
 	lines := []string{
 		fmt.Sprintf("Role report for %s", m.roleTitle()),
-		"View: current briefing, company snapshot, and department metrics",
+		"View: current briefing, typed report sections, and decision prompts",
 	}
 	if report.BonusReminder != "" {
 		lines = append(lines, wrapLine("Bonus reminder: "+report.BonusReminder, paneTextWidth(width)))
 	}
-	company := companywideReportLines(report.Companywide)
-	if len(company) > 0 {
+	if report.Department.FocusQuestion != "" {
+		lines = append(lines, wrapLine("Core decision: "+report.Department.FocusQuestion, paneTextWidth(width)))
+	}
+	if len(report.Companywide.Sections) > 0 {
 		lines = append(lines, "", "Company snapshot")
-		for _, line := range company {
-			lines = append(lines, wrapLine("- "+line, paneTextWidth(width)))
+		for _, section := range report.Companywide.Sections {
+			lines = append(lines, renderReportSectionLines(section, width)...)
 		}
 	}
-	if len(report.Department.KeyMetrics) > 0 {
-		lines = append(lines, "", "Key metrics")
-		for _, metric := range report.Department.KeyMetrics {
-			lines = append(lines, fmt.Sprintf("- %s: %d %s", metric.MetricID, metric.Value, metric.DisplayUnit))
-		}
-	}
-	if len(report.Department.DetailLines) > 0 {
-		lines = append(lines, "", "Role notes")
-		for _, detail := range report.Department.DetailLines {
-			lines = append(lines, wrapLine("- "+detail, paneTextWidth(width)))
+	if len(report.Department.Sections) > 0 {
+		lines = append(lines, "", "Department view")
+		for _, section := range report.Department.Sections {
+			lines = append(lines, renderReportSectionLines(section, width)...)
 		}
 	}
 	if len(lines) == 2 {
@@ -486,10 +485,10 @@ func (m Model) renderStatsPane(width, height int) string {
 		fmt.Sprintf("Debt ceiling: %d", view.ActiveTargets.DebtCeilingTarget),
 	}
 
-	if len(report.Department.KeyMetrics) > 0 {
+	if metrics := departmentStatsMetrics(report.Department); len(metrics) > 0 {
 		lines = append(lines, "", "Role metrics")
-		for _, metric := range report.Department.KeyMetrics {
-			lines = append(lines, fmt.Sprintf("%s: %d %s", metric.MetricID, metric.Value, metric.DisplayUnit))
+		for _, metric := range metrics {
+			lines = append(lines, fmt.Sprintf("%s: %d %s", metric.Label, metric.Metric.Value, metric.Metric.DisplayUnit))
 		}
 	}
 
@@ -1183,47 +1182,114 @@ func timelinePhaseLabel(phase domain.RoundTimelinePhase) string {
 	}
 }
 
-func companywideReportLines(report domain.CompanywidePerformanceReport) []string {
-	lines := []string{
-		fmt.Sprintf("Inventory value: %d", report.CurrentInventoryLevels.TotalValue),
+func lastRoundEntries(rounds []domain.RoundHistoryEntry, limit int) []domain.RoundHistoryEntry {
+	if len(rounds) <= limit {
+		return rounds
+	}
+	return rounds[len(rounds)-limit:]
+}
+
+func departmentPaneLines(report domain.DepartmentPerformanceReport) []string {
+	section := findReportSection(report.Sections, domain.RoleReportSectionExecutiveSummary)
+	if section == nil {
+		return nil
 	}
 
-	lines = append(lines, companyMetricLine("New sales", report.NewSales))
-	lines = append(lines, companyMetricLine("Unshipped sales", report.UnshippedSales))
-	lines = append(lines, companyMetricLine("Sales at risk", report.SalesAtRisk))
-	lines = append(lines, companyUnitMetricLine("Products produced last week", report.ProductsProducedLastWeek))
-	lines = append(lines, fmt.Sprintf("Tracked product financial summaries: %d", len(report.Financials)))
-
+	lines := append([]string{}, section.Summary...)
+	for _, warning := range section.Warnings {
+		lines = append(lines, warning.Headline)
+	}
+	if operating := findReportSection(report.Sections, domain.RoleReportSectionOperatingPicture); operating != nil {
+		lines = append(lines, operating.Facts...)
+	}
 	return lines
 }
 
-func companyMetricLine(label string, items []domain.ProductValueSummary) string {
+func departmentStatsMetrics(report domain.DepartmentPerformanceReport) []domain.RoleReportMetric {
+	if operating := findReportSection(report.Sections, domain.RoleReportSectionOperatingPicture); operating != nil && len(operating.Metrics) > 0 {
+		return operating.Metrics
+	}
+	if executive := findReportSection(report.Sections, domain.RoleReportSectionExecutiveSummary); executive != nil {
+		return executive.Metrics
+	}
+	return nil
+}
+
+func findReportSection(sections []domain.RoleReportSection, kind domain.RoleReportSectionKind) *domain.RoleReportSection {
+	for i := range sections {
+		if sections[i].Kind == kind {
+			return &sections[i]
+		}
+	}
+	return nil
+}
+
+func renderReportSectionLines(section domain.RoleReportSection, width int) []string {
+	lines := []string{section.Title}
+	if section.DecisionFocus != "" {
+		lines = append(lines, wrapLine("Decision support: "+section.DecisionFocus, paneTextWidth(width)))
+	}
+	for _, summary := range section.Summary {
+		lines = append(lines, wrapLine("- "+summary, paneTextWidth(width)))
+	}
+	for _, metric := range section.Metrics {
+		line := fmt.Sprintf("- %s: %d %s", metric.Label, metric.Metric.Value, metric.Metric.DisplayUnit)
+		if metric.Interpretation != "" {
+			line += " | " + metric.Interpretation
+		}
+		lines = append(lines, wrapLine(line, paneTextWidth(width)))
+	}
+	for _, fact := range section.Facts {
+		lines = append(lines, wrapLine("- "+fact, paneTextWidth(width)))
+	}
+	if section.Inventory != nil {
+		lines = append(lines, wrapLine(fmt.Sprintf("- Inventory value: %d", section.Inventory.TotalValue), paneTextWidth(width)))
+		for _, bucket := range section.Inventory.Detail {
+			lines = append(lines, wrapLine(fmt.Sprintf("- %s: %d", bucket.Bucket, bucket.TotalValue), paneTextWidth(width)))
+		}
+	}
+	if len(section.ProductValues) > 0 {
+		lines = append(lines, wrapLine("- "+productValueSummaryLine(section.ProductValues), paneTextWidth(width)))
+	}
+	if len(section.ProductUnits) > 0 {
+		lines = append(lines, wrapLine("- "+productUnitSummaryLine(section.ProductUnits), paneTextWidth(width)))
+	}
+	if len(section.Financials) > 0 {
+		lines = append(lines, wrapLine(fmt.Sprintf("- Tracked product financial summaries: %d", len(section.Financials)), paneTextWidth(width)))
+	}
+	for _, warning := range section.Warnings {
+		lines = append(lines, wrapLine("- Warning: "+warning.Headline, paneTextWidth(width)))
+		lines = append(lines, wrapLine("  "+warning.Detail, paneTextWidth(width)))
+	}
+	for _, tradeoff := range section.Tradeoffs {
+		lines = append(lines, wrapLine("- Tradeoff: "+tradeoff.Focus+" | "+tradeoff.Tension, paneTextWidth(width)))
+		if tradeoff.Guidance != "" {
+			lines = append(lines, wrapLine("  "+tradeoff.Guidance, paneTextWidth(width)))
+		}
+	}
+	for _, prompt := range section.Prompts {
+		lines = append(lines, wrapLine("- Prompt: "+prompt.Question, paneTextWidth(width)))
+		if prompt.WhyItMatters != "" {
+			lines = append(lines, wrapLine("  "+prompt.WhyItMatters, paneTextWidth(width)))
+		}
+	}
+	return append(lines, "")
+}
+
+func productValueSummaryLine(items []domain.ProductValueSummary) string {
 	var units domain.Units
 	var totalValue domain.Money
 	for _, item := range items {
 		units += item.Count
 		totalValue += item.TotalValue
 	}
-	if len(items) == 0 {
-		return label + ": none recorded"
-	}
-	return fmt.Sprintf("%s: %d units across %d products worth %d", label, units, len(items), totalValue)
+	return fmt.Sprintf("Product value summary: %d units across %d products worth %d", units, len(items), totalValue)
 }
 
-func companyUnitMetricLine(label string, items []domain.ProductUnitSummary) string {
+func productUnitSummaryLine(items []domain.ProductUnitSummary) string {
 	var units domain.Units
 	for _, item := range items {
 		units += item.Count
 	}
-	if len(items) == 0 {
-		return label + ": none recorded"
-	}
-	return fmt.Sprintf("%s: %d units across %d products", label, units, len(items))
-}
-
-func lastRoundEntries(rounds []domain.RoundHistoryEntry, limit int) []domain.RoundHistoryEntry {
-	if len(rounds) <= limit {
-		return rounds
-	}
-	return rounds[len(rounds)-limit:]
+	return fmt.Sprintf("Product unit summary: %d units across %d products", units, len(items))
 }

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -662,8 +662,9 @@ func TestModelRoleReportShowsCompanySnapshot(t *testing.T) {
 		"cycle",
 		"Role report for Procurement Manager",
 		"Company snapshot",
+		"Core decision:",
+		"Inventory risk",
 		"Inventory value:",
-		"Tracked product financial summaries:",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("role report missing %q\n%s", want, view)

--- a/internal/domain/reports.go
+++ b/internal/domain/reports.go
@@ -10,20 +10,72 @@ type RoleRoundReport struct {
 	BonusReminder string
 }
 
+type RoleReportSectionKind string
+
+const (
+	RoleReportSectionExecutiveSummary   RoleReportSectionKind = "executive_summary"
+	RoleReportSectionOperatingPicture   RoleReportSectionKind = "operating_picture"
+	RoleReportSectionConstraintRiskView RoleReportSectionKind = "constraint_risk_view"
+	RoleReportSectionTradeoffPressure   RoleReportSectionKind = "tradeoff_pressure_view"
+	RoleReportSectionDecisionPrompts    RoleReportSectionKind = "decision_prompts"
+	RoleReportSectionInventoryRisk      RoleReportSectionKind = "inventory_risk"
+	RoleReportSectionBacklogHealth      RoleReportSectionKind = "backlog_health"
+	RoleReportSectionServiceRisk        RoleReportSectionKind = "service_risk"
+	RoleReportSectionMarginVariance     RoleReportSectionKind = "margin_variance"
+	RoleReportSectionCapacityPressure   RoleReportSectionKind = "capacity_pressure"
+	RoleReportSectionDemandHealth       RoleReportSectionKind = "demand_health"
+	RoleReportSectionCashDebtPressure   RoleReportSectionKind = "cash_debt_pressure"
+	RoleReportSectionOperationalNotes   RoleReportSectionKind = "operational_notes"
+)
+
 type CompanywidePerformanceReport struct {
-	NewSales                 []ProductValueSummary
-	UnshippedSales           []ProductValueSummary
-	SalesAtRisk              []ProductValueSummary
-	ProductsProducedLastWeek []ProductUnitSummary
-	CurrentInventoryLevels   InventoryValueSummary
-	Financials               []ProductFinancialSummary
+	Sections []RoleReportSection
 }
 
 type DepartmentPerformanceReport struct {
-	RoleID       RoleID
-	KeyMetrics   []MetricValue
-	DetailLines  []string
-	BonusSummary string
+	RoleID        RoleID
+	Sections      []RoleReportSection
+	BonusSummary  string
+	FocusQuestion string
+}
+
+type RoleReportSection struct {
+	Kind          RoleReportSectionKind
+	Title         string
+	DecisionFocus string
+	Summary       []string
+	Metrics       []RoleReportMetric
+	Facts         []string
+	ProductValues []ProductValueSummary
+	ProductUnits  []ProductUnitSummary
+	Inventory     *InventoryValueSummary
+	Financials    []ProductFinancialSummary
+	Warnings      []RoleReportWarning
+	Tradeoffs     []RoleReportTradeoff
+	Prompts       []RoleReportPrompt
+}
+
+type RoleReportMetric struct {
+	Metric         MetricValue
+	Label          string
+	Interpretation string
+}
+
+type RoleReportWarning struct {
+	Code     string
+	Headline string
+	Detail   string
+}
+
+type RoleReportTradeoff struct {
+	Focus    string
+	Tension  string
+	Guidance string
+}
+
+type RoleReportPrompt struct {
+	Question     string
+	WhyItMatters string
 }
 
 type ProductValueSummary struct {
@@ -67,21 +119,16 @@ func (r RoleRoundReport) Clone() RoleRoundReport {
 
 func (r CompanywidePerformanceReport) Clone() CompanywidePerformanceReport {
 	return CompanywidePerformanceReport{
-		NewSales:                 slices.Clone(r.NewSales),
-		UnshippedSales:           slices.Clone(r.UnshippedSales),
-		SalesAtRisk:              slices.Clone(r.SalesAtRisk),
-		ProductsProducedLastWeek: slices.Clone(r.ProductsProducedLastWeek),
-		CurrentInventoryLevels:   r.CurrentInventoryLevels.Clone(),
-		Financials:               slices.Clone(r.Financials),
+		Sections: cloneSlice(r.Sections, RoleReportSection.Clone),
 	}
 }
 
 func (r DepartmentPerformanceReport) Clone() DepartmentPerformanceReport {
 	return DepartmentPerformanceReport{
-		RoleID:       r.RoleID,
-		KeyMetrics:   slices.Clone(r.KeyMetrics),
-		DetailLines:  slices.Clone(r.DetailLines),
-		BonusSummary: r.BonusSummary,
+		RoleID:        r.RoleID,
+		Sections:      cloneSlice(r.Sections, RoleReportSection.Clone),
+		BonusSummary:  r.BonusSummary,
+		FocusQuestion: r.FocusQuestion,
 	}
 }
 
@@ -90,4 +137,42 @@ func (s InventoryValueSummary) Clone() InventoryValueSummary {
 		TotalValue: s.TotalValue,
 		Detail:     slices.Clone(s.Detail),
 	}
+}
+
+func (s RoleReportSection) Clone() RoleReportSection {
+	return RoleReportSection{
+		Kind:          s.Kind,
+		Title:         s.Title,
+		DecisionFocus: s.DecisionFocus,
+		Summary:       slices.Clone(s.Summary),
+		Metrics:       cloneSlice(s.Metrics, RoleReportMetric.Clone),
+		Facts:         slices.Clone(s.Facts),
+		ProductValues: slices.Clone(s.ProductValues),
+		ProductUnits:  slices.Clone(s.ProductUnits),
+		Inventory:     clonePtr(s.Inventory, InventoryValueSummary.Clone),
+		Financials:    slices.Clone(s.Financials),
+		Warnings:      cloneSlice(s.Warnings, RoleReportWarning.Clone),
+		Tradeoffs:     cloneSlice(s.Tradeoffs, RoleReportTradeoff.Clone),
+		Prompts:       cloneSlice(s.Prompts, RoleReportPrompt.Clone),
+	}
+}
+
+func (m RoleReportMetric) Clone() RoleReportMetric {
+	return RoleReportMetric{
+		Metric:         m.Metric,
+		Label:          m.Label,
+		Interpretation: m.Interpretation,
+	}
+}
+
+func (w RoleReportWarning) Clone() RoleReportWarning {
+	return w
+}
+
+func (t RoleReportTradeoff) Clone() RoleReportTradeoff {
+	return t
+}
+
+func (p RoleReportPrompt) Clone() RoleReportPrompt {
+	return p
 }

--- a/internal/projection/role_report.go
+++ b/internal/projection/role_report.go
@@ -22,6 +22,7 @@ func buildCompanywidePerformanceReport(state domain.MatchState) domain.Companywi
 	backlogAtRisk := sumBacklogUnitsAtRisk(state.Plant.Backlog)
 	inventory := inventorySummary(state.Plant)
 	financials := financialSummary(latestRound, ok)
+	produced := producedSummary(latestRound, ok)
 
 	return domain.CompanywidePerformanceReport{
 		Sections: []domain.RoleReportSection{
@@ -87,6 +88,7 @@ func buildCompanywidePerformanceReport(state domain.MatchState) domain.Companywi
 					reportMetric("capacity_loss_units", "Capacity loss", int(state.Metrics.CapacityLossUnits), "units", "Capacity loss indicates congestion or stress penalties."),
 					reportMetric("overtime_units", "Overtime", int(state.Metrics.OvertimeUnits), "units", "Overtime can protect throughput but increases spend and stress."),
 				},
+				ProductUnits: produced,
 				Facts: []string{
 					stressSummaryLine(state.Plant.Workstations),
 					laborBottleneckLine(state.Plant.Workstations),

--- a/internal/projection/role_report.go
+++ b/internal/projection/role_report.go
@@ -18,95 +18,422 @@ func BuildRoleRoundReport(state domain.MatchState, viewerRoleID domain.RoleID) d
 
 func buildCompanywidePerformanceReport(state domain.MatchState) domain.CompanywidePerformanceReport {
 	latestRound, ok := latestRound(state)
+	backlogUnits := sumBacklogUnits(state.Plant.Backlog)
+	backlogAtRisk := sumBacklogUnitsAtRisk(state.Plant.Backlog)
+	inventory := inventorySummary(state.Plant)
+	financials := financialSummary(latestRound, ok)
 
 	return domain.CompanywidePerformanceReport{
-		NewSales:                 newSalesSummary(latestRound, ok),
-		UnshippedSales:           backlogSummary(state.Plant.Backlog),
-		SalesAtRisk:              backlogAtRiskSummary(state.Plant.Backlog),
-		ProductsProducedLastWeek: producedSummary(latestRound, ok),
-		CurrentInventoryLevels:   inventorySummary(state.Plant),
-		Financials:               financialSummary(latestRound, ok),
+		Sections: []domain.RoleReportSection{
+			{
+				Kind:          domain.RoleReportSectionInventoryRisk,
+				Title:         "Inventory risk",
+				DecisionFocus: "Shows how much working capital is currently trapped in inventory.",
+				Summary: []string{
+					fmt.Sprintf("Inventory currently ties up %d across parts, WIP, and finished goods.", inventory.TotalValue),
+				},
+				Inventory: cloneInventorySummary(inventory),
+				Facts: []string{
+					fmt.Sprintf("Parts value is %d, WIP value is %d, and finished goods value is %d.", inventoryBucketTotal(state.Plant.PartsInventory), wipInventoryValue(state.Plant.WIPInventory), finishedInventoryValue(state.Plant.FinishedInventory)),
+				},
+				Warnings: inventoryRiskWarnings(state.Plant, inventory),
+			},
+			{
+				Kind:          domain.RoleReportSectionBacklogHealth,
+				Title:         "Backlog health and aging",
+				DecisionFocus: "Highlights open demand that is still waiting to ship and where service risk is accumulating.",
+				Summary: []string{
+					fmt.Sprintf("Open backlog totals %d unit(s), with %d unit(s) already at expiry risk.", backlogUnits, backlogAtRisk),
+				},
+				ProductValues: backlogSummary(state.Plant.Backlog),
+				Warnings:      backlogWarnings(state.Plant.Backlog),
+			},
+			{
+				Kind:          domain.RoleReportSectionServiceRisk,
+				Title:         "Service risk",
+				DecisionFocus: "Shows whether shipments and backlog quality are putting customer service credibility at risk.",
+				Summary: []string{
+					fmt.Sprintf("On-time shipment rate closed at %d%% with %d lost sales unit(s).", state.Metrics.OnTimeShipmentRate, state.Metrics.LostSalesUnits),
+				},
+				Metrics: []domain.RoleReportMetric{
+					reportMetric("on_time_shipment_rate", "On-time shipment rate", int(state.Metrics.OnTimeShipmentRate), "pct", "Higher values indicate the plant is keeping its service promises."),
+					reportMetric("lost_sales_units", "Lost sales", int(state.Metrics.LostSalesUnits), "units", "Lost sales indicate demand the plant could not convert into revenue."),
+				},
+				Warnings: serviceWarnings(state),
+			},
+			{
+				Kind:          domain.RoleReportSectionMarginVariance,
+				Title:         "Margin and variance",
+				DecisionFocus: "Summarizes whether revenue, production cost, and parts cost are producing healthy economics.",
+				Summary: []string{
+					fmt.Sprintf("Round profit closed at %d and product contribution summaries are available for %d product(s).", state.Metrics.RoundProfit, len(financials)),
+				},
+				Metrics: []domain.RoleReportMetric{
+					reportMetric("round_profit", "Round profit", int(state.Metrics.RoundProfit), "money", "Profit signals whether the current operating mix is economically healthy."),
+					reportMetric("throughput_revenue", "Throughput revenue", int(state.Metrics.ThroughputRevenue), "money", "Revenue shows how much shipped demand converted into cash-generating output."),
+				},
+				Financials: financials,
+				Warnings:   marginWarnings(state),
+			},
+			{
+				Kind:          domain.RoleReportSectionCapacityPressure,
+				Title:         "Capacity pressure",
+				DecisionFocus: "Shows whether the line is running into congestion, idle labor, or overtime dependence.",
+				Summary: []string{
+					fmt.Sprintf("The plant produced %d unit(s), lost %d unit(s) of capacity, and used %d overtime unit(s) last round.", state.Metrics.ProductionOutputUnits, state.Metrics.CapacityLossUnits, state.Metrics.OvertimeUnits),
+				},
+				Metrics: []domain.RoleReportMetric{
+					reportMetric("production_output_units", "Output", int(state.Metrics.ProductionOutputUnits), "units", "Completed output is the plant's realized production flow."),
+					reportMetric("capacity_loss_units", "Capacity loss", int(state.Metrics.CapacityLossUnits), "units", "Capacity loss indicates congestion or stress penalties."),
+					reportMetric("overtime_units", "Overtime", int(state.Metrics.OvertimeUnits), "units", "Overtime can protect throughput but increases spend and stress."),
+				},
+				Facts: []string{
+					stressSummaryLine(state.Plant.Workstations),
+					laborBottleneckLine(state.Plant.Workstations),
+				},
+				Warnings: capacityWarnings(state),
+			},
+			{
+				Kind:          domain.RoleReportSectionDemandHealth,
+				Title:         "Customer sentiment and demand health",
+				DecisionFocus: "Shows whether current demand is healthy, weak, or turning fragile because of service or price posture.",
+				Summary: []string{
+					fmt.Sprintf("New demand realized last round totaled %d product line(s) and customer sentiment averages %d.", len(newSalesSummary(latestRound, ok)), averageCustomerSentiment(state.Customers)),
+				},
+				ProductValues: newSalesSummary(latestRound, ok),
+				Metrics: []domain.RoleReportMetric{
+					reportMetric("customer_sentiment", "Average sentiment", averageCustomerSentiment(state.Customers), "score", "Sentiment helps signal whether future demand pressure is durable."),
+				},
+				Warnings: demandWarnings(state),
+			},
+			{
+				Kind:          domain.RoleReportSectionCashDebtPressure,
+				Title:         "Cash and debt pressure",
+				DecisionFocus: "Shows whether the plant can fund operations comfortably or is drifting toward liquidity stress.",
+				Summary: []string{
+					fmt.Sprintf("Current cash is %d against debt %d and a debt ceiling of %d.", state.Plant.Cash, state.Plant.Debt, state.Plant.DebtCeiling),
+				},
+				Metrics: []domain.RoleReportMetric{
+					reportMetric("cash_position", "Cash", int(state.Plant.Cash), "money", "Cash is the first buffer against operating volatility."),
+					reportMetric("debt_position", "Debt", int(state.Plant.Debt), "money", "Debt rises when the plant spends beyond available cash."),
+					reportMetric("net_cash_change", "Net cash change", int(state.Metrics.NetCashChange), "money", "Net cash change shows whether the week strengthened or weakened liquidity."),
+				},
+				Facts: []string{
+					fmt.Sprintf("Open receivables total %d and open payables total %d.", sumCommitmentAmount(state.Plant.Receivables), sumCommitmentAmount(state.Plant.Payables)),
+				},
+				Warnings: cashDebtWarnings(state),
+			},
+		},
 	}
 }
 
 func buildDepartmentPerformanceReport(state domain.MatchState, viewerRoleID domain.RoleID) domain.DepartmentPerformanceReport {
 	switch viewerRoleID {
 	case domain.RoleProcurementManager:
-		return domain.DepartmentPerformanceReport{
-			RoleID: viewerRoleID,
-			KeyMetrics: []domain.MetricValue{
-				{MetricID: "ordered_parts", Value: int(sumInTransitSupply(state.Plant.InTransitSupply)), DisplayUnit: "units"},
-				{MetricID: "parts_on_hand", Value: int(state.Metrics.PartsOnHandUnits), DisplayUnit: "units"},
-				{MetricID: "supplier_reliability", Value: int(state.Metrics.SupplierReliability), DisplayUnit: "pct"},
-			},
-			DetailLines: []string{
-				fmt.Sprintf("In-transit supply totals %d units across open purchase orders.", sumInTransitSupply(state.Plant.InTransitSupply)),
-				fmt.Sprintf("On-hand parts inventory value is %d.", inventoryBucketTotal(state.Plant.PartsInventory)),
-				supplierScorecardLine(state.Suppliers),
-				nextSupplyArrivalLine(state.Plant.InTransitSupply, state.CurrentRound),
-			},
-			BonusSummary: bonusReminder(viewerRoleID),
-		}
+		return procurementDepartmentReport(state, viewerRoleID)
 	case domain.RoleProductionManager:
-		return domain.DepartmentPerformanceReport{
-			RoleID: viewerRoleID,
-			KeyMetrics: []domain.MetricValue{
-				{MetricID: "wip_units", Value: int(sumWIPUnits(state.Plant.WIPInventory)), DisplayUnit: "units"},
-				{MetricID: "output_units", Value: int(state.Metrics.ProductionOutputUnits), DisplayUnit: "units"},
-				{MetricID: "capacity_loss", Value: int(state.Metrics.CapacityLossUnits), DisplayUnit: "units"},
-				{MetricID: "idle_labor", Value: int(state.Metrics.IdleLaborUnits), DisplayUnit: "units"},
-				{MetricID: "overtime_units", Value: int(state.Metrics.OvertimeUnits), DisplayUnit: "units"},
-			},
-			DetailLines: []string{
-				fmt.Sprintf("Current WIP totals %d units across active workstations.", sumWIPUnits(state.Plant.WIPInventory)),
-				fmt.Sprintf("Finished goods on hand total %d units.", state.Metrics.FinishedGoodsUnits),
-				stressSummaryLine(state.Plant.Workstations),
-				fmt.Sprintf("Idle labor totaled %d unit(s) and overtime added %d unit(s) last round.", state.Metrics.IdleLaborUnits, state.Metrics.OvertimeUnits),
-				laborBottleneckLine(state.Plant.Workstations),
-			},
-			BonusSummary: bonusReminder(viewerRoleID),
-		}
+		return productionDepartmentReport(state, viewerRoleID)
 	case domain.RoleSalesManager:
-		return domain.DepartmentPerformanceReport{
-			RoleID: viewerRoleID,
-			KeyMetrics: []domain.MetricValue{
-				{MetricID: "sales_pipeline", Value: int(sumBacklogUnits(state.Plant.Backlog)), DisplayUnit: "units"},
-				{MetricID: "throughput_revenue", Value: int(state.Metrics.ThroughputRevenue), DisplayUnit: "money"},
-			},
-			DetailLines: []string{
-				fmt.Sprintf("Open backlog totals %d units awaiting shipment.", sumBacklogUnits(state.Plant.Backlog)),
-				fmt.Sprintf("Latest realized throughput revenue is %d.", state.Metrics.ThroughputRevenue),
-			},
-			BonusSummary: bonusReminder(viewerRoleID),
-		}
+		return salesDepartmentReport(state, viewerRoleID)
 	case domain.RoleFinanceController:
-		projectedCash, projectedDebt := projectedPositionAfterCommitments(state.Plant)
-		return domain.DepartmentPerformanceReport{
-			RoleID: viewerRoleID,
-			KeyMetrics: []domain.MetricValue{
-				{MetricID: "margin", Value: int(state.Metrics.RoundProfit), DisplayUnit: "money"},
-				{MetricID: "cash_position", Value: int(state.Plant.Cash), DisplayUnit: "money"},
-				{MetricID: "cash_receipts", Value: int(state.Metrics.CashReceipts), DisplayUnit: "money"},
-				{MetricID: "cash_disbursements", Value: int(state.Metrics.CashDisbursements), DisplayUnit: "money"},
-				{MetricID: "labor_cost", Value: int(state.Metrics.LaborCost), DisplayUnit: "money"},
-				{MetricID: "overtime_cost", Value: int(state.Metrics.OvertimeCost), DisplayUnit: "money"},
-			},
-			DetailLines: []string{
-				fmt.Sprintf("Current cash is %d against debt ceiling %d.", state.Plant.Cash, state.Plant.DebtCeiling),
-				fmt.Sprintf("Round profit most recently closed at %d.", state.Metrics.RoundProfit),
-				fmt.Sprintf("Projected cash after all open commitments is %d with projected debt %d.", projectedCash, projectedDebt),
-				fmt.Sprintf("Next-round maturities net to %d (%d receivable, %d payable).", nextRoundNetCash(state.Plant, state.CurrentRound), sumCommitmentsDue(state.Plant.Receivables, state.CurrentRound), sumCommitmentsDue(state.Plant.Payables, state.CurrentRound)),
-				fmt.Sprintf("Open receivables total %d, with %d due next round.", sumCommitmentAmount(state.Plant.Receivables), sumCommitmentsDue(state.Plant.Receivables, state.CurrentRound)),
-				fmt.Sprintf("Open payables total %d, with %d due next round.", sumCommitmentAmount(state.Plant.Payables), sumCommitmentsDue(state.Plant.Payables, state.CurrentRound)),
-				fmt.Sprintf("Labor cost ran %d with overtime cost at %d last round.", state.Metrics.LaborCost, state.Metrics.OvertimeCost),
-			},
-			BonusSummary: bonusReminder(viewerRoleID),
-		}
+		return financeDepartmentReport(state, viewerRoleID)
 	default:
 		return domain.DepartmentPerformanceReport{
 			RoleID:       viewerRoleID,
 			BonusSummary: bonusReminder(viewerRoleID),
+			Sections: []domain.RoleReportSection{
+				{
+					Kind:          domain.RoleReportSectionExecutiveSummary,
+					Title:         "Executive summary",
+					DecisionFocus: "No role-specific report is configured yet.",
+					Summary:       []string{"This role currently falls back to the shared companywide report only."},
+				},
+			},
 		}
+	}
+}
+
+func procurementDepartmentReport(state domain.MatchState, viewerRoleID domain.RoleID) domain.DepartmentPerformanceReport {
+	inTransit := sumInTransitSupply(state.Plant.InTransitSupply)
+	partsValue := inventoryBucketTotal(state.Plant.PartsInventory)
+	return domain.DepartmentPerformanceReport{
+		RoleID:        viewerRoleID,
+		BonusSummary:  bonusReminder(viewerRoleID),
+		FocusQuestion: "Which purchases best protect next-round production without creating avoidable cash and inventory drag?",
+		Sections: []domain.RoleReportSection{
+			{
+				Kind:          domain.RoleReportSectionExecutiveSummary,
+				Title:         "Executive summary",
+				DecisionFocus: "Set the overall buying posture for this week.",
+				Summary: []string{
+					fmt.Sprintf("Procurement is balancing %d unit(s) already in transit against %d unit(s) on hand.", inTransit, state.Metrics.PartsOnHandUnits),
+					fmt.Sprintf("Supplier reliability is %d%%, so buying posture should reflect both continuity and cash discipline.", state.Metrics.SupplierReliability),
+				},
+				Warnings: procurementWarnings(state),
+			},
+			{
+				Kind:          domain.RoleReportSectionOperatingPicture,
+				Title:         "Role-critical operating picture",
+				DecisionFocus: "Shows current material coverage, receipts, and supplier posture.",
+				Metrics: []domain.RoleReportMetric{
+					reportMetric("ordered_parts", "In-transit supply", int(inTransit), "units", "Open purchase orders already provide some next-round protection."),
+					reportMetric("parts_on_hand", "Parts on hand", int(state.Metrics.PartsOnHandUnits), "units", "On-hand parts are the immediate material buffer."),
+					reportMetric("supplier_reliability", "Supplier reliability", int(state.Metrics.SupplierReliability), "pct", "Reliability signals how much schedule confidence procurement can assume."),
+				},
+				Facts: []string{
+					fmt.Sprintf("On-hand parts inventory value is %d.", partsValue),
+					supplierScorecardLine(state.Suppliers),
+					nextSupplyArrivalLine(state.Plant.InTransitSupply, state.CurrentRound),
+				},
+			},
+			{
+				Kind:          domain.RoleReportSectionConstraintRiskView,
+				Title:         "Constraint and risk view",
+				DecisionFocus: "Highlights where shortages or overbuy risk are becoming dangerous.",
+				Warnings:      procurementWarnings(state),
+				Facts: []string{
+					fmt.Sprintf("Open inbound supply totals %d unit(s) across current purchase orders.", inTransit),
+				},
+			},
+			{
+				Kind:          domain.RoleReportSectionTradeoffPressure,
+				Title:         "Tradeoff and pressure view",
+				DecisionFocus: "Shows the tension between shortage protection and cash discipline.",
+				Tradeoffs: []domain.RoleReportTradeoff{
+					{
+						Focus:    "Continuity versus overbuy",
+						Tension:  "Buying too little risks starving production, but buying too much traps cash in parts inventory.",
+						Guidance: fmt.Sprintf("Use the %d unit(s) already in transit before layering on duplicate protection.", inTransit),
+					},
+					{
+						Focus:    "Cheap supply versus reliable supply",
+						Tension:  "A lower-cost source is not attractive if reliability makes next-round production fragile.",
+						Guidance: supplierScorecardLine(state.Suppliers),
+					},
+				},
+			},
+			{
+				Kind:          domain.RoleReportSectionDecisionPrompts,
+				Title:         "Decision prompts",
+				DecisionFocus: "End with the concrete buying questions procurement should answer now.",
+				Prompts: []domain.RoleReportPrompt{
+					{Question: "Which exposed part is actually worth buying now?", WhyItMatters: "Not every low stock position deserves immediate cash."},
+					{Question: "Does existing in-transit supply already cover the next bottleneck risk?", WhyItMatters: "Avoiding duplicate buys preserves liquidity."},
+					{Question: "Where is reliability weak enough that supply continuity deserves extra protection?", WhyItMatters: "A fragile supplier base can erase a seemingly efficient order plan."},
+				},
+			},
+		},
+	}
+}
+
+func productionDepartmentReport(state domain.MatchState, viewerRoleID domain.RoleID) domain.DepartmentPerformanceReport {
+	return domain.DepartmentPerformanceReport{
+		RoleID:        viewerRoleID,
+		BonusSummary:  bonusReminder(viewerRoleID),
+		FocusQuestion: "What is the highest-value feasible production plan given visible parts, capacity, WIP, and spend pressure?",
+		Sections: []domain.RoleReportSection{
+			{
+				Kind:          domain.RoleReportSectionExecutiveSummary,
+				Title:         "Executive summary",
+				DecisionFocus: "Sets whether this week is about throughput, recovery, or congestion control.",
+				Summary: []string{
+					fmt.Sprintf("Production closed with %d unit(s) of output, %d unit(s) of WIP, and %d unit(s) of capacity loss.", state.Metrics.ProductionOutputUnits, sumWIPUnits(state.Plant.WIPInventory), state.Metrics.CapacityLossUnits),
+					fmt.Sprintf("Overtime contributed %d unit(s) while idle labor left %d unit(s) unused.", state.Metrics.OvertimeUnits, state.Metrics.IdleLaborUnits),
+				},
+				Warnings: productionWarnings(state),
+			},
+			{
+				Kind:          domain.RoleReportSectionOperatingPicture,
+				Title:         "Role-critical operating picture",
+				DecisionFocus: "Shows output flow, bottlenecks, and material readiness.",
+				Metrics: []domain.RoleReportMetric{
+					reportMetric("wip_units", "WIP", int(sumWIPUnits(state.Plant.WIPInventory)), "units", "WIP indicates how much work is already committed to the line."),
+					reportMetric("output_units", "Output", int(state.Metrics.ProductionOutputUnits), "units", "Output shows how much useful work actually finished."),
+					reportMetric("capacity_loss", "Capacity loss", int(state.Metrics.CapacityLossUnits), "units", "Capacity loss highlights congestion and stress."),
+					reportMetric("idle_labor", "Idle labor", int(state.Metrics.IdleLaborUnits), "units", "Idle labor shows unused labor that could be redeployed."),
+					reportMetric("overtime_units", "Overtime", int(state.Metrics.OvertimeUnits), "units", "Overtime may protect output but increases operating pressure."),
+				},
+				Facts: []string{
+					fmt.Sprintf("Finished goods on hand total %d unit(s).", state.Metrics.FinishedGoodsUnits),
+					stressSummaryLine(state.Plant.Workstations),
+					laborBottleneckLine(state.Plant.Workstations),
+				},
+			},
+			{
+				Kind:          domain.RoleReportSectionConstraintRiskView,
+				Title:         "Constraint and risk view",
+				DecisionFocus: "Shows where line congestion or material readiness can break the plan.",
+				Warnings:      productionWarnings(state),
+			},
+			{
+				Kind:          domain.RoleReportSectionTradeoffPressure,
+				Title:         "Tradeoff and pressure view",
+				DecisionFocus: "Frames the throughput-versus-congestion decisions production must make.",
+				Tradeoffs: []domain.RoleReportTradeoff{
+					{
+						Focus:    "Throughput versus congestion",
+						Tension:  "More release can improve output only if bottlenecks are still absorbent.",
+						Guidance: stressSummaryLine(state.Plant.Workstations),
+					},
+					{
+						Focus:    "Overtime versus spend discipline",
+						Tension:  "Selective overtime can rescue high-value output, but broad overtime adds cost without fixing bad flow.",
+						Guidance: fmt.Sprintf("Last round used %d overtime unit(s) for %d in overtime cost.", state.Metrics.OvertimeUnits, state.Metrics.OvertimeCost),
+					},
+				},
+			},
+			{
+				Kind:          domain.RoleReportSectionDecisionPrompts,
+				Title:         "Decision prompts",
+				DecisionFocus: "Ends with the production plan choices that matter this week.",
+				Prompts: []domain.RoleReportPrompt{
+					{Question: "What is the highest-value feasible mix this week?", WhyItMatters: "Not every release is equally valuable when capacity is constrained."},
+					{Question: "Will more release protect throughput or just clog the bottleneck?", WhyItMatters: "Pushing work into a congested line can lower real output."},
+					{Question: "Is selective overtime justified by the output it protects?", WhyItMatters: "Overtime should solve a real constraint, not mask a bad plan."},
+				},
+			},
+		},
+	}
+}
+
+func salesDepartmentReport(state domain.MatchState, viewerRoleID domain.RoleID) domain.DepartmentPerformanceReport {
+	return domain.DepartmentPerformanceReport{
+		RoleID:        viewerRoleID,
+		BonusSummary:  bonusReminder(viewerRoleID),
+		FocusQuestion: "How should pricing shape future demand without creating backlog, service, or margin damage the plant cannot support?",
+		Sections: []domain.RoleReportSection{
+			{
+				Kind:          domain.RoleReportSectionExecutiveSummary,
+				Title:         "Executive summary",
+				DecisionFocus: "Sets whether sales should press growth, hold steady, or protect credibility.",
+				Summary: []string{
+					fmt.Sprintf("Sales is carrying %d unit(s) of backlog with %d%% on-time shipment performance.", sumBacklogUnits(state.Plant.Backlog), state.Metrics.OnTimeShipmentRate),
+					fmt.Sprintf("Latest throughput revenue is %d and lost sales reached %d unit(s).", state.Metrics.ThroughputRevenue, state.Metrics.LostSalesUnits),
+				},
+				Warnings: salesWarnings(state),
+			},
+			{
+				Kind:          domain.RoleReportSectionOperatingPicture,
+				Title:         "Role-critical operating picture",
+				DecisionFocus: "Shows backlog, shipped revenue, and customer demand pressure.",
+				Metrics: []domain.RoleReportMetric{
+					reportMetric("sales_pipeline", "Backlog", int(sumBacklogUnits(state.Plant.Backlog)), "units", "Backlog is the booked demand already competing for fulfillment."),
+					reportMetric("throughput_revenue", "Throughput revenue", int(state.Metrics.ThroughputRevenue), "money", "Revenue shows the demand that actually converted into shipments."),
+					reportMetric("on_time_shipment_rate", "On-time shipment rate", int(state.Metrics.OnTimeShipmentRate), "pct", "Service quality shapes future credibility."),
+				},
+				Facts: []string{
+					fmt.Sprintf("Finished goods on hand total %d unit(s).", state.Metrics.FinishedGoodsUnits),
+					fmt.Sprintf("Average visible customer sentiment is %d.", averageCustomerSentiment(state.Customers)),
+				},
+			},
+			{
+				Kind:          domain.RoleReportSectionConstraintRiskView,
+				Title:         "Constraint and risk view",
+				DecisionFocus: "Highlights where backlog or service misses make incremental demand dangerous.",
+				Warnings:      salesWarnings(state),
+				ProductValues: backlogAtRiskSummary(state.Plant.Backlog),
+			},
+			{
+				Kind:          domain.RoleReportSectionTradeoffPressure,
+				Title:         "Tradeoff and pressure view",
+				DecisionFocus: "Frames the growth-versus-service tradeoff sales is managing.",
+				Tradeoffs: []domain.RoleReportTradeoff{
+					{
+						Focus:    "Revenue growth versus service credibility",
+						Tension:  "Pushing for more demand is only healthy if the plant can still fulfill it on time.",
+						Guidance: fmt.Sprintf("Backlog at risk already totals %d unit(s).", sumBacklogUnitsAtRisk(state.Plant.Backlog)),
+					},
+					{
+						Focus:    "Demand capture versus margin quality",
+						Tension:  "A lower price may book more demand, but it can create weak economics if margin and service both deteriorate.",
+						Guidance: fmt.Sprintf("Round profit is %d while throughput revenue is %d.", state.Metrics.RoundProfit, state.Metrics.ThroughputRevenue),
+					},
+				},
+			},
+			{
+				Kind:          domain.RoleReportSectionDecisionPrompts,
+				Title:         "Decision prompts",
+				DecisionFocus: "Ends with the pricing questions sales should answer now.",
+				Prompts: []domain.RoleReportPrompt{
+					{Question: "Are we winning healthy demand or dangerous backlog?", WhyItMatters: "Demand quality matters as much as demand volume."},
+					{Question: "Should pricing cool demand until service credibility recovers?", WhyItMatters: "Overpromising can damage future demand more than a cautious week."},
+					{Question: "Which product can still support price without outrunning finished-goods availability?", WhyItMatters: "Pricing should respect the plant's visible ability to serve."},
+				},
+			},
+		},
+	}
+}
+
+func financeDepartmentReport(state domain.MatchState, viewerRoleID domain.RoleID) domain.DepartmentPerformanceReport {
+	projectedCash, projectedDebt := projectedPositionAfterCommitments(state.Plant)
+	return domain.DepartmentPerformanceReport{
+		RoleID:        viewerRoleID,
+		BonusSummary:  bonusReminder(viewerRoleID),
+		FocusQuestion: "Which next-round targets protect liquidity and discipline without starving the plant of the support it still needs?",
+		Sections: []domain.RoleReportSection{
+			{
+				Kind:          domain.RoleReportSectionExecutiveSummary,
+				Title:         "Executive summary",
+				DecisionFocus: "Sets whether finance should tighten, hold, or selectively support.",
+				Summary: []string{
+					fmt.Sprintf("Finance is carrying %d cash, %d debt, and %d round profit.", state.Plant.Cash, state.Plant.Debt, state.Metrics.RoundProfit),
+					fmt.Sprintf("Projected position after all open commitments is cash %d and debt %d.", projectedCash, projectedDebt),
+				},
+				Warnings: financeWarnings(state, projectedCash, projectedDebt),
+			},
+			{
+				Kind:          domain.RoleReportSectionOperatingPicture,
+				Title:         "Role-critical operating picture",
+				DecisionFocus: "Shows liquidity, cash commitments, and current economic quality.",
+				Metrics: []domain.RoleReportMetric{
+					reportMetric("margin", "Round profit", int(state.Metrics.RoundProfit), "money", "Profit is the cleanest weekly read on whether the plant is earning its activity."),
+					reportMetric("cash_position", "Cash", int(state.Plant.Cash), "money", "Cash is the plant's immediate operating buffer."),
+					reportMetric("cash_receipts", "Cash receipts", int(state.Metrics.CashReceipts), "money", "Receipts show recent cash conversion."),
+					reportMetric("cash_disbursements", "Cash disbursements", int(state.Metrics.CashDisbursements), "money", "Disbursements show the weekly cash burn."),
+					reportMetric("labor_cost", "Labor cost", int(state.Metrics.LaborCost), "money", "Labor cost is a major controllable operating spend."),
+					reportMetric("overtime_cost", "Overtime cost", int(state.Metrics.OvertimeCost), "money", "Overtime cost should buy real throughput, not just activity."),
+				},
+				Facts: []string{
+					fmt.Sprintf("Current cash is %d against debt ceiling %d.", state.Plant.Cash, state.Plant.DebtCeiling),
+					fmt.Sprintf("Next-round maturities net to %d (%d receivable, %d payable).", nextRoundNetCash(state.Plant, state.CurrentRound), sumCommitmentsDue(state.Plant.Receivables, state.CurrentRound), sumCommitmentsDue(state.Plant.Payables, state.CurrentRound)),
+					fmt.Sprintf("Open receivables total %d, with %d due next round.", sumCommitmentAmount(state.Plant.Receivables), sumCommitmentsDue(state.Plant.Receivables, state.CurrentRound)),
+					fmt.Sprintf("Open payables total %d, with %d due next round.", sumCommitmentAmount(state.Plant.Payables), sumCommitmentsDue(state.Plant.Payables, state.CurrentRound)),
+				},
+			},
+			{
+				Kind:          domain.RoleReportSectionConstraintRiskView,
+				Title:         "Constraint and risk view",
+				DecisionFocus: "Highlights where liquidity or working-capital stress is becoming dangerous.",
+				Warnings:      financeWarnings(state, projectedCash, projectedDebt),
+			},
+			{
+				Kind:          domain.RoleReportSectionTradeoffPressure,
+				Title:         "Tradeoff and pressure view",
+				DecisionFocus: "Frames the support-versus-discipline tradeoffs finance must enforce.",
+				Tradeoffs: []domain.RoleReportTradeoff{
+					{
+						Focus:    "Liquidity discipline versus throughput support",
+						Tension:  "Tighter budgets protect cash, but over-tightening can starve the operations that still create value.",
+						Guidance: fmt.Sprintf("Projected post-commitment position is cash %d and debt %d.", projectedCash, projectedDebt),
+					},
+					{
+						Focus:    "Inventory support versus trapped working capital",
+						Tension:  "Inventory can protect service, but excess stock traps cash that may be needed elsewhere.",
+						Guidance: fmt.Sprintf("Inventory currently represents %d of plant value exposure.", inventorySummary(state.Plant).TotalValue),
+					},
+				},
+			},
+			{
+				Kind:          domain.RoleReportSectionDecisionPrompts,
+				Title:         "Decision prompts",
+				DecisionFocus: "Ends with the questions finance should answer when setting next-round guardrails.",
+				Prompts: []domain.RoleReportPrompt{
+					{Question: "Which spend should tighten and which still deserves support?", WhyItMatters: "The plant rarely needs every budget tightened equally."},
+					{Question: "How much liquidity buffer is actually required for the next round?", WhyItMatters: "Targets should reflect visible cash risk rather than generic caution."},
+					{Question: "Where is cash being trapped in low-value inventory or overtime?", WhyItMatters: "Working-capital leakage reduces strategic flexibility quickly."},
+				},
+			},
+		},
 	}
 }
 
@@ -245,6 +572,17 @@ func financialSummary(round domain.RoundRecord, ok bool) []domain.ProductFinanci
 func sumBacklogUnits(backlog []domain.BacklogEntry) domain.Units {
 	total := domain.Units(0)
 	for _, entry := range backlog {
+		total += entry.Quantity
+	}
+	return total
+}
+
+func sumBacklogUnitsAtRisk(backlog []domain.BacklogEntry) domain.Units {
+	total := domain.Units(0)
+	for _, entry := range backlog {
+		if entry.AgeInRounds < 2 {
+			continue
+		}
 		total += entry.Quantity
 	}
 	return total
@@ -464,4 +802,212 @@ func minMoney(left, right domain.Money) domain.Money {
 		return left
 	}
 	return right
+}
+
+func reportMetric(metricID, label string, value int, unit, interpretation string) domain.RoleReportMetric {
+	return domain.RoleReportMetric{
+		Metric: domain.MetricValue{
+			MetricID:    domain.MetricID(metricID),
+			Value:       value,
+			DisplayUnit: unit,
+		},
+		Label:          label,
+		Interpretation: interpretation,
+	}
+}
+
+func inventoryRiskWarnings(plant domain.PlantState, inventory domain.InventoryValueSummary) []domain.RoleReportWarning {
+	warnings := make([]domain.RoleReportWarning, 0, 2)
+	if inventory.TotalValue > plant.Cash && inventory.TotalValue > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "inventory_exceeds_cash",
+			Headline: "Inventory value exceeds current cash.",
+			Detail:   "Working capital is heavily tied up in stock relative to liquid cash on hand.",
+		})
+	}
+	if len(plant.InspectionHolds) > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "inspection_hold_inventory",
+			Headline: "Some inventory is stuck in inspection hold.",
+			Detail:   fmt.Sprintf("%d hold lot(s) are not currently available to support demand.", len(plant.InspectionHolds)),
+		})
+	}
+	return warnings
+}
+
+func backlogWarnings(backlog []domain.BacklogEntry) []domain.RoleReportWarning {
+	atRisk := sumBacklogUnitsAtRisk(backlog)
+	if atRisk == 0 {
+		return nil
+	}
+	return []domain.RoleReportWarning{{
+		Code:     "aging_backlog",
+		Headline: "Aging backlog is accumulating.",
+		Detail:   fmt.Sprintf("%d backlog unit(s) are at risk because they have aged two rounds or more.", atRisk),
+	}}
+}
+
+func serviceWarnings(state domain.MatchState) []domain.RoleReportWarning {
+	warnings := make([]domain.RoleReportWarning, 0, 2)
+	if state.Metrics.OnTimeShipmentRate < 90 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "service_level_low",
+			Headline: "On-time shipment performance is below target.",
+			Detail:   "Customer service credibility is at risk if new demand continues to outpace fulfillment.",
+		})
+	}
+	if state.Metrics.LostSalesUnits > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "lost_sales",
+			Headline: "The plant is already losing demand.",
+			Detail:   fmt.Sprintf("%d unit(s) of demand were lost last round.", state.Metrics.LostSalesUnits),
+		})
+	}
+	return warnings
+}
+
+func marginWarnings(state domain.MatchState) []domain.RoleReportWarning {
+	if state.Metrics.RoundProfit >= 0 {
+		return nil
+	}
+	return []domain.RoleReportWarning{{
+		Code:     "negative_profit",
+		Headline: "The latest round closed at a loss.",
+		Detail:   "Current pricing, spend, or production mix is not generating healthy economics.",
+	}}
+}
+
+func capacityWarnings(state domain.MatchState) []domain.RoleReportWarning {
+	warnings := make([]domain.RoleReportWarning, 0, 2)
+	if state.Metrics.CapacityLossUnits > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "capacity_stress",
+			Headline: "Capacity stress reduced effective output.",
+			Detail:   fmt.Sprintf("%d unit(s) of capacity were lost to stress or congestion.", state.Metrics.CapacityLossUnits),
+		})
+	}
+	if state.Metrics.OvertimeUnits > state.Metrics.IdleLaborUnits && state.Metrics.OvertimeUnits > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "overtime_dependency",
+			Headline: "Output is leaning on overtime.",
+			Detail:   "The plant is relying more on overtime than on unused labor slack, which can become expensive quickly.",
+		})
+	}
+	return warnings
+}
+
+func demandWarnings(state domain.MatchState) []domain.RoleReportWarning {
+	warnings := make([]domain.RoleReportWarning, 0, 2)
+	if averageCustomerSentiment(state.Customers) <= 4 && len(state.Customers) > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "customer_sentiment_softening",
+			Headline: "Customer sentiment is softening.",
+			Detail:   "Future demand may weaken if service or pricing pressure continues.",
+		})
+	}
+	if sumBacklogUnits(state.Plant.Backlog) > state.Metrics.FinishedGoodsUnits && len(state.Plant.Backlog) > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "demand_outpacing_inventory",
+			Headline: "Booked demand is outrunning finished goods.",
+			Detail:   "Current demand pressure may be turning into service risk rather than healthy growth.",
+		})
+	}
+	return warnings
+}
+
+func cashDebtWarnings(state domain.MatchState) []domain.RoleReportWarning {
+	projectedCash, projectedDebt := projectedPositionAfterCommitments(state.Plant)
+	return financeWarnings(state, projectedCash, projectedDebt)
+}
+
+func procurementWarnings(state domain.MatchState) []domain.RoleReportWarning {
+	warnings := make([]domain.RoleReportWarning, 0, 3)
+	if state.Metrics.SupplierReliability < 90 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "supplier_reliability_low",
+			Headline: "Supplier reliability is below comfort range.",
+			Detail:   "Receipts may be less dependable, so coverage assumptions should stay conservative.",
+		})
+	}
+	if sumInTransitSupply(state.Plant.InTransitSupply) == 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "no_inbound_supply",
+			Headline: "No inbound supply is currently scheduled.",
+			Detail:   "Production continuity may depend entirely on existing stock unless procurement acts.",
+		})
+	}
+	if inventoryBucketTotal(state.Plant.PartsInventory) > state.Plant.Cash && state.Metrics.PartsOnHandUnits > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "parts_cash_drag",
+			Headline: "Parts inventory is becoming a cash drag.",
+			Detail:   "More buys may worsen liquidity unless they clearly protect near-term throughput.",
+		})
+	}
+	return warnings
+}
+
+func productionWarnings(state domain.MatchState) []domain.RoleReportWarning {
+	warnings := capacityWarnings(state)
+	if sumWIPUnits(state.Plant.WIPInventory) > state.Metrics.ProductionOutputUnits && sumWIPUnits(state.Plant.WIPInventory) > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "wip_building",
+			Headline: "WIP is building faster than finished output.",
+			Detail:   "More release may create congestion instead of more useful throughput.",
+		})
+	}
+	return warnings
+}
+
+func salesWarnings(state domain.MatchState) []domain.RoleReportWarning {
+	warnings := serviceWarnings(state)
+	if sumBacklogUnitsAtRisk(state.Plant.Backlog) > 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "backlog_expiry_risk",
+			Headline: "Some backlog is old enough to threaten service credibility.",
+			Detail:   "Aggressive pricing may be counterproductive until aging orders are stabilized.",
+		})
+	}
+	return warnings
+}
+
+func financeWarnings(state domain.MatchState, projectedCash, projectedDebt domain.Money) []domain.RoleReportWarning {
+	warnings := make([]domain.RoleReportWarning, 0, 3)
+	if projectedDebt > state.Plant.Debt {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "projected_debt_increase",
+			Headline: "Open commitments are likely to increase debt.",
+			Detail:   fmt.Sprintf("Projected debt rises to %d after currently visible commitments.", projectedDebt),
+		})
+	}
+	if projectedCash < state.ActiveTargets.CashFloorTarget {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "cash_floor_pressure",
+			Headline: "Projected cash falls below the active cash floor target.",
+			Detail:   fmt.Sprintf("Projected cash is %d against a target floor of %d.", projectedCash, state.ActiveTargets.CashFloorTarget),
+		})
+	}
+	if nextRoundNetCash(state.Plant, state.CurrentRound) < 0 {
+		warnings = append(warnings, domain.RoleReportWarning{
+			Code:     "negative_next_round_maturities",
+			Headline: "Next-round maturities are net cash-negative.",
+			Detail:   "Near-term commitments are likely to pressure liquidity unless operations recover cash quickly.",
+		})
+	}
+	return warnings
+}
+
+func averageCustomerSentiment(customers []domain.CustomerState) int {
+	if len(customers) == 0 {
+		return 0
+	}
+	total := 0
+	for _, customer := range customers {
+		total += customer.Sentiment
+	}
+	return total / len(customers)
+}
+
+func cloneInventorySummary(summary domain.InventoryValueSummary) *domain.InventoryValueSummary {
+	cloned := summary.Clone()
+	return &cloned
 }

--- a/internal/projection/role_report_test.go
+++ b/internal/projection/role_report_test.go
@@ -32,12 +32,20 @@ func TestFinanceReportIncludesProjectedCashView(t *testing.T) {
 	}
 
 	report := projection.BuildRoleRoundReport(state, domain.RoleFinanceController)
-	details := strings.Join(report.Department.DetailLines, "\n")
-
-	if !strings.Contains(details, "Projected cash after all open commitments is 3 with projected debt 0.") {
-		t.Fatalf("finance detail lines missing projected position: %q", details)
+	var details []string
+	for _, section := range report.Department.Sections {
+		details = append(details, section.Summary...)
+		details = append(details, section.Facts...)
+		for _, warning := range section.Warnings {
+			details = append(details, warning.Headline, warning.Detail)
+		}
 	}
-	if !strings.Contains(details, "Next-round maturities net to 2 (5 receivable, 3 payable).") {
-		t.Fatalf("finance detail lines missing maturity summary: %q", details)
+	joined := strings.Join(details, "\n")
+
+	if !strings.Contains(joined, "Projected position after all open commitments is cash 3 and debt 0.") {
+		t.Fatalf("finance sections missing projected position: %q", joined)
+	}
+	if !strings.Contains(joined, "Next-round maturities net to 2 (5 receivable, 3 payable).") {
+		t.Fatalf("finance sections missing maturity summary: %q", joined)
 	}
 }


### PR DESCRIPTION
## Summary
- replace the thin role report contract with typed report sections, metrics, warnings, tradeoffs, and decision prompts
- build companywide and role-specific weekly decision-support sections for the MVP roles
- update the TUI to render the new canonical report structure and keep tests aligned with the richer report surface

## Why
Issue #118 asks for a richer, typed report model that supports realistic weekly plant management for both human-facing and AI-facing consumers. This PR moves the report contract away from generic metric/detail lists and into stable, section-oriented report semantics.

## Validation
- `go test ./...`

## Clarification
I interpreted "typed report sections" as a canonical section model with stable section kinds plus typed signals, warnings, tradeoffs, and prompts that both the TUI and AI payloads can consume. If you want the next step to go further into fully specialized structs per section family (for example dedicated cash/debt or backlog-health section types), I can build that follow-up on top of this foundation.