### PR TITLE
TUI: replace flat debug log with role-scoped debug tree

### DIFF
--- a/internal/adapters/tui/debug_tree.go
+++ b/internal/adapters/tui/debug_tree.go
@@ -1,0 +1,516 @@
+package tui
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+type debugTreeNode struct {
+	id       string
+	parentID string
+	title    string
+	body     string
+	children []*debugTreeNode
+}
+
+type debugVisibleNode struct {
+	node  *debugTreeNode
+	depth int
+}
+
+type debugWorkspaceRender struct {
+	lines             []string
+	selectedLineStart int
+	selectedLineCount int
+}
+
+func (m Model) debugRoleRecords() []ports.AICallRecord {
+	if m.debugLog == nil {
+		return nil
+	}
+
+	roleID := m.selectedAssignment().RoleID
+	if roleID == "" {
+		return nil
+	}
+
+	records := m.debugLog.Records()
+	filtered := make([]ports.AICallRecord, 0, len(records))
+	for _, record := range records {
+		if record.RoleID == roleID {
+			filtered = append(filtered, record)
+		}
+	}
+	return filtered
+}
+
+func (m Model) buildDebugTree() []*debugTreeNode {
+	records := m.debugRoleRecords()
+	if len(records) == 0 {
+		return nil
+	}
+
+	roundNodes := make([]*debugTreeNode, 0)
+	roundIndex := make(map[domain.RoundNumber]*debugTreeNode)
+	attemptIndex := make(map[string]*debugTreeNode)
+	attemptCounts := make(map[domain.RoundNumber]int)
+
+	for _, record := range records {
+		roundNode := roundIndex[record.Round]
+		if roundNode == nil {
+			roundNode = &debugTreeNode{
+				id:    debugRoundNodeID(record.Round),
+				title: fmt.Sprintf("Round %d", record.Round),
+			}
+			roundIndex[record.Round] = roundNode
+			roundNodes = append(roundNodes, roundNode)
+		}
+
+		attemptID := debugAttemptNodeID(record.Round, record.Attempt)
+		if attemptIndex[attemptID] != nil {
+			continue
+		}
+
+		attemptNode := buildDebugAttemptNode(record)
+		attemptNode.parentID = roundNode.id
+		roundNode.children = append(roundNode.children, attemptNode)
+		attemptIndex[attemptID] = attemptNode
+		attemptCounts[record.Round]++
+	}
+
+	slices.SortFunc(roundNodes, func(left, right *debugTreeNode) int {
+		switch {
+		case left.id < right.id:
+			return -1
+		case left.id > right.id:
+			return 1
+		default:
+			return 0
+		}
+	})
+	for _, roundNode := range roundNodes {
+		round := parseRoundID(roundNode.id)
+		roundNode.title = fmt.Sprintf("Round %d (%d tries)", round, attemptCounts[round])
+		slices.SortFunc(roundNode.children, func(left, right *debugTreeNode) int {
+			switch {
+			case left.id < right.id:
+				return -1
+			case left.id > right.id:
+				return 1
+			default:
+				return 0
+			}
+		})
+	}
+
+	return roundNodes
+}
+
+func buildDebugAttemptNode(record ports.AICallRecord) *debugTreeNode {
+	_, statusBody := debugAttemptStatus(record)
+	requestSummary := fmt.Sprintf(
+		"Request Summary (%s/%s, system %d chars, user %d chars)",
+		record.Provider,
+		record.Model,
+		len(record.SystemPrompt),
+		len(record.UserPrompt),
+	)
+	responseSummary := fmt.Sprintf(
+		"Response Summary (%s)",
+		debugResponseSummary(record),
+	)
+
+	attemptNode := &debugTreeNode{
+		id:    debugAttemptNodeID(record.Round, record.Attempt),
+		title: fmt.Sprintf("Try %d - %s", record.Attempt, debugAttemptOutcome(record)),
+	}
+	statusNode := &debugTreeNode{
+		id:       debugStatusNodeID(record.Round, record.Attempt),
+		parentID: attemptNode.id,
+		title:    "Try status details",
+		body:     statusBody,
+	}
+	requestSummaryNode := &debugTreeNode{
+		id:       debugRequestSummaryNodeID(record.Round, record.Attempt),
+		parentID: attemptNode.id,
+		title:    requestSummary,
+	}
+	requestDetailNode := &debugTreeNode{
+		id:       debugRequestDetailNodeID(record.Round, record.Attempt),
+		parentID: requestSummaryNode.id,
+		title:    "Request details",
+		body:     debugRequestDetails(record),
+	}
+	responseSummaryNode := &debugTreeNode{
+		id:       debugResponseSummaryNodeID(record.Round, record.Attempt),
+		parentID: attemptNode.id,
+		title:    responseSummary,
+	}
+	responseDetailNode := &debugTreeNode{
+		id:       debugResponseDetailNodeID(record.Round, record.Attempt),
+		parentID: responseSummaryNode.id,
+		title:    "Response details",
+		body:     debugResponseDetails(record),
+	}
+
+	requestSummaryNode.children = []*debugTreeNode{requestDetailNode}
+	responseSummaryNode.children = []*debugTreeNode{responseDetailNode}
+	attemptNode.children = []*debugTreeNode{statusNode, requestSummaryNode, responseSummaryNode}
+	return attemptNode
+}
+
+func (m Model) visibleDebugNodes() []debugVisibleNode {
+	return m.flattenDebugNodes(m.buildDebugTree(), 0)
+}
+
+func (m Model) flattenDebugNodes(nodes []*debugTreeNode, depth int) []debugVisibleNode {
+	visible := make([]debugVisibleNode, 0)
+	for _, node := range nodes {
+		visible = append(visible, debugVisibleNode{node: node, depth: depth})
+		if len(node.children) == 0 || !m.isDebugNodeExpanded(node.id, depth) {
+			continue
+		}
+		visible = append(visible, m.flattenDebugNodes(node.children, depth+1)...)
+	}
+	return visible
+}
+
+func (m Model) isDebugNodeExpanded(nodeID string, depth int) bool {
+	expanded, ok := m.debugExpanded[nodeID]
+	if ok {
+		return expanded
+	}
+	return depth == 0
+}
+
+func (m *Model) ensureDebugSelection() {
+	if m.workspace != workspaceDebug {
+		return
+	}
+
+	visible := m.visibleDebugNodes()
+	if len(visible) == 0 {
+		m.debugSelected = ""
+		return
+	}
+
+	for _, node := range visible {
+		if node.node.id == m.debugSelected {
+			return
+		}
+	}
+	m.debugSelected = visible[0].node.id
+}
+
+func (m *Model) ensureDebugSelectionVisible() {
+	if m.workspace != workspaceDebug {
+		return
+	}
+
+	width, _ := m.historyPaneDimensions()
+	rendered := m.renderDebugWorkspaceContent(width)
+	visibleLines := m.historyVisibleLineCount()
+	if visibleLines <= 0 || rendered.selectedLineCount == 0 {
+		m.historyScroll = 0
+		return
+	}
+
+	top := m.historyScroll
+	bottom := top + visibleLines
+	selectedTop := rendered.selectedLineStart
+	selectedBottom := rendered.selectedLineStart + rendered.selectedLineCount
+
+	switch {
+	case selectedTop < top:
+		m.historyScroll = selectedTop
+	case selectedBottom > bottom:
+		m.historyScroll = selectedBottom - visibleLines
+	}
+
+	m.historyScroll = clampScrollOffset(m.historyScroll, len(flattenLines(rendered.lines)), visibleLines)
+}
+
+func (m *Model) moveDebugSelection(delta int) {
+	visible := m.visibleDebugNodes()
+	if len(visible) == 0 {
+		m.debugSelected = ""
+		return
+	}
+
+	index := m.debugSelectionIndex(visible)
+	index = max(min(index+delta, len(visible)-1), 0)
+	m.debugSelected = visible[index].node.id
+	m.ensureDebugSelectionVisible()
+}
+
+func (m Model) debugSelectionIndex(visible []debugVisibleNode) int {
+	for index, node := range visible {
+		if node.node.id == m.debugSelected {
+			return index
+		}
+	}
+	return 0
+}
+
+func (m *Model) expandDebugSelection() {
+	visible := m.visibleDebugNodes()
+	if len(visible) == 0 {
+		return
+	}
+
+	selected := visible[m.debugSelectionIndex(visible)].node
+	if len(selected.children) == 0 {
+		return
+	}
+	m.debugExpanded[selected.id] = true
+	m.debugSelected = selected.children[0].id
+	m.ensureDebugSelectionVisible()
+}
+
+func (m *Model) collapseDebugSelection() {
+	visible := m.visibleDebugNodes()
+	if len(visible) == 0 {
+		return
+	}
+
+	selected := visible[m.debugSelectionIndex(visible)].node
+	if len(selected.children) == 0 {
+		if selected.parentID == "" {
+			return
+		}
+		m.debugExpanded[selected.parentID] = false
+		m.debugSelected = selected.parentID
+		m.ensureDebugSelectionVisible()
+		return
+	}
+
+	if m.debugExpanded[selected.id] {
+		m.debugExpanded[selected.id] = false
+		if selected.parentID != "" {
+			m.debugSelected = selected.parentID
+		}
+		m.ensureDebugSelectionVisible()
+		return
+	}
+
+	if selected.parentID != "" {
+		m.debugExpanded[selected.parentID] = false
+		m.debugSelected = selected.parentID
+		m.ensureDebugSelectionVisible()
+	}
+}
+
+func (m *Model) pageDebugSelection(delta int) {
+	if delta == 0 {
+		return
+	}
+	m.moveDebugSelection(delta)
+}
+
+func (m *Model) moveDebugSelectionToEdge(toEnd bool) {
+	visible := m.visibleDebugNodes()
+	if len(visible) == 0 {
+		m.debugSelected = ""
+		return
+	}
+	if toEnd {
+		m.debugSelected = visible[len(visible)-1].node.id
+	} else {
+		m.debugSelected = visible[0].node.id
+	}
+	m.ensureDebugSelectionVisible()
+}
+
+func (m Model) renderDebugWorkspaceContent(width int) debugWorkspaceRender {
+	lines := []string{
+		fmt.Sprintf("Debug tree for %s", m.roleTitle()),
+		"View: role-scoped AI API requests and responses in a drill-down tree",
+		"",
+	}
+
+	if m.debugLog == nil {
+		lines = append(lines, "Debug log not available. AI logging requires a live game with AI players.")
+		return debugWorkspaceRender{lines: lines}
+	}
+
+	visible := m.visibleDebugNodes()
+	if len(visible) == 0 {
+		lines = append(lines, "No AI API calls recorded yet for this role.")
+		return debugWorkspaceRender{lines: lines}
+	}
+
+	textWidth := paneTextWidth(width)
+	selectedLineStart := -1
+	selectedLineCount := 0
+
+	for _, visibleNode := range visible {
+		nodeLines := renderDebugTreeNode(visibleNode, textWidth, m.isDebugNodeExpanded(visibleNode.node.id, visibleNode.depth), visibleNode.node.id == m.debugSelected)
+		if visibleNode.node.id == m.debugSelected {
+			selectedLineStart = len(flattenLines(lines))
+			selectedLineCount = len(flattenLines(nodeLines))
+		}
+		lines = append(lines, nodeLines...)
+	}
+
+	if selectedLineStart < 0 {
+		selectedLineStart = 0
+	}
+
+	return debugWorkspaceRender{
+		lines:             lines,
+		selectedLineStart: selectedLineStart,
+		selectedLineCount: max(selectedLineCount, 1),
+	}
+}
+
+func renderDebugTreeNode(visible debugVisibleNode, width int, expanded, selected bool) []string {
+	indent := strings.Repeat("  ", visible.depth)
+	prefix := " "
+	if selected {
+		prefix = ">"
+	}
+
+	marker := "."
+	if len(visible.node.children) > 0 {
+		marker = "+"
+		if expanded {
+			marker = "-"
+		}
+	}
+
+	lines := wrapIndentedBlock(prefix+" "+indent+marker+" "+visible.node.title, width, prefix+" "+indent+"  ")
+	if strings.TrimSpace(visible.node.body) == "" {
+		return lines
+	}
+
+	bodyIndent := prefix + " " + indent + "    "
+	lines = append(lines, wrapIndentedBlock(bodyIndent+visible.node.body, width, bodyIndent)...)
+	return lines
+}
+
+func wrapIndentedBlock(text string, width int, continuation string) []string {
+	parts := strings.Split(text, "\n")
+	lines := make([]string, 0, len(parts))
+	for _, part := range parts {
+		wrapped := wrapLine(part, width)
+		segments := strings.Split(wrapped, "\n")
+		for index, segment := range segments {
+			if index == 0 {
+				lines = append(lines, segment)
+				continue
+			}
+			lines = append(lines, continuation+strings.TrimSpace(segment))
+		}
+	}
+	return lines
+}
+
+func debugAttemptOutcome(record ports.AICallRecord) string {
+	if record.Valid {
+		return "Success"
+	}
+	return "Failure"
+}
+
+func debugAttemptStatus(record ports.AICallRecord) (string, string) {
+	if record.Valid {
+		return "Success", "Accepted final response."
+	}
+	if record.IsToolCall {
+		return "Failure", "The model requested a lookup tool call, so the attempt did not return a final decision.\n" + debugStatusErrorBody(record)
+	}
+	if strings.TrimSpace(record.ErrorMessage) != "" {
+		return "Failure", debugFailureKind(record) + "\n" + debugStatusErrorBody(record)
+	}
+	return "Failure", "The attempt did not produce a valid final response."
+}
+
+func debugFailureKind(record ports.AICallRecord) string {
+	if strings.TrimSpace(record.RawResponse) == "" {
+		return "Transport/provider failure."
+	}
+	return "Parse/validation failure."
+}
+
+func debugStatusErrorBody(record ports.AICallRecord) string {
+	if strings.TrimSpace(record.ErrorMessage) == "" {
+		return "No additional error details were recorded."
+	}
+	return "Recorded details:\n" + sanitizeDebugText(record.ErrorMessage)
+}
+
+func debugRequestDetails(record ports.AICallRecord) string {
+	var sections []string
+	if strings.TrimSpace(record.SystemPrompt) != "" {
+		sections = append(sections, "System prompt:\n"+sanitizeDebugText(record.SystemPrompt))
+	}
+	if strings.TrimSpace(record.UserPrompt) != "" {
+		sections = append(sections, "User prompt:\n"+sanitizeDebugText(record.UserPrompt))
+	}
+	if len(sections) == 0 {
+		return "No request payload was recorded."
+	}
+	return strings.Join(sections, "\n\n")
+}
+
+func debugResponseSummary(record ports.AICallRecord) string {
+	switch {
+	case strings.TrimSpace(record.RawResponse) == "":
+		return "no response body captured"
+	case record.IsToolCall:
+		return fmt.Sprintf("%d chars, tool call", len(record.RawResponse))
+	case record.Valid:
+		return fmt.Sprintf("%d chars, valid JSON", len(record.RawResponse))
+	default:
+		return fmt.Sprintf("%d chars, invalid response", len(record.RawResponse))
+	}
+}
+
+func debugResponseDetails(record ports.AICallRecord) string {
+	if strings.TrimSpace(record.RawResponse) == "" {
+		return "No response body was captured for this attempt."
+	}
+	return sanitizeDebugText(record.RawResponse)
+}
+
+func sanitizeDebugText(text string) string {
+	return strings.ReplaceAll(text, "\t", " ")
+}
+
+func debugRoundNodeID(round domain.RoundNumber) string {
+	return fmt.Sprintf("debug:round:%06d", round)
+}
+
+func debugAttemptNodeID(round domain.RoundNumber, attempt int) string {
+	return fmt.Sprintf("debug:round:%06d:attempt:%03d", round, attempt)
+}
+
+func debugStatusNodeID(round domain.RoundNumber, attempt int) string {
+	return debugAttemptNodeID(round, attempt) + ":status"
+}
+
+func debugRequestSummaryNodeID(round domain.RoundNumber, attempt int) string {
+	return debugAttemptNodeID(round, attempt) + ":request:summary"
+}
+
+func debugRequestDetailNodeID(round domain.RoundNumber, attempt int) string {
+	return debugAttemptNodeID(round, attempt) + ":request:detail"
+}
+
+func debugResponseSummaryNodeID(round domain.RoundNumber, attempt int) string {
+	return debugAttemptNodeID(round, attempt) + ":response:summary"
+}
+
+func debugResponseDetailNodeID(round domain.RoundNumber, attempt int) string {
+	return debugAttemptNodeID(round, attempt) + ":response:detail"
+}
+
+func parseRoundID(id string) domain.RoundNumber {
+	var round int
+	_, _ = fmt.Sscanf(id, "debug:round:%06d", &round)
+	return domain.RoundNumber(round)
+}

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -75,6 +75,8 @@ type Model struct {
 	spinnerActive bool
 	spinnerGen    int
 	historyScroll int
+	debugSelected string
+	debugExpanded map[string]bool
 	drafts        map[domain.RoleID]actionDraft
 	lookup        lookupBrowserState
 }
@@ -88,13 +90,14 @@ func NewModel(definition scenario.Definition, source StateSource) Model {
 // submission hook for forwarding locked human actions into the shared runner.
 func NewModelWithSubmit(definition scenario.Definition, source StateSource, submit SubmitFunc) Model {
 	return Model{
-		scenario:  definition,
-		source:    source,
-		updates:   source.Updates(),
-		submit:    submit,
-		workspace: workspaceActionEntry,
-		status:    "Loading round state...",
-		drafts:    make(map[domain.RoleID]actionDraft),
+		scenario:      definition,
+		source:        source,
+		updates:       source.Updates(),
+		submit:        submit,
+		workspace:     workspaceActionEntry,
+		status:        "Loading round state...",
+		drafts:        make(map[domain.RoleID]actionDraft),
+		debugExpanded: make(map[string]bool),
 	}
 }
 
@@ -167,6 +170,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.state = typed.state.Clone()
 		m.selectedRole = clampRoleIndex(m.selectedRole, len(m.state.Roles))
+		m.ensureDebugSelection()
+		m.ensureDebugSelectionVisible()
 		m.status = fmt.Sprintf("Round %d loaded for %s", m.state.CurrentRound, m.roleTitle())
 		cmds := []tea.Cmd{waitForUpdateCmd(m.updates)}
 		if m.hasProviderWaits() {
@@ -276,6 +281,8 @@ func (m *Model) moveRole(delta int) {
 
 	m.selectedRole = (m.selectedRole + delta + roleCount) % roleCount
 	m.historyScroll = 0
+	m.ensureDebugSelection()
+	m.ensureDebugSelectionVisible()
 	m.status = fmt.Sprintf("Selected %s", m.roleTitle())
 }
 
@@ -283,6 +290,8 @@ func (m *Model) moveWorkspace(delta int) {
 	modeCount := int(workspaceDebug) + 1
 	m.workspace = workspaceMode((int(m.workspace) + delta + modeCount) % modeCount)
 	m.historyScroll = 0
+	m.ensureDebugSelection()
+	m.ensureDebugSelectionVisible()
 	m.status = fmt.Sprintf("Workspace switched to %s", m.workspace.label())
 }
 
@@ -294,6 +303,8 @@ func (m *Model) setWorkspace(mode workspaceMode) {
 
 	m.workspace = mode
 	m.historyScroll = 0
+	m.ensureDebugSelection()
+	m.ensureDebugSelectionVisible()
 	m.status = fmt.Sprintf("Workspace switched to %s", m.workspace.label())
 }
 
@@ -471,55 +482,11 @@ func (m Model) renderHistoryArchiveWorkspace(width int) []string {
 }
 
 func (m Model) renderDebugWorkspace(width int) []string {
-	lines := []string{
-		"AI API call log",
-		"View: LLM provider requests and raw responses for all AI players",
-		"",
-	}
-
-	if m.debugLog == nil {
-		lines = append(lines, "Debug log not available. AI logging requires a live game with AI players.")
-		return lines
-	}
-
-	records := m.debugLog.Records()
-	if len(records) == 0 {
-		lines = append(lines, "No AI API calls recorded yet.")
-		return lines
-	}
-
-	textWidth := paneTextWidth(width)
-	for i, rec := range records {
-		status := "INVALID"
-		if rec.Valid {
-			status = "OK"
-		}
-		header := fmt.Sprintf("[%d] Round %d | %s | %s/%s | attempt %d | %s",
-			i+1, rec.Round, rec.RoleID, rec.Provider, rec.Model, rec.Attempt, status)
-		lines = append(lines, header)
-		if rec.ErrorMessage != "" {
-			lines = append(lines, wrapLines("  Error: "+rec.ErrorMessage, textWidth)...)
-		}
-		if rec.SystemPrompt != "" {
-			preview := truncateDebugText(rec.SystemPrompt, 2000)
-			lines = append(lines, wrapLines("  System: "+preview, textWidth)...)
-		}
-		if rec.UserPrompt != "" {
-			preview := truncateDebugText(rec.UserPrompt, 2000)
-			lines = append(lines, wrapLines("  User: "+preview, textWidth)...)
-		}
-		if rec.RawResponse != "" {
-			preview := truncateDebugText(rec.RawResponse, 4000)
-			lines = append(lines, wrapLines("  Response: "+preview, textWidth)...)
-		}
-		lines = append(lines, "")
-	}
-
-	return lines
+	return m.renderDebugWorkspaceContent(width).lines
 }
 
 func truncateDebugText(s string, maxLen int) string {
-	s = strings.ReplaceAll(s, "\n", " ")
+	//s = strings.ReplaceAll(s, "\n", " ")
 	s = strings.ReplaceAll(s, "\t", " ")
 	if len(s) <= maxLen {
 		return s
@@ -1017,7 +984,7 @@ func workspaceInteractionHint(active workspaceMode) string {
 	case workspaceHistoryArchive:
 		return "up/down/pgup/pgdn/home/end scroll archive history"
 	case workspaceDebug:
-		return "up/down/pgup/pgdn/home/end scroll AI API call log"
+		return "up/down move, enter expand, esc collapse, pgup/pgdn/home/end jump through debug tree"
 	default:
 		return "up/down/pgup/pgdn/home/end scroll round feed history"
 	}
@@ -1030,6 +997,31 @@ func (m Model) historyWorkspaceSupportsScroll() bool {
 func (m *Model) handleHistoryScrollKey(msg tea.KeyMsg) bool {
 	if m.focusedPane != paneHistory || !m.historyWorkspaceSupportsScroll() {
 		return false
+	}
+
+	if m.workspace == workspaceDebug {
+		m.ensureDebugSelection()
+		switch msg.String() {
+		case "up":
+			m.moveDebugSelection(-1)
+		case "down":
+			m.moveDebugSelection(1)
+		case "enter":
+			m.expandDebugSelection()
+		case "esc":
+			m.collapseDebugSelection()
+		case "pgup":
+			m.pageDebugSelection(-m.historyPageSize())
+		case "pgdown":
+			m.pageDebugSelection(m.historyPageSize())
+		case "home":
+			m.moveDebugSelectionToEdge(false)
+		case "end":
+			m.moveDebugSelectionToEdge(true)
+		default:
+			return false
+		}
+		return true
 	}
 
 	switch msg.String() {
@@ -1055,6 +1047,19 @@ func (m *Model) handleHistoryScrollKey(msg tea.KeyMsg) bool {
 func (m *Model) handleHistoryScrollMouse(msg tea.MouseMsg) bool {
 	if m.focusedPane != paneHistory || !m.historyWorkspaceSupportsScroll() || !tea.MouseEvent(msg).IsWheel() {
 		return false
+	}
+
+	if m.workspace == workspaceDebug {
+		m.ensureDebugSelection()
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			m.moveDebugSelection(-3)
+		case tea.MouseButtonWheelDown:
+			m.moveDebugSelection(3)
+		default:
+			return false
+		}
+		return true
 	}
 
 	switch msg.Button {

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -39,6 +39,11 @@ const (
 
 type workspaceMode int
 
+var (
+	_ = truncateDebugText
+	_ = wrapLines
+)
+
 type stateLoadedMsg struct {
 	state domain.MatchState
 }

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -9,8 +9,10 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
+	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/engine"
+	"github.com/jpconstantineau/herbiego/internal/ports"
 	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
@@ -25,6 +27,16 @@ func (s testStateSource) Snapshot() domain.MatchState {
 
 func (s testStateSource) Updates() <-chan domain.MatchState {
 	return s.updates
+}
+
+type testDebugSource struct {
+	records []ports.AICallRecord
+}
+
+func (s testDebugSource) Records() []ports.AICallRecord {
+	cloned := make([]ports.AICallRecord, len(s.records))
+	copy(cloned, s.records)
+	return cloned
 }
 
 func TestModelLoadsInitialSnapshotAndRendersShell(t *testing.T) {
@@ -959,6 +971,200 @@ func TestModelScrollsArchiveHistoryWithMouseWheel(t *testing.T) {
 	scrolledView := scrolledShell.View()
 	if !strings.Contains(scrolledView, "[R1] 1 actions | 1 events | 1 commentary") {
 		t.Fatalf("scrolled archive view missing oldest round\n%s", scrolledView)
+	}
+}
+
+func TestModelDebugWorkspaceFiltersRecordsBySelectedRole(t *testing.T) {
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.debugLog = testDebugSource{records: []ports.AICallRecord{
+		{
+			RoleID:       domain.RoleProcurementManager,
+			Round:        1,
+			Attempt:      1,
+			Provider:     "ollama",
+			Model:        "llama3",
+			SystemPrompt: "Procurement system prompt",
+			UserPrompt:   "Procurement user prompt",
+			RawResponse:  `{"action":{"procurement":{"orders":[]}},"commentary":{"public_summary":"ok","focus_tags":["supply"]}}`,
+			Valid:        true,
+		},
+		{
+			RoleID:       domain.RoleSalesManager,
+			Round:        2,
+			Attempt:      1,
+			Provider:     "openrouter",
+			Model:        "gpt",
+			SystemPrompt: "Sales system prompt",
+			UserPrompt:   "Sales user prompt",
+			RawResponse:  `{"action":{"sales":{"product_offers":[]}},"commentary":{"public_summary":"ok","focus_tags":["pricing"]}}`,
+			Valid:        true,
+		},
+	}}
+	shell.workspace = workspaceDebug
+	shell.width = 120
+	shell.height = 30
+	shell.ensureDebugSelection()
+	shell.debugExpanded[debugRoundNodeID(1)] = true
+	shell.debugExpanded[debugAttemptNodeID(1, 1)] = true
+
+	view := shell.View()
+	for _, want := range []string{
+		"Debug tree for Procurement Manager",
+		"Round 1 (1 tries)",
+		"Try 1 - Success",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("procurement debug view missing %q\n%s", want, view)
+		}
+	}
+	for _, unwanted := range []string{
+		"Round 2 (1 tries)",
+		"Sales system prompt",
+	} {
+		if strings.Contains(view, unwanted) {
+			t.Fatalf("procurement debug view leaked %q\n%s", unwanted, view)
+		}
+	}
+
+	shell.focusedPane = paneDepartments
+	next, _ := shell.Update(tea.KeyMsg{Type: tea.KeyDown})
+	next, _ = next.(Model).Update(tea.KeyMsg{Type: tea.KeyDown})
+	salesShell := next.(Model)
+	salesShell.width = shell.width
+	salesShell.height = shell.height
+	salesShell.debugExpanded[debugRoundNodeID(2)] = true
+
+	salesView := salesShell.View()
+	if !strings.Contains(salesView, "Debug tree for Sales Manager") || !strings.Contains(salesView, "Round 2 (1 tries)") {
+		t.Fatalf("sales debug view did not follow role selection\n%s", salesView)
+	}
+	if strings.Contains(salesView, "Procurement system prompt") {
+		t.Fatalf("sales debug view leaked procurement request\n%s", salesView)
+	}
+}
+
+func TestModelDebugTreeNavigationExpandsAndCollapses(t *testing.T) {
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
+	})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.debugLog = testDebugSource{records: []ports.AICallRecord{
+		{
+			RoleID:       domain.RoleProcurementManager,
+			Round:        1,
+			Attempt:      1,
+			Provider:     "ollama",
+			Model:        "llama3",
+			SystemPrompt: "System prompt body",
+			UserPrompt:   "User prompt body",
+			RawResponse:  `{"bad_json":`,
+			ErrorMessage: "response failed validation",
+		},
+	}}
+	shell.workspace = workspaceDebug
+	shell.focusedPane = paneHistory
+	shell.width = 120
+	shell.height = 30
+	shell.ensureDebugSelection()
+
+	if got := shell.debugSelected; got != debugRoundNodeID(1) {
+		t.Fatalf("initial debugSelected = %q, want round node", got)
+	}
+
+	next, _ := shell.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	shell = next.(Model)
+	if !shell.debugExpanded[debugRoundNodeID(1)] || shell.debugSelected != debugAttemptNodeID(1, 1) {
+		t.Fatalf("enter on round did not expand/select first child: expanded=%v selected=%q", shell.debugExpanded[debugRoundNodeID(1)], shell.debugSelected)
+	}
+
+	next, _ = shell.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	shell = next.(Model)
+	if !shell.debugExpanded[debugAttemptNodeID(1, 1)] || shell.debugSelected != debugStatusNodeID(1, 1) {
+		t.Fatalf("enter on attempt did not expand/select status child: expanded=%v selected=%q", shell.debugExpanded[debugAttemptNodeID(1, 1)], shell.debugSelected)
+	}
+
+	view := shell.View()
+	for _, want := range []string{
+		"Try status details",
+		"Recorded details:",
+		"response failed validation",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("expanded debug view missing %q\n%s", want, view)
+		}
+	}
+
+	next, _ = shell.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	shell = next.(Model)
+	if shell.debugExpanded[debugAttemptNodeID(1, 1)] || shell.debugSelected != debugAttemptNodeID(1, 1) {
+		t.Fatalf("esc on status details did not collapse to attempt: expanded=%v selected=%q", shell.debugExpanded[debugAttemptNodeID(1, 1)], shell.debugSelected)
+	}
+
+	next, _ = shell.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	shell = next.(Model)
+	if shell.debugExpanded[debugRoundNodeID(1)] || shell.debugSelected != debugRoundNodeID(1) {
+		t.Fatalf("esc on attempt did not collapse to round: expanded=%v selected=%q", shell.debugExpanded[debugRoundNodeID(1)], shell.debugSelected)
+	}
+}
+
+func TestModelDebugTreeKeepsSelectionWhenNewRecordsArrive(t *testing.T) {
+	debugLog := app.NewDebugLog(10)
+	debugLog.Append(ports.AICallRecord{
+		RoleID:       domain.RoleProcurementManager,
+		Round:        1,
+		Attempt:      1,
+		Provider:     "ollama",
+		Model:        "llama3",
+		SystemPrompt: "System one",
+		UserPrompt:   "User one",
+		RawResponse:  `{"action":{"procurement":{"orders":[]}},"commentary":{"public_summary":"ok","focus_tags":["supply"]}}`,
+		Valid:        true,
+	})
+
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot: scenario.Starter().InitialState("starter-match", starterAssignments()),
+	})
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.debugLog = debugLog
+	shell.workspace = workspaceDebug
+	shell.focusedPane = paneHistory
+	shell.width = 120
+	shell.height = 24
+	shell.ensureDebugSelection()
+	shell.debugExpanded[debugRoundNodeID(1)] = true
+	shell.debugSelected = debugAttemptNodeID(1, 1)
+
+	debugLog.Append(ports.AICallRecord{
+		RoleID:       domain.RoleProcurementManager,
+		Round:        1,
+		Attempt:      2,
+		Provider:     "ollama",
+		Model:        "llama3",
+		SystemPrompt: "System two",
+		UserPrompt:   "User two",
+		RawResponse:  `{"action":{"procurement":{"orders":[]}},"commentary":{"public_summary":"retry ok","focus_tags":["supply"]}}`,
+		Valid:        true,
+	})
+
+	next, _ := shell.Update(stateLoadedMsg{state: shell.state})
+	updated := next.(Model)
+	updated.width = shell.width
+	updated.height = shell.height
+
+	if got := updated.debugSelected; got != debugAttemptNodeID(1, 1) {
+		t.Fatalf("debugSelected after update = %q, want first attempt preserved", got)
+	}
+	view := updated.View()
+	if !strings.Contains(view, "Try 2 - Success") {
+		t.Fatalf("updated debug view missing new attempt\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the flat debug log dump with a hierarchical, role-scoped debug tree in the center pane
- keep round nodes expanded by default while leaving attempts and request/response sections collapsed until navigated
- preserve the current debug selection as new records arrive, and add tests for filtering, navigation, and live updates

## Issue
- Closes #224

## Behavior
- the debug workspace now only shows AI API calls for the currently selected role
- records are grouped by round, then try, with request/response summary and detail nodes under each try
- `up/down` moves selection, `enter` drills down, and `esc` collapses one level back up
- request/response detail nodes show the full raw payload, and try status details distinguish transport/provider failures from parse/validation failures

## Validation
- `go test ./internal/adapters/tui`
- `go test ./...`