### PR TITLE
[codex] Add structured logging for match and AI flows

### DIFF
--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -52,10 +52,11 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, rounds int) error
 	}
 
 	runner := app.MatchRunner{
-		Collector: app.RoundCollector{Players: players},
+		Collector: app.RoundCollector{Players: players, Logger: runtime.Logger},
 		Resolver:  engine.NewResolver(runtime.Scenario.ResolverOptions()),
 		Random:    runtime.Random,
 		OnState:   controller.Publish,
+		Logger:    runtime.Logger,
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/cmd/herbiego/players.go
+++ b/cmd/herbiego/players.go
@@ -21,6 +21,7 @@ func buildPlayersWithHumanSubmit(runtime app.Runtime, submit human.SubmitFunc) (
 	debugLog := app.NewDebugLog(0)
 	orchestrator := app.NewAIOrchestrator(runtime.Scenario, decisionClient)
 	orchestrator.DebugLog = debugLog
+	orchestrator.Logger = runtime.Logger
 
 	players := make(map[domain.RoleID]ports.Player, len(runtime.InitialMatch.Roles))
 	for _, assignment := range runtime.InitialMatch.Roles {

--- a/internal/app/ai_orchestrator.go
+++ b/internal/app/ai_orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -29,6 +30,7 @@ type AIOrchestrator struct {
 	MaxAttempts  int
 	MaxToolCalls int
 	DebugLog     *DebugLog
+	Logger       *slog.Logger
 }
 
 func NewAIOrchestrator(definition scenario.Definition, client ports.DecisionClient) AIOrchestrator {
@@ -84,9 +86,18 @@ func (o AIOrchestrator) Decide(ctx context.Context, request ports.AIDecisionRequ
 	audit := ports.AIDecisionAudit{}
 	retryContext := request.RetryContext
 	toolCalls := 0
+	logger := loggerOrDiscard(o.Logger).With(
+		"component", "ai_orchestrator",
+		"match_id", request.MatchID,
+		"round", request.Round,
+		"role_id", request.RoleID,
+		"provider", request.Provider,
+		"model", request.Model,
+	)
 
 	for attempt := range attempts {
 		audit.AttemptCount = attempt + 1
+		logger.Debug("ai decision attempt started", "attempt", attempt+1)
 
 		providerRequest := ports.ProviderDecisionRequest{
 			Provider:            request.Provider,
@@ -109,6 +120,7 @@ func (o AIOrchestrator) Decide(ctx context.Context, request ports.AIDecisionRequ
 				UserPrompt:   providerRequest.UserPrompt,
 				ErrorMessage: err.Error(),
 			})
+			logger.Error("ai decision request failed", "attempt", attempt+1, "error", err)
 			return domain.ActionSubmission{}, audit, fmt.Errorf("app: ai decision runner: request decision: %w", err)
 		}
 
@@ -135,24 +147,29 @@ func (o AIOrchestrator) Decide(ctx context.Context, request ports.AIDecisionRequ
 				toolCalls++
 				if toolCalls > max(0, o.MaxToolCalls) && o.MaxToolCalls > 0 {
 					validationErrors = []ports.ValidationError{{Path: "tool_call", Message: fmt.Sprintf("tool call budget exceeded; at most %d tool calls allowed", o.MaxToolCalls)}}
+					logger.Warn("ai tool call budget exceeded", "attempt", attempt+1, "tool_call_count", toolCalls, "tool_call_budget", o.MaxToolCalls)
 				} else {
 					toolResult, toolErr := o.executeToolCall(*toolCall)
 					if toolErr != nil {
 						validationErrors = []ports.ValidationError{{Path: "tool_call", Message: toolErr.Error()}}
+						logger.Warn("ai tool call failed", "attempt", attempt+1, "tool_name", toolCall.ToolName, "error", toolErr)
 					} else {
 						request.ToolResults = append(request.ToolResults, toolResult)
 						request.PriorAIResponse = result.RawResponse
 						retryContext = nil
 						audit.ValidationErrors = nil
+						logger.Debug("ai tool call completed", "attempt", attempt+1, "tool_name", toolCall.ToolName, "tool_call_count", toolCalls)
 						continue
 					}
 				}
 			} else {
+				logger.Info("ai decision completed", "attempt_count", attempt+1, "tool_call_count", toolCalls)
 				return responseToSubmission(response, request), audit, nil
 			}
 		}
 
 		audit.ValidationErrors = validationErrors
+		logger.Debug("ai decision validation failed", "attempt", attempt+1, "validation_error_count", len(validationErrors), "parse_error", parseErr != nil)
 		retryContext = &ports.RetryFeedback{
 			Attempt:          attempt + 1,
 			ValidationErrors: slices.Clone(validationErrors),
@@ -163,6 +180,7 @@ func (o AIOrchestrator) Decide(ctx context.Context, request ports.AIDecisionRequ
 	submission, reason := fallbackSubmission(request)
 	audit.UsedFallback = true
 	audit.FallbackReason = reason
+	logger.Warn("ai decision fell back", "attempt_count", audit.AttemptCount, "tool_call_count", toolCalls, "fallback_reason", reason)
 	return submission, audit, nil
 }
 

--- a/internal/app/ai_orchestrator_test.go
+++ b/internal/app/ai_orchestrator_test.go
@@ -1,8 +1,10 @@
 package app_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -358,5 +360,36 @@ func TestAIOrchestratorUsesStructuredProviderResponsesWhenAvailable(t *testing.T
 	}
 	if got := submission.Commentary.Body; got != "Raise price to protect constrained throughput." {
 		t.Fatalf("Commentary.Body = %q, want structured commentary", got)
+	}
+}
+
+func TestAIOrchestratorEmitsStructuredLogs(t *testing.T) {
+	client := &stubDecisionClient{
+		responses: []ports.ProviderDecisionResult{
+			{RawResponse: `{"action":{"sales":{"product_offers":[{"product_id":"pump","unit_price":16}]}},"commentary":{"public_summary":"","focus_tags":[]}}`},
+			{RawResponse: `{"action":{"sales":{"product_offers":[{"product_id":"pump","unit_price":15}]}},"commentary":{"public_summary":"Reducing price slightly to protect revenue without outrunning flow.","focus_tags":["revenue","flow"]}}`},
+		},
+	}
+
+	var logs bytes.Buffer
+	orchestrator := app.NewAIOrchestrator(scenario.Starter(), client)
+	orchestrator.Logger = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	_, _, err := orchestrator.Decide(context.Background(), orchestrator.BuildRequest(aiRoundRequest(domain.RoleSalesManager)))
+	if err != nil {
+		t.Fatalf("Decide() error = %v", err)
+	}
+
+	output := logs.String()
+	if !strings.Contains(output, "msg=\"ai decision validation failed\"") {
+		t.Fatalf("logs = %q, want validation failure entry", output)
+	}
+	if !strings.Contains(output, "msg=\"ai decision completed\"") {
+		t.Fatalf("logs = %q, want completion entry", output)
+	}
+	if !strings.Contains(output, "match_id=match-17") || !strings.Contains(output, "role_id=sales_manager") {
+		t.Fatalf("logs = %q, want structured match and role fields", output)
 	}
 }

--- a/internal/app/logging.go
+++ b/internal/app/logging.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"io"
+	"log/slog"
+	"os"
+)
+
+func loggerOrDiscard(logger *slog.Logger) *slog.Logger {
+	if logger != nil {
+		return logger
+	}
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newProcessLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+}

--- a/internal/app/match_runner.go
+++ b/internal/app/match_runner.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/engine"
@@ -17,6 +18,7 @@ type MatchRunner struct {
 	Random    ports.RandomSource
 	OnState   func(domain.MatchState)
 	OnRound   func(engine.Result)
+	Logger    *slog.Logger
 }
 
 // Play advances the match for the requested number of rounds.
@@ -34,8 +36,16 @@ func (r MatchRunner) Play(ctx context.Context, initial domain.MatchState, rounds
 	state := prepareCollectionState(initial.Clone())
 	previous := previousAcceptedActions(state)
 	results := make([]engine.Result, 0, rounds)
+	logger := loggerOrDiscard(r.Logger).With(
+		"component", "match_runner",
+		"match_id", state.MatchID,
+		"scenario_id", state.ScenarioID,
+	)
+	logger.Info("match play started", "rounds_requested", rounds, "starting_round", state.CurrentRound)
 
 	for range rounds {
+		roundLogger := logger.With("round", state.CurrentRound)
+		roundLogger.Info("round started")
 		r.emitState(state)
 
 		collector := r.Collector
@@ -47,6 +57,7 @@ func (r MatchRunner) Play(ctx context.Context, initial domain.MatchState, rounds
 
 		actions, err := collector.Collect(ctx, state, previous)
 		if err != nil {
+			roundLogger.Error("round collection failed", "error", err)
 			return state, results, err
 		}
 
@@ -56,6 +67,7 @@ func (r MatchRunner) Play(ctx context.Context, initial domain.MatchState, rounds
 
 		result, err := r.Resolver.ResolveRound(state, actions, r.Random)
 		if err != nil {
+			roundLogger.Error("round resolution failed", "error", err)
 			return state, results, err
 		}
 
@@ -68,10 +80,20 @@ func (r MatchRunner) Play(ctx context.Context, initial domain.MatchState, rounds
 		}
 		r.emitRound(result)
 		r.emitState(revealed)
+		roundLogger.Info(
+			"round completed",
+			"action_count", len(result.Round.Actions),
+			"next_round", revealed.CurrentRound,
+			"cash", revealed.Plant.Cash,
+			"debt", revealed.Plant.Debt,
+			"backlog_count", len(revealed.Plant.Backlog),
+			"round_profit", revealed.Metrics.RoundProfit,
+		)
 
 		state = prepareCollectionState(revealed)
 	}
 
+	logger.Info("match play completed", "final_round", state.CurrentRound, "resolved_rounds", len(results))
 	return state.Clone(), results, nil
 }
 

--- a/internal/app/match_runner_test.go
+++ b/internal/app/match_runner_test.go
@@ -1,8 +1,11 @@
 package app_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
@@ -75,6 +78,50 @@ func TestMatchRunnerPlaysMultipleResolvedRounds(t *testing.T) {
 		if len(result.Round.Timeline) == 0 {
 			t.Fatalf("round %d timeline is empty", index+1)
 		}
+	}
+}
+
+func TestMatchRunnerEmitsStructuredLogs(t *testing.T) {
+	starter := scenario.Starter()
+	initial := starter.InitialState("starter-match", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", Provider: "ollama", ModelName: "gemma4:e4b"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", Provider: "openrouter", ModelName: "openai/gpt-5-mini"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "openai", ModelName: "gpt-5-mini"},
+	})
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	runner := app.MatchRunner{
+		Collector: app.RoundCollector{
+			Players: scriptedPlayers(),
+			Logger:  logger,
+		},
+		Resolver: engine.NewResolver(starter.ResolverOptions()),
+		Random:   seeded.New(1),
+		Logger:   logger,
+	}
+
+	_, _, err := runner.Play(context.Background(), initial, 1)
+	if err != nil {
+		t.Fatalf("Play() error = %v", err)
+	}
+
+	output := logs.String()
+	if !strings.Contains(output, "msg=\"match play started\"") {
+		t.Fatalf("logs = %q, want match start entry", output)
+	}
+	if !strings.Contains(output, "msg=\"round collection started\"") {
+		t.Fatalf("logs = %q, want collection start entry", output)
+	}
+	if !strings.Contains(output, "msg=\"round completed\"") {
+		t.Fatalf("logs = %q, want round completion entry", output)
+	}
+	if !strings.Contains(output, "component=match_runner") || !strings.Contains(output, "match_id=starter-match") {
+		t.Fatalf("logs = %q, want structured component and match fields", output)
 	}
 }
 

--- a/internal/app/round_collection.go
+++ b/internal/app/round_collection.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync"
@@ -20,6 +21,7 @@ type RoundCollector struct {
 	Players     map[domain.RoleID]ports.Player
 	Now         func() time.Time
 	OnRoundFlow func(domain.RoundFlowState)
+	Logger      *slog.Logger
 }
 
 // Collect walks the assigned roles in stable match order so mixed human and AI
@@ -36,6 +38,12 @@ func (c RoundCollector) Collect(ctx context.Context, state domain.MatchState, pr
 	collected := make([]domain.ActionSubmission, len(state.Roles))
 	group, groupCtx := errgroup.WithContext(ctx)
 	progress := newRoundFlowProgress(state.RoundFlow, state.Roles, c.OnRoundFlow)
+	logger := loggerOrDiscard(c.Logger).With(
+		"component", "round_collector",
+		"match_id", state.MatchID,
+		"round", state.CurrentRound,
+	)
+	logger.Info("round collection started", "role_count", len(state.Roles))
 
 	for i, assignment := range state.Roles {
 		i := i
@@ -51,28 +59,40 @@ func (c RoundCollector) Collect(ctx context.Context, state domain.MatchState, pr
 			RoleReport:             projection.BuildRoleRoundReport(state, assignment.RoleID),
 			PreviousAcceptedAction: clonePrevious(previous[assignment.RoleID]),
 		}
+		roleLogger := logger.With(
+			"role_id", assignment.RoleID,
+			"is_human", assignment.IsHuman,
+			"provider", assignment.Provider,
+			"model", assignment.ModelName,
+		)
 
 		group.Go(func() error {
 			progress.markProviderWaiting(assignment, true)
+			roleLogger.Debug("waiting for player submission")
 			submission, err := player.SubmitRound(groupCtx, request)
 			if err != nil {
+				roleLogger.Warn("player submission failed; attempting recovery", "error", err)
 				submission, err = player.RecoverFromNonResponse(groupCtx, request, err)
 				if err != nil {
 					progress.markProviderWaiting(assignment, false)
+					roleLogger.Error("player submission recovery failed", "error", err)
 					return fmt.Errorf("app: collect round %d for %q: %w", state.CurrentRound, assignment.RoleID, err)
 				}
 			}
 
 			collected[i] = normalizeSubmission(submission, request, now)
 			progress.markSubmitted(assignment.RoleID)
+			roleLogger.Info("player submission collected")
 			return nil
 		})
 	}
 
 	if err := group.Wait(); err != nil {
+		logger.Error("round collection failed", "error", err)
 		return nil, err
 	}
 
+	logger.Info("round collection completed", "collected_count", len(collected))
 	return collected, nil
 }
 

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
@@ -13,6 +14,7 @@ import (
 // Runtime contains the process dependencies created during startup.
 type Runtime struct {
 	Config       Config
+	Logger       *slog.Logger
 	Random       ports.RandomSource
 	Scenario     scenario.Definition
 	InitialMatch domain.MatchState
@@ -47,6 +49,7 @@ func NewRuntime(cfg Config) (Runtime, error) {
 
 	return Runtime{
 		Config:       cfg,
+		Logger:       newProcessLogger(),
 		Random:       seeded.New(cfg.Random.Seed),
 		Scenario:     starter,
 		InitialMatch: initialMatch,

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -59,4 +59,7 @@ func TestNewRuntimeSeedsDefaultStarterMatch(t *testing.T) {
 	if got := len(runtime.InitialMatch.RoundFlow.WaitingOnRoles); got != 4 {
 		t.Fatalf("InitialMatch.RoundFlow.WaitingOnRoles len = %d, want 4", got)
 	}
+	if runtime.Logger == nil {
+		t.Fatal("runtime.Logger = nil, want process logger")
+	}
 }


### PR DESCRIPTION
## Summary
- add `slog` logger injection to `AIOrchestrator`, `RoundCollector`, and `MatchRunner`
- wire a process logger through runtime startup and live gameplay player construction
- add tests covering emitted structured logging events and runtime logger setup

## Why
Issue #201 calls for a low-cost observability foundation so AI retries, fallbacks, provider errors, tool calls, and round progression are visible outside the current in-memory flow.

## Validation
- `go test ./internal/app ./cmd/herbiego`
- `go test ./...`

Closes #201