### PR TITLE
[codex] Derive AI prompt examples from round view

### DIFF
--- a/internal/prompting/ai.go
+++ b/internal/prompting/ai.go
@@ -12,6 +12,7 @@ import (
 // BuildSystemPrompt renders the role-facing system prompt.
 func BuildSystemPrompt(request ports.AIDecisionRequest) string {
 	briefing := request.Briefing
+	examples := promptExamples(request)
 	var lines []string
 	lines = append(lines, "# Role")
 	lines = append(lines, fmt.Sprintf("You are a %s working for the HerbieGo Manufacturing plant.", briefing.DisplayName))
@@ -54,7 +55,7 @@ func BuildSystemPrompt(request ports.AIDecisionRequest) string {
 	lines = append(lines, "Once you have your decision, communicate it to the rest of the team in JSON format according to the example below.")
 	lines = append(lines, "")
 	lines = append(lines, mustJSON(map[string]any{
-		"action": exampleAction(request.RoleID, request.RoundView.ActiveTargets),
+		"action": examples.decisionAction,
 		"commentary": map[string]any{
 			"public_summary": "Explain the decision in one short player-facing sentence.",
 			"focus_tags":     []string{"throughput"},
@@ -70,6 +71,7 @@ func BuildSystemPrompt(request ports.AIDecisionRequest) string {
 // BuildUserPrompt renders the canonical provider-neutral decision prompt.
 func BuildUserPrompt(request ports.AIDecisionRequest, retry *ports.RetryFeedback) string {
 	var sections []string
+	examples := promptExamples(request)
 
 	sections = append(sections, "## Role Briefing\n"+mustJSON(request.Briefing))
 	sections = append(sections, "## Current Round Facts\n"+mustJSON(map[string]any{
@@ -81,7 +83,7 @@ func BuildUserPrompt(request ports.AIDecisionRequest, retry *ports.RetryFeedback
 	sections = append(sections, "## Response Format\n"+mustJSON(map[string]any{
 		"response_spec": request.ResponseSpec,
 		"decision_example": map[string]any{
-			"action": exampleAction(request.RoleID, request.RoundView.ActiveTargets),
+			"action": examples.decisionAction,
 			"commentary": map[string]any{
 				"public_summary": "Explain the decision in one short player-facing sentence.",
 				"focus_tags":     []string{"throughput"},
@@ -91,13 +93,8 @@ func BuildUserPrompt(request ports.AIDecisionRequest, retry *ports.RetryFeedback
 
 	if len(request.Tools) > 0 {
 		sections = append(sections, "## Tool Lookup\n"+mustJSON(map[string]any{
-			"available_tools": request.Tools,
-			"tool_call_example": map[string]any{
-				"tool_call": map[string]any{
-					"tool_name": "show_product_route",
-					"arguments": map[string]string{"product_id": "pump"},
-				},
-			},
+			"available_tools":   request.Tools,
+			"tool_call_example": examples.toolCallExample,
 			"instructions": []string{
 				"If you need more catalog information, return exactly one tool_call JSON object.",
 				"After you receive tool results, return the final decision JSON in the main contract format.",
@@ -158,6 +155,234 @@ func exampleAction(roleID domain.RoleID, targets domain.BudgetTargets) domain.Ro
 	default:
 		return domain.RoleAction{}
 	}
+}
+
+type promptExampleSet struct {
+	decisionAction  domain.RoleAction
+	toolCallExample map[string]any
+}
+
+func promptExamples(request ports.AIDecisionRequest) promptExampleSet {
+	selector := exampleSelector{view: request.RoundView}
+	return promptExampleSet{
+		decisionAction: exampleActionForView(request.RoleID, selector),
+		toolCallExample: map[string]any{
+			"tool_call": selector.toolCallExample(request.Tools),
+		},
+	}
+}
+
+func exampleActionForView(roleID domain.RoleID, selector exampleSelector) domain.RoleAction {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return domain.RoleAction{
+			Procurement: &domain.ProcurementAction{
+				Orders: []domain.PurchaseOrderIntent{{
+					PartID:     selector.partID(),
+					SupplierID: selector.supplierID(),
+					Quantity:   1,
+				}},
+			},
+		}
+	case domain.RoleProductionManager:
+		productID := selector.productID()
+		return domain.RoleAction{
+			Production: &domain.ProductionAction{
+				Releases: []domain.ProductionRelease{{ProductID: productID, Quantity: 1}},
+				CapacityAllocation: []domain.CapacityAllocation{{
+					WorkstationID: selector.workstationID(),
+					ProductID:     productID,
+					Capacity:      1,
+				}},
+			},
+		}
+	case domain.RoleSalesManager:
+		return domain.RoleAction{
+			Sales: &domain.SalesAction{
+				ProductOffers: []domain.ProductOffer{{ProductID: selector.productID(), UnitPrice: 14}},
+			},
+		}
+	case domain.RoleFinanceController:
+		return domain.RoleAction{
+			Finance: &domain.FinanceAction{NextRoundTargets: selector.view.ActiveTargets},
+		}
+	default:
+		return domain.RoleAction{}
+	}
+}
+
+type exampleSelector struct {
+	view domain.RoundView
+}
+
+func (s exampleSelector) productID() domain.ProductID {
+	for _, item := range s.view.Plant.WIPInventory {
+		if item.ProductID != "" {
+			return item.ProductID
+		}
+	}
+	for _, item := range s.view.Plant.FinishedInventory {
+		if item.ProductID != "" {
+			return item.ProductID
+		}
+	}
+	for _, item := range s.view.Plant.Backlog {
+		if item.ProductID != "" {
+			return item.ProductID
+		}
+	}
+	for _, customer := range s.view.Customers {
+		for _, item := range customer.Backlog {
+			if item.ProductID != "" {
+				return item.ProductID
+			}
+		}
+	}
+	for _, round := range s.view.RecentRounds {
+		for _, event := range round.Events {
+			if productID := productIDFromPayload(event.Payload); productID != "" {
+				return productID
+			}
+		}
+	}
+	return "product_id"
+}
+
+func (s exampleSelector) partID() domain.PartID {
+	for _, item := range s.view.Plant.PartsInventory {
+		if item.PartID != "" {
+			return item.PartID
+		}
+	}
+	for _, item := range s.view.Plant.InTransitSupply {
+		if item.PartID != "" {
+			return item.PartID
+		}
+	}
+	for _, round := range s.view.RecentRounds {
+		for _, event := range round.Events {
+			if partID := partIDFromPayload(event.Payload); partID != "" {
+				return partID
+			}
+		}
+	}
+	return "part_id"
+}
+
+func (s exampleSelector) supplierID() domain.SupplierID {
+	for _, item := range s.view.Suppliers {
+		if item.SupplierID != "" {
+			return item.SupplierID
+		}
+	}
+	for _, item := range s.view.Plant.InTransitSupply {
+		if item.SupplierID != "" {
+			return item.SupplierID
+		}
+	}
+	for _, round := range s.view.RecentRounds {
+		for _, event := range round.Events {
+			if supplierID := supplierIDFromPayload(event.Payload); supplierID != "" {
+				return supplierID
+			}
+		}
+	}
+	return "supplier_id"
+}
+
+func (s exampleSelector) workstationID() domain.WorkstationID {
+	for _, item := range s.view.Plant.Workstations {
+		if item.WorkstationID != "" {
+			return item.WorkstationID
+		}
+	}
+	for _, item := range s.view.Plant.WIPInventory {
+		if item.WorkstationID != "" {
+			return item.WorkstationID
+		}
+	}
+	return "workstation_id"
+}
+
+func (s exampleSelector) customerID() domain.CustomerID {
+	for _, item := range s.view.Customers {
+		if item.CustomerID != "" {
+			return item.CustomerID
+		}
+	}
+	for _, item := range s.view.Plant.Backlog {
+		if item.CustomerID != "" {
+			return item.CustomerID
+		}
+	}
+	for _, round := range s.view.RecentRounds {
+		for _, event := range round.Events {
+			if customerID := customerIDFromPayload(event.Payload); customerID != "" {
+				return customerID
+			}
+		}
+	}
+	return "customer_id"
+}
+
+func (s exampleSelector) toolCallExample(tools []ports.LookupToolSpec) map[string]any {
+	for _, tool := range tools {
+		if tool.Name == "show_customer_demand_profile" {
+			return map[string]any{
+				"tool_name": tool.Name,
+				"arguments": map[string]string{
+					"customer_id": string(s.customerID()),
+					"product_id":  string(s.productID()),
+				},
+			}
+		}
+	}
+
+	for _, tool := range tools {
+		switch tool.Name {
+		case "show_product_route", "show_product_bom":
+			return map[string]any{
+				"tool_name": tool.Name,
+				"arguments": map[string]string{
+					"product_id": string(s.productID()),
+				},
+			}
+		case "list_valid_suppliers":
+			return map[string]any{
+				"tool_name": tool.Name,
+				"arguments": map[string]string{
+					"part_id": string(s.partID()),
+				},
+			}
+		}
+	}
+
+	return map[string]any{
+		"tool_name": "show_product_route",
+		"arguments": map[string]string{
+			"product_id": string(s.productID()),
+		},
+	}
+}
+
+func productIDFromPayload(payload map[string]any) domain.ProductID {
+	value, _ := payload["product_id"].(string)
+	return domain.ProductID(value)
+}
+
+func partIDFromPayload(payload map[string]any) domain.PartID {
+	value, _ := payload["part_id"].(string)
+	return domain.PartID(value)
+}
+
+func supplierIDFromPayload(payload map[string]any) domain.SupplierID {
+	value, _ := payload["supplier_id"].(string)
+	return domain.SupplierID(value)
+}
+
+func customerIDFromPayload(payload map[string]any) domain.CustomerID {
+	value, _ := payload["customer_id"].(string)
+	return domain.CustomerID(value)
 }
 
 func roleObjective(briefing ports.RoleBriefing) string {

--- a/internal/prompting/ai.go
+++ b/internal/prompting/ai.go
@@ -127,36 +127,6 @@ func mustJSON(value any) string {
 	return string(data)
 }
 
-func exampleAction(roleID domain.RoleID, targets domain.BudgetTargets) domain.RoleAction {
-	switch roleID {
-	case domain.RoleProcurementManager:
-		return domain.RoleAction{
-			Procurement: &domain.ProcurementAction{
-				Orders: []domain.PurchaseOrderIntent{{PartID: "housing", SupplierID: "forgeco", Quantity: 1}},
-			},
-		}
-	case domain.RoleProductionManager:
-		return domain.RoleAction{
-			Production: &domain.ProductionAction{
-				Releases:           []domain.ProductionRelease{{ProductID: "pump", Quantity: 1}},
-				CapacityAllocation: []domain.CapacityAllocation{{WorkstationID: "fabrication", ProductID: "pump", Capacity: 1}},
-			},
-		}
-	case domain.RoleSalesManager:
-		return domain.RoleAction{
-			Sales: &domain.SalesAction{
-				ProductOffers: []domain.ProductOffer{{ProductID: "pump", UnitPrice: 14}},
-			},
-		}
-	case domain.RoleFinanceController:
-		return domain.RoleAction{
-			Finance: &domain.FinanceAction{NextRoundTargets: targets},
-		}
-	default:
-		return domain.RoleAction{}
-	}
-}
-
 type promptExampleSet struct {
 	decisionAction  domain.RoleAction
 	toolCallExample map[string]any

--- a/internal/prompting/ai_test.go
+++ b/internal/prompting/ai_test.go
@@ -1,0 +1,137 @@
+package prompting
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+func TestBuildSystemPromptUsesRoundViewEntitiesInExamples(t *testing.T) {
+	request := exampleRequest()
+
+	procurement := BuildSystemPrompt(withRole(request, domain.RoleProcurementManager))
+	if !strings.Contains(procurement, `"part_id": "casing"`) {
+		t.Fatalf("procurement prompt = %q, want dynamic part id", procurement)
+	}
+	if !strings.Contains(procurement, `"supplier_id": "rapidparts"`) {
+		t.Fatalf("procurement prompt = %q, want dynamic supplier id", procurement)
+	}
+	if strings.Contains(procurement, `"part_id": "housing"`) || strings.Contains(procurement, `"supplier_id": "forgeco"`) {
+		t.Fatalf("procurement prompt = %q, want no starter procurement ids", procurement)
+	}
+
+	production := BuildSystemPrompt(withRole(request, domain.RoleProductionManager))
+	if !strings.Contains(production, `"product_id": "compressor"`) {
+		t.Fatalf("production prompt = %q, want dynamic product id", production)
+	}
+	if !strings.Contains(production, `"workstation_id": "milling"`) {
+		t.Fatalf("production prompt = %q, want dynamic workstation id", production)
+	}
+	if strings.Contains(production, `"product_id": "pump"`) || strings.Contains(production, `"workstation_id": "fabrication"`) {
+		t.Fatalf("production prompt = %q, want no starter production ids", production)
+	}
+
+	sales := BuildSystemPrompt(withRole(request, domain.RoleSalesManager))
+	if !strings.Contains(sales, `"product_id": "compressor"`) {
+		t.Fatalf("sales prompt = %q, want dynamic sales product id", sales)
+	}
+	if strings.Contains(sales, `"product_id": "pump"`) {
+		t.Fatalf("sales prompt = %q, want no starter sales ids", sales)
+	}
+}
+
+func TestBuildUserPromptUsesRoundViewEntitiesInDecisionAndToolExamples(t *testing.T) {
+	request := withRole(exampleRequest(), domain.RoleSalesManager)
+
+	prompt := BuildUserPrompt(request, nil)
+	if !strings.Contains(prompt, `"product_id": "compressor"`) {
+		t.Fatalf("user prompt = %q, want dynamic product id", prompt)
+	}
+	if !strings.Contains(prompt, `"customer_id": "metrofab"`) {
+		t.Fatalf("user prompt = %q, want dynamic customer id in tool example", prompt)
+	}
+	if strings.Contains(prompt, `"product_id": "pump"`) || strings.Contains(prompt, `"customer_id": "northbuild"`) {
+		t.Fatalf("user prompt = %q, want no starter tool/example ids", prompt)
+	}
+}
+
+func withRole(request ports.AIDecisionRequest, roleID domain.RoleID) ports.AIDecisionRequest {
+	request.RoleID = roleID
+	request.Briefing = ports.RoleBriefing{
+		RoleID:                 roleID,
+		DisplayName:            string(roleID),
+		PublicResponsibilities: []string{"Help the plant."},
+		HiddenIncentives:       []string{"Protect local goals."},
+		DecisionPrinciples:     []string{"Protect throughput."},
+		AllowedActionSummary:   []string{"Return valid JSON."},
+	}
+	request.AllowedActions = ports.AllowedActionSchema{
+		RoleID:         roleID,
+		RequiredAction: string(roleID),
+		JSONSchemaName: "ExampleAction",
+		Rules:          []string{"Use live round-view ids."},
+	}
+	return request
+}
+
+func exampleRequest() ports.AIDecisionRequest {
+	return ports.AIDecisionRequest{
+		RoundView: domain.RoundView{
+			Plant: domain.PlantState{
+				PartsInventory: []domain.PartInventory{
+					{PartID: "casing", OnHandQty: 2, UnitCost: 3},
+				},
+				WIPInventory: []domain.WIPInventory{
+					{ProductID: "compressor", WorkstationID: "milling", Quantity: 1, UnitCost: 9},
+				},
+				FinishedInventory: []domain.FinishedInventory{
+					{ProductID: "filter", OnHandQty: 1, UnitCost: 7},
+				},
+				Workstations: []domain.WorkstationState{
+					{WorkstationID: "milling", CapacityPerRound: 4},
+					{WorkstationID: "packout", CapacityPerRound: 3},
+				},
+				Backlog: []domain.BacklogEntry{
+					{CustomerID: "metrofab", ProductID: "compressor", Quantity: 2, OriginRound: 1},
+				},
+			},
+			Customers: []domain.CustomerState{
+				{CustomerID: "metrofab", DisplayName: "MetroFab", Sentiment: 6},
+			},
+			Suppliers: []domain.SupplierState{
+				{SupplierID: "rapidparts", DisplayName: "RapidParts", ReliabilityScore: 95},
+			},
+			ActiveTargets: domain.BudgetTargets{
+				EffectiveRound:        3,
+				ProcurementBudget:     22,
+				ProductionSpendBudget: 18,
+				RevenueTarget:         40,
+				CashFloorTarget:       10,
+				DebtCeilingTarget:     20,
+			},
+		},
+		Tools: []ports.LookupToolSpec{
+			{
+				Name:        "show_product_route",
+				Description: "Return the ordered workstation route for one product.",
+				Arguments:   []ports.LookupToolArgument{{Name: "product_id", Required: true}},
+			},
+			{
+				Name:        "show_customer_demand_profile",
+				Description: "Return demand settings for one customer/product pair.",
+				Arguments: []ports.LookupToolArgument{
+					{Name: "customer_id", Required: true},
+					{Name: "product_id", Required: true},
+				},
+			},
+		},
+		ResponseSpec: ports.ResponseFormatSpec{
+			RequireJSONOnly:     true,
+			AllowMarkdownFences: true,
+			MaxCommentaryChars:  280,
+			MaxFocusTags:        4,
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- replace starter-specific prompt example IDs with values derived from the active round view
- make the tool-call example choose live product, customer, supplier, part, and workstation identifiers when available
- add prompt-focused tests that fail if starter vocabulary leaks into non-starter prompt examples

## Why
Issue #202 calls out that the AI examples currently teach the model starter-only identifiers even when another scenario is active. This change keeps the examples aligned with the current match context without broadening into the larger prompt/template cleanup tracked in #211.

## Validation
- `go test ./internal/prompting ./internal/app ./cmd/herbiego`
- `go test ./...`

Closes #202