### PR TITLE
[codex] Generate runtime match IDs

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -45,6 +45,7 @@ const (
 // Config holds process-level runtime configuration.
 type Config struct {
 	Environment  string                       `yaml:"environment"`
+	MatchID      domain.MatchID               `yaml:"match_id"`
 	Random       RandomConfig                 `yaml:"random"`
 	HumanPlayers int                          `yaml:"human_players"`
 	UI           UIConfig                     `yaml:"ui"`
@@ -84,6 +85,7 @@ type RoleConfigFile struct {
 type BootstrapOptions struct {
 	ConfigPath           string
 	LLMCatalogPath       string
+	MatchIDOverride      *domain.MatchID
 	HumanPlayersOverride *int
 	SeedOverride         *uint64
 }
@@ -169,6 +171,10 @@ func LoadLLMCatalog(path string) (LLMCatalog, error) {
 
 // ApplyOverrides applies runtime-only startup overrides after config loading.
 func (c Config) ApplyOverrides(options BootstrapOptions) Config {
+	if options.MatchIDOverride != nil {
+		c.MatchID = *options.MatchIDOverride
+	}
+
 	if options.HumanPlayersOverride != nil {
 		c.HumanPlayers = *options.HumanPlayersOverride
 	}

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -142,6 +142,25 @@ models:
 	}
 }
 
+func TestConfigApplyOverridesSupportsMatchIDOverride(t *testing.T) {
+	cfg := Config{
+		Environment: "local",
+		MatchID:     "config-match",
+		Random: RandomConfig{
+			Seed: 7,
+		},
+	}
+
+	override := domain.MatchID("fixture-match-99")
+	cfg = cfg.ApplyOverrides(BootstrapOptions{
+		MatchIDOverride: &override,
+	})
+
+	if got := cfg.MatchID; got != "fixture-match-99" {
+		t.Fatalf("MatchID = %q, want override", got)
+	}
+}
+
 func TestLoadConfigReportsValidationErrors(t *testing.T) {
 	configPath := writeConfigFile(t, `
 human_players: 5

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"time"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
 	"github.com/jpconstantineau/herbiego/internal/domain"
@@ -19,6 +20,8 @@ type Runtime struct {
 	Scenario     scenario.Definition
 	InitialMatch domain.MatchState
 }
+
+var runtimeTimeNow = time.Now
 
 // Bootstrap loads startup configuration and constructs process dependencies.
 func Bootstrap(options BootstrapOptions) (Runtime, error) {
@@ -44,7 +47,7 @@ func NewRuntime(cfg Config) (Runtime, error) {
 	}
 
 	starter := scenario.Default()
-	initialMatch := starter.InitialState("starter-match", runtimeRoles(cfg))
+	initialMatch := starter.InitialState(runtimeMatchID(cfg, starter.ID), runtimeRoles(cfg))
 	initialMatch.RoundFlow.AIRevealDelaySeconds = cfg.UI.AIRevealDelaySeconds
 
 	return Runtime{
@@ -54,6 +57,19 @@ func NewRuntime(cfg Config) (Runtime, error) {
 		Scenario:     starter,
 		InitialMatch: initialMatch,
 	}, nil
+}
+
+func runtimeMatchID(cfg Config, scenarioID domain.ScenarioID) domain.MatchID {
+	if cfg.MatchID != "" {
+		return cfg.MatchID
+	}
+
+	return domain.MatchID(fmt.Sprintf(
+		"%s-match-%d-%d",
+		scenarioID,
+		cfg.Random.Seed,
+		runtimeTimeNow().UTC().UnixNano(),
+	))
 }
 
 // RoleSummaries returns a stable summary of role runtime assignments.

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -1,8 +1,19 @@
 package app
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-func TestNewRuntimeSeedsDefaultStarterMatch(t *testing.T) {
+func TestNewRuntimeSeedsGeneratedStarterMatch(t *testing.T) {
+	originalNow := runtimeTimeNow
+	runtimeTimeNow = func() time.Time {
+		return time.Date(2026, time.May, 3, 17, 30, 45, 123456789, time.UTC)
+	}
+	t.Cleanup(func() {
+		runtimeTimeNow = originalNow
+	})
+
 	runtime, err := NewRuntime(Config{
 		Environment:  "test",
 		HumanPlayers: 1,
@@ -32,8 +43,11 @@ func TestNewRuntimeSeedsDefaultStarterMatch(t *testing.T) {
 	if got := runtime.Scenario.ID; got != "starter" {
 		t.Fatalf("Scenario.ID = %q, want starter", got)
 	}
-	if got := runtime.InitialMatch.MatchID; got != "starter-match" {
-		t.Fatalf("InitialMatch.MatchID = %q, want starter-match", got)
+	if got := runtime.InitialMatch.MatchID; got != "starter-match-9-1777829445123456789" {
+		t.Fatalf("InitialMatch.MatchID = %q, want generated deterministic id", got)
+	}
+	if got := runtime.InitialMatch.MatchID; got == "starter-match" {
+		t.Fatalf("InitialMatch.MatchID = %q, want generated id instead of hardcoded literal", got)
 	}
 	if got := runtime.InitialMatch.CurrentRound; got != 1 {
 		t.Fatalf("InitialMatch.CurrentRound = %d, want 1", got)
@@ -61,5 +75,38 @@ func TestNewRuntimeSeedsDefaultStarterMatch(t *testing.T) {
 	}
 	if runtime.Logger == nil {
 		t.Fatal("runtime.Logger = nil, want process logger")
+	}
+}
+
+func TestNewRuntimeUsesConfiguredMatchIDWhenProvided(t *testing.T) {
+	runtime, err := NewRuntime(Config{
+		Environment:  "test",
+		MatchID:      "fixture-match-42",
+		HumanPlayers: 1,
+		UI: UIConfig{
+			AIRevealDelaySeconds: 12,
+		},
+		Random: RandomConfig{
+			Seed: 9,
+		},
+		LLMCatalog: LLMCatalog{
+			Entries: []LLMCatalogEntry{
+				{Provider: "ollama-localhost", Model: "gemma4:e4b", URL: "http://localhost:11434/v1/", APISDKType: APISDKTypeOpenAI},
+				{Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: APISDKTypeOpenAI},
+			},
+		},
+		RoleConfigs: []RoleConfigFile{
+			{RoleID: "procurement_manager", Provider: "ollama-localhost"},
+			{RoleID: "production_manager", Provider: "ollama-localhost"},
+			{RoleID: "sales_manager", Provider: "openrouter"},
+			{RoleID: "finance_controller", Provider: "ollama-localhost"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime() error = %v, want nil", err)
+	}
+
+	if got := runtime.InitialMatch.MatchID; got != "fixture-match-42" {
+		t.Fatalf("InitialMatch.MatchID = %q, want configured match id", got)
 	}
 }


### PR DESCRIPTION
## Summary
- replace the hardcoded `starter-match` runtime match id with a generated id derived from scenario, seed, and startup time
- support explicit `match_id` configuration and `BootstrapOptions` override for deterministic fixtures
- add runtime and config coverage for generated ids and override behavior

## Why
Issue #207 calls out that every runtime currently starts with the same match id, which will collide immediately once persistence is wired in. This change keeps the default startup path unique while still allowing deterministic fixture ids when tests or tooling need them.

## Validation
- `go test ./internal/app ./cmd/herbiego`
- `staticcheck ./...`
- `go test ./...`

Closes #207