### PR TITLE
[codex] Persist rounds through the match runner

### DIFF
--- a/internal/app/match_runner.go
+++ b/internal/app/match_runner.go
@@ -16,6 +16,7 @@ type MatchRunner struct {
 	Collector RoundCollector
 	Resolver  *engine.Resolver
 	Random    ports.RandomSource
+	Store     ports.MatchStateStore
 	OnState   func(domain.MatchState)
 	OnRound   func(engine.Result)
 	Logger    *slog.Logger
@@ -33,7 +34,7 @@ func (r MatchRunner) Play(ctx context.Context, initial domain.MatchState, rounds
 		return domain.MatchState{}, nil, fmt.Errorf("app: match random source is not configured")
 	}
 
-	state := prepareCollectionState(initial.Clone())
+	state := initial.Clone()
 	previous := previousAcceptedActions(state)
 	results := make([]engine.Result, 0, rounds)
 	logger := loggerOrDiscard(r.Logger).With(
@@ -42,6 +43,16 @@ func (r MatchRunner) Play(ctx context.Context, initial domain.MatchState, rounds
 		"scenario_id", state.ScenarioID,
 	)
 	logger.Info("match play started", "rounds_requested", rounds, "starting_round", state.CurrentRound)
+
+	if r.Store != nil {
+		if err := r.Store.CreateMatch(state); err != nil {
+			logger.Error("match store create failed", "error", err)
+			return domain.MatchState{}, nil, fmt.Errorf("app: create match in store: %w", err)
+		}
+		logger.Info("match store initialized")
+	}
+
+	state = prepareCollectionState(state)
 
 	for range rounds {
 		roundLogger := logger.With("round", state.CurrentRound)
@@ -74,6 +85,16 @@ func (r MatchRunner) Play(ctx context.Context, initial domain.MatchState, rounds
 		revealed := result.NextState.Clone()
 		revealed.RoundFlow = roundFlowFor(state.Roles, actions, domain.RoundPhaseRevealed, state.RoundFlow.AIRevealDelaySeconds)
 		result.NextState = revealed.Clone()
+		if r.Store != nil {
+			committed, err := r.Store.CommitRound(state.MatchID, result.NextState, result.Round)
+			if err != nil {
+				roundLogger.Error("round persistence failed", "error", err)
+				return state, results, fmt.Errorf("app: commit round %d: %w", result.Round.Round, err)
+			}
+			revealed = committed.Clone()
+			result.NextState = committed.Clone()
+			roundLogger.Info("round persisted")
+		}
 		results = append(results, result)
 		for _, action := range result.Round.Actions {
 			previous[action.RoleID] = action.Clone()

--- a/internal/app/match_runner_test.go
+++ b/internal/app/match_runner_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jpconstantineau/herbiego/internal/adapters/persistence/memory"
 	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
@@ -122,6 +123,69 @@ func TestMatchRunnerEmitsStructuredLogs(t *testing.T) {
 	}
 	if !strings.Contains(output, "component=match_runner") || !strings.Contains(output, "match_id=starter-match") {
 		t.Fatalf("logs = %q, want structured component and match fields", output)
+	}
+}
+
+func TestMatchRunnerPersistsCommittedRoundsWhenStoreConfigured(t *testing.T) {
+	starter := scenario.Starter()
+	initial := starter.InitialState("match-207", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", Provider: "ollama", ModelName: "gemma4:e4b"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", Provider: "openrouter", ModelName: "openai/gpt-5-mini"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "openai", ModelName: "gpt-5-mini"},
+	})
+
+	store := memory.NewStore(memory.Options{RecentHistoryLimit: 10})
+	runner := app.MatchRunner{
+		Collector: app.RoundCollector{
+			Players: scriptedPlayers(),
+		},
+		Resolver: engine.NewResolver(starter.ResolverOptions()),
+		Random:   seeded.New(1),
+		Store:    store,
+	}
+
+	final, results, err := runner.Play(context.Background(), initial, 2)
+	if err != nil {
+		t.Fatalf("Play() error = %v", err)
+	}
+	if got := len(results); got != 2 {
+		t.Fatalf("len(results) = %d, want 2", got)
+	}
+
+	current, err := store.CurrentState(initial.MatchID)
+	if err != nil {
+		t.Fatalf("CurrentState() error = %v", err)
+	}
+	if got := current.CurrentRound; got != final.CurrentRound {
+		t.Fatalf("stored CurrentRound = %d, want %d", got, final.CurrentRound)
+	}
+	if got := len(current.History.RecentRounds); got != 2 {
+		t.Fatalf("stored history rounds = %d, want 2", got)
+	}
+
+	roundOne, err := store.Round(initial.MatchID, 1)
+	if err != nil {
+		t.Fatalf("Round(1) error = %v", err)
+	}
+	if got := len(roundOne.Actions); got != 4 {
+		t.Fatalf("stored round 1 actions = %d, want 4", got)
+	}
+
+	timeline, err := store.EventTimeline(initial.MatchID)
+	if err != nil {
+		t.Fatalf("EventTimeline() error = %v", err)
+	}
+	if len(timeline) == 0 {
+		t.Fatal("stored event timeline is empty, want persisted events")
+	}
+
+	commentary, err := store.Commentary(initial.MatchID)
+	if err != nil {
+		t.Fatalf("Commentary() error = %v", err)
+	}
+	if got := len(commentary); got != 8 {
+		t.Fatalf("stored commentary count = %d, want 8", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add optional `MatchStateStore` support to `app.MatchRunner`
- initialize the store with the starting match state and commit each resolved round through the game loop
- add runner coverage that exercises the in-memory store through live round execution

## Why
Issue #212 points out that the persistence adapters exist but the live match loop never uses them. This change adds the single integration point needed for replay/resume and later SQLite wiring without changing the rest of the game flow.

## Validation
- `go test ./internal/app ./internal/adapters/persistence/memory ./cmd/herbiego`
- `staticcheck ./...`
- `go test ./...`

Closes #212