### PR TITLE
Build debugging and operator inspection views

### DIFF
--- a/cmd/herbiego/live_gameplay_controller.go
+++ b/cmd/herbiego/live_gameplay_controller.go
@@ -17,15 +17,21 @@ type submissionKey struct {
 type liveGameplayController struct {
 	mu          sync.Mutex
 	latest      domain.MatchState
+	snapshots   []domain.MatchState
 	updates     chan domain.MatchState
 	submissions chan domain.ActionSubmission
 	pending     map[submissionKey][]domain.ActionSubmission
 	closed      bool
 }
 
-func newLiveGameplayController(initial domain.MatchState) *liveGameplayController {
+func newLiveGameplayController(initial domain.MatchState, snapshots []domain.MatchState) *liveGameplayController {
+	clonedSnapshots := cloneMatchStates(snapshots)
+	if len(clonedSnapshots) == 0 {
+		clonedSnapshots = []domain.MatchState{initial.Clone()}
+	}
 	return &liveGameplayController{
 		latest:      initial.Clone(),
+		snapshots:   clonedSnapshots,
 		updates:     make(chan domain.MatchState, 8),
 		submissions: make(chan domain.ActionSubmission, len(initial.Roles)+1),
 		pending:     make(map[submissionKey][]domain.ActionSubmission),
@@ -42,6 +48,12 @@ func (c *liveGameplayController) Updates() <-chan domain.MatchState {
 	return c.updates
 }
 
+func (c *liveGameplayController) StateSnapshots() []domain.MatchState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return cloneMatchStates(c.snapshots)
+}
+
 func (c *liveGameplayController) Publish(state domain.MatchState) {
 	cloned := state.Clone()
 
@@ -51,6 +63,7 @@ func (c *liveGameplayController) Publish(state domain.MatchState) {
 		return
 	}
 	c.latest = cloned.Clone()
+	c.snapshots = appendOrReplaceSnapshot(c.snapshots, cloned)
 	updates := c.updates
 	c.mu.Unlock()
 
@@ -137,4 +150,23 @@ func (c *liveGameplayController) storePending(key submissionKey, submission doma
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.pending[key] = append(c.pending[key], submission.Clone())
+}
+
+func cloneMatchStates(states []domain.MatchState) []domain.MatchState {
+	cloned := make([]domain.MatchState, len(states))
+	for i := range states {
+		cloned[i] = states[i].Clone()
+	}
+	return cloned
+}
+
+func appendOrReplaceSnapshot(states []domain.MatchState, next domain.MatchState) []domain.MatchState {
+	cloned := next.Clone()
+	for i := range states {
+		if states[i].CurrentRound == cloned.CurrentRound {
+			states[i] = cloned
+			return states
+		}
+	}
+	return append(states, cloned)
 }

--- a/cmd/herbiego/live_gameplay_controller_test.go
+++ b/cmd/herbiego/live_gameplay_controller_test.go
@@ -25,7 +25,7 @@ func TestLiveGameplayControllerDeliversHumanSubmissionAndStreamsRoundPhases(t *t
 		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "ollama", ModelName: "gemma"},
 	})
 
-	controller := newLiveGameplayController(initial)
+	controller := newLiveGameplayController(initial, nil)
 	now := time.Date(2026, time.April, 21, 20, 0, 0, 0, time.UTC)
 	runner := app.MatchRunner{
 		Collector: app.RoundCollector{

--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/engine"
+	"github.com/jpconstantineau/herbiego/internal/ports"
 )
 
 func main() {
@@ -58,13 +59,32 @@ func main() {
 }
 
 func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState domain.MatchState, store persistentStore, rounds int, persistAIDebug bool) error {
-	controller := newLiveGameplayController(initialState)
+	stateSnapshots := []domain.MatchState{initialState.Clone()}
+	if store != nil {
+		persistedSnapshots, err := store.StateSnapshots(initialState.MatchID)
+		if err != nil {
+			return fmt.Errorf("load persisted state snapshots: %w", err)
+		}
+		stateSnapshots = persistedSnapshots
+	}
+	controller := newLiveGameplayController(initialState, stateSnapshots)
 	players, debugLog, err := buildPlayersWithHumanSubmit(runtime, initialState, controller.SubmitRound)
 	if err != nil {
 		return fmt.Errorf("player setup: %w", err)
 	}
 	if store != nil && persistAIDebug {
 		configureAICallPersistence(debugLog, runtime.Logger, store, initialState.MatchID)
+	}
+	debugSource := tui.DebugSource(debugLog)
+	if store != nil {
+		debugRecords, err := store.AICallRecords(initialState.MatchID)
+		if err != nil {
+			return fmt.Errorf("load persisted ai traces: %w", err)
+		}
+		debugSource = combinedDebugSource{
+			live:      debugLog,
+			persisted: debugRecords,
+		}
 	}
 
 	runner := app.MatchRunner{
@@ -83,7 +103,7 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 		runtime.Scenario,
 		controller,
 		controller.Submit,
-		debugLog,
+		debugSource,
 		tea.WithAltScreen(),
 		tea.WithContext(ctx),
 	)
@@ -125,4 +145,21 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 		return playErr
 	}
 	return nil
+}
+
+type combinedDebugSource struct {
+	live      *app.DebugLog
+	persisted []ports.AICallRecord
+}
+
+func (s combinedDebugSource) Records() []ports.AICallRecord {
+	liveRecords := s.live.Records()
+	if len(s.persisted) == 0 {
+		return liveRecords
+	}
+
+	records := make([]ports.AICallRecord, 0, len(s.persisted)+len(liveRecords))
+	records = append(records, s.persisted...)
+	records = append(records, liveRecords...)
+	return records
 }

--- a/cmd/herbiego/persistence.go
+++ b/cmd/herbiego/persistence.go
@@ -15,6 +15,8 @@ type persistentStore interface {
 	ports.MatchStateStore
 	Close() error
 	AppendAICall(matchID domain.MatchID, record ports.AICallRecord) error
+	AICallRecords(matchID domain.MatchID) ([]ports.AICallRecord, error)
+	StateSnapshots(matchID domain.MatchID) ([]domain.MatchState, error)
 }
 
 func resolveMatchPersistence(runtime app.Runtime, sqlitePath, resumeMatchID string) (persistentStore, domain.MatchState, error) {

--- a/internal/adapters/persistence/memory/store.go
+++ b/internal/adapters/persistence/memory/store.go
@@ -23,6 +23,7 @@ type Store struct {
 
 type storedMatch struct {
 	state      domain.MatchState
+	snapshots  []domain.MatchState
 	rounds     []domain.RoundRecord
 	events     []domain.RoundEvent
 	commentary []domain.CommentaryRecord
@@ -54,6 +55,7 @@ func (s *Store) CreateMatch(initial domain.MatchState) error {
 
 	s.matches[initial.MatchID] = storedMatch{
 		state:      state,
+		snapshots:  []domain.MatchState{state.Clone()},
 		rounds:     cloneRoundRecords(rounds),
 		events:     flattenEvents(rounds),
 		commentary: flattenCommentary(rounds),
@@ -109,6 +111,7 @@ func (s *Store) CommitRound(matchID domain.MatchID, nextState domain.MatchState,
 	match.state.History = domain.RoundHistory{
 		RecentRounds: cloneRoundRecords(tail(match.rounds, s.historyLimit)),
 	}
+	match.snapshots = appendOrReplaceSnapshot(match.snapshots, match.state)
 
 	s.matches[matchID] = match
 	return match.state.Clone(), nil
@@ -155,6 +158,19 @@ func (s *Store) Commentary(matchID domain.MatchID) ([]domain.CommentaryRecord, e
 	}
 
 	return slices.Clone(match.commentary), nil
+}
+
+// StateSnapshots returns one canonical state snapshot per current-round value.
+func (s *Store) StateSnapshots(matchID domain.MatchID) ([]domain.MatchState, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	match, ok := s.matches[matchID]
+	if !ok {
+		return nil, ports.ErrMatchNotFound
+	}
+
+	return cloneStates(match.snapshots), nil
 }
 
 func normalizedHistoryLimit(limit int) int {
@@ -207,6 +223,29 @@ func flattenCommentary(rounds []domain.RoundRecord) []domain.CommentaryRecord {
 	}
 
 	return commentary
+}
+
+func cloneStates(states []domain.MatchState) []domain.MatchState {
+	if states == nil {
+		return nil
+	}
+
+	cloned := make([]domain.MatchState, len(states))
+	for i := range states {
+		cloned[i] = states[i].Clone()
+	}
+	return cloned
+}
+
+func appendOrReplaceSnapshot(states []domain.MatchState, next domain.MatchState) []domain.MatchState {
+	cloned := next.Clone()
+	for i := range states {
+		if states[i].CurrentRound == cloned.CurrentRound {
+			states[i] = cloned
+			return states
+		}
+	}
+	return append(states, cloned)
 }
 
 func tail[T any](items []T, limit int) []T {

--- a/internal/adapters/persistence/memory/store_test.go
+++ b/internal/adapters/persistence/memory/store_test.go
@@ -154,3 +154,37 @@ func TestStoreTrimsCurrentHistoryWindowButKeepsAppendOnlyTimeline(t *testing.T) 
 		t.Fatalf("timeline len = %d, want 3", len(timeline))
 	}
 }
+
+func TestStoreExposesStateSnapshotsAcrossRounds(t *testing.T) {
+	store := memory.NewStore(memory.Options{RecentHistoryLimit: 2})
+	initial := domain.MatchState{
+		MatchID:      "match-snapshots",
+		ScenarioID:   "starter",
+		CurrentRound: 1,
+		Plant:        domain.PlantState{Cash: 24},
+	}
+	if err := store.CreateMatch(initial); err != nil {
+		t.Fatalf("CreateMatch() error = %v", err)
+	}
+
+	nextState := initial.Clone()
+	nextState.CurrentRound = 2
+	nextState.Plant.Cash = 31
+	if _, err := store.CommitRound(initial.MatchID, nextState, domain.RoundRecord{Round: 1}); err != nil {
+		t.Fatalf("CommitRound() error = %v", err)
+	}
+
+	snapshots, err := store.StateSnapshots(initial.MatchID)
+	if err != nil {
+		t.Fatalf("StateSnapshots() error = %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("StateSnapshots len = %d, want 2", len(snapshots))
+	}
+	if got := snapshots[0].CurrentRound; got != 1 {
+		t.Fatalf("snapshots[0].CurrentRound = %d, want 1", got)
+	}
+	if got := snapshots[1].Plant.Cash; got != 31 {
+		t.Fatalf("snapshots[1].Plant.Cash = %d, want 31", got)
+	}
+}

--- a/internal/adapters/persistence/sqlite/store.go
+++ b/internal/adapters/persistence/sqlite/store.go
@@ -80,6 +80,12 @@ func (s *Store) CreateMatch(initial domain.MatchState) error {
 	`, initial.MatchID, initial.ScenarioID, stateJSON, now, now); err != nil {
 		return fmt.Errorf("sqlite store: create match %q: %w", initial.MatchID, err)
 	}
+	if _, err := tx.Exec(`
+		INSERT INTO state_snapshots(match_id, current_round, state_json)
+		VALUES (?, ?, ?)
+	`, initial.MatchID, state.CurrentRound, stateJSON); err != nil {
+		return fmt.Errorf("sqlite store: insert initial snapshot for %q: %w", initial.MatchID, err)
+	}
 
 	if err := insertRounds(tx, initial.MatchID, rounds); err != nil {
 		return err
@@ -172,6 +178,13 @@ func (s *Store) CommitRound(matchID domain.MatchID, nextState domain.MatchState,
 		VALUES (?, ?, ?)
 	`, matchID, round.Round, roundJSON); err != nil {
 		return domain.MatchState{}, fmt.Errorf("sqlite store: insert round %d: %w", round.Round, err)
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO state_snapshots(match_id, current_round, state_json)
+		VALUES (?, ?, ?)
+		ON CONFLICT(match_id, current_round) DO UPDATE SET state_json = excluded.state_json
+	`, matchID, next.CurrentRound, stateJSON); err != nil {
+		return domain.MatchState{}, fmt.Errorf("sqlite store: insert snapshot for round %d: %w", next.CurrentRound, err)
 	}
 	if err := insertEvents(tx, matchID, committedRound.Events); err != nil {
 		return domain.MatchState{}, err
@@ -335,6 +348,41 @@ func (s *Store) AICallRecords(matchID domain.MatchID) ([]ports.AICallRecord, err
 	return records, nil
 }
 
+func (s *Store) StateSnapshots(matchID domain.MatchID) ([]domain.MatchState, error) {
+	rows, err := s.db.Query(`
+		SELECT state_json
+		FROM state_snapshots
+		WHERE match_id = ?
+		ORDER BY current_round ASC
+	`, matchID)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite store: query state snapshots: %w", err)
+	}
+	defer rows.Close()
+
+	var snapshots []domain.MatchState
+	for rows.Next() {
+		var encoded string
+		if err := rows.Scan(&encoded); err != nil {
+			return nil, fmt.Errorf("sqlite store: scan state snapshot: %w", err)
+		}
+		var state domain.MatchState
+		if err := json.Unmarshal([]byte(encoded), &state); err != nil {
+			return nil, fmt.Errorf("sqlite store: decode state snapshot: %w", err)
+		}
+		snapshots = append(snapshots, state)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite store: iterate state snapshots: %w", err)
+	}
+	if len(snapshots) == 0 {
+		if _, err := s.CurrentState(matchID); err != nil {
+			return nil, err
+		}
+	}
+	return snapshots, nil
+}
+
 func (s *Store) initSchema() error {
 	if _, err := s.db.Exec(`
 		PRAGMA foreign_keys = ON;
@@ -350,6 +398,12 @@ func (s *Store) initSchema() error {
 			round_number INTEGER NOT NULL,
 			round_json TEXT NOT NULL,
 			PRIMARY KEY(match_id, round_number)
+		);
+		CREATE TABLE IF NOT EXISTS state_snapshots (
+			match_id TEXT NOT NULL,
+			current_round INTEGER NOT NULL,
+			state_json TEXT NOT NULL,
+			PRIMARY KEY(match_id, current_round)
 		);
 		CREATE TABLE IF NOT EXISTS events (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/adapters/persistence/sqlite/store_test.go
+++ b/internal/adapters/persistence/sqlite/store_test.go
@@ -164,6 +164,40 @@ func TestStorePersistsAICallRecordsWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestStorePersistsStateSnapshotsAcrossRounds(t *testing.T) {
+	store := newStore(t)
+	initial := domain.MatchState{
+		MatchID:      "match-4",
+		ScenarioID:   "starter",
+		CurrentRound: 1,
+		Plant:        domain.PlantState{Cash: 24},
+	}
+	if err := store.CreateMatch(initial); err != nil {
+		t.Fatalf("CreateMatch() error = %v", err)
+	}
+
+	nextState := initial.Clone()
+	nextState.CurrentRound = 2
+	nextState.Plant.Cash = 31
+	if _, err := store.CommitRound(initial.MatchID, nextState, domain.RoundRecord{Round: 1}); err != nil {
+		t.Fatalf("CommitRound() error = %v", err)
+	}
+
+	snapshots, err := store.StateSnapshots(initial.MatchID)
+	if err != nil {
+		t.Fatalf("StateSnapshots() error = %v", err)
+	}
+	if len(snapshots) != 2 {
+		t.Fatalf("StateSnapshots len = %d, want 2", len(snapshots))
+	}
+	if got := snapshots[0].CurrentRound; got != 1 {
+		t.Fatalf("snapshots[0].CurrentRound = %d, want 1", got)
+	}
+	if got := snapshots[1].Plant.Cash; got != 31 {
+		t.Fatalf("snapshots[1].Plant.Cash = %d, want 31", got)
+	}
+}
+
 func newStore(t *testing.T) *sqlite.Store {
 	t.Helper()
 

--- a/internal/adapters/tui/debug_tree.go
+++ b/internal/adapters/tui/debug_tree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/ports"
@@ -49,14 +50,87 @@ func (m Model) debugRoleRecords() []ports.AICallRecord {
 }
 
 func (m Model) buildDebugTree() []*debugTreeNode {
+	var roots []*debugTreeNode
+	if inspection := m.buildRoundInspectionTree(); inspection != nil {
+		roots = append(roots, inspection)
+	}
+	if traces := m.buildTraceTree(); traces != nil {
+		roots = append(roots, traces)
+	}
+	return roots
+}
+
+func (m Model) buildRoundInspectionTree() *debugTreeNode {
+	if len(m.state.History.RecentRounds) == 0 {
+		return nil
+	}
+
+	root := &debugTreeNode{
+		id:    "debug:inspection",
+		title: fmt.Sprintf("Round inspections (%d retained)", len(m.state.History.RecentRounds)),
+	}
+	for _, round := range slices.Backward(m.state.History.RecentRounds) {
+		root.children = append(root.children, m.buildRoundInspectionNode(round))
+	}
+	return root
+}
+
+func (m Model) buildRoundInspectionNode(round domain.RoundRecord) *debugTreeNode {
+	node := &debugTreeNode{
+		id:       debugInspectionRoundNodeID(round.Round),
+		parentID: "debug:inspection",
+		title: fmt.Sprintf(
+			"Round %d (%d actions | %d events | %d commentary)",
+			round.Round,
+			len(round.Actions),
+			len(round.Events),
+			len(round.Commentary),
+		),
+	}
+
+	actionNode := &debugTreeNode{
+		id:       debugInspectionActionNodeID(round.Round),
+		parentID: node.id,
+		title:    fmt.Sprintf("Action inspection for %s", m.roleTitle()),
+		body:     debugActionInspectionBody(round, m.selectedAssignment().RoleID),
+	}
+	stateNode := &debugTreeNode{
+		id:       debugInspectionStateNodeID(round.Round),
+		parentID: node.id,
+		title:    "State transition summary",
+		body:     m.debugStateDiffBody(round.Round, round.Metrics),
+	}
+	timelineNode := &debugTreeNode{
+		id:       debugInspectionTimelineNodeID(round.Round),
+		parentID: node.id,
+		title:    "Round timeline highlights",
+		body:     debugTimelineBody(round),
+	}
+
+	node.children = []*debugTreeNode{actionNode, stateNode, timelineNode}
+	return node
+}
+
+func (m Model) buildTraceTree() *debugTreeNode {
 	records := m.debugRoleRecords()
 	if len(records) == 0 {
 		return nil
 	}
 
+	root := &debugTreeNode{
+		id:    "debug:traces",
+		title: fmt.Sprintf("Prompt/response traces for %s (%d total)", m.roleTitle(), len(records)),
+	}
+	for _, roundNode := range buildTraceRoundNodes(records) {
+		roundNode.parentID = root.id
+		root.children = append(root.children, roundNode)
+	}
+	return root
+}
+
+func buildTraceRoundNodes(records []ports.AICallRecord) []*debugTreeNode {
 	roundNodes := make([]*debugTreeNode, 0)
 	roundIndex := make(map[domain.RoundNumber]*debugTreeNode)
-	attemptIndex := make(map[string]*debugTreeNode)
 	attemptCounts := make(map[domain.RoundNumber]int)
 
 	for _, record := range records {
@@ -70,23 +144,15 @@ func (m Model) buildDebugTree() []*debugTreeNode {
 			roundNodes = append(roundNodes, roundNode)
 		}
 
-		attemptID := debugAttemptNodeID(record.Round, record.Attempt)
-		if attemptIndex[attemptID] != nil {
-			continue
-		}
-
-		attemptNode := buildDebugAttemptNode(record)
-		attemptNode.parentID = roundNode.id
-		roundNode.children = append(roundNode.children, attemptNode)
-		attemptIndex[attemptID] = attemptNode
+		roundNode.children = append(roundNode.children, buildDebugAttemptNode(record, roundNode.id))
 		attemptCounts[record.Round]++
 	}
 
 	slices.SortFunc(roundNodes, func(left, right *debugTreeNode) int {
 		switch {
-		case left.id < right.id:
-			return -1
 		case left.id > right.id:
+			return -1
+		case left.id < right.id:
 			return 1
 		default:
 			return 0
@@ -110,23 +176,24 @@ func (m Model) buildDebugTree() []*debugTreeNode {
 	return roundNodes
 }
 
-func buildDebugAttemptNode(record ports.AICallRecord) *debugTreeNode {
+func buildDebugAttemptNode(record ports.AICallRecord, parentID string) *debugTreeNode {
 	_, statusBody := debugAttemptStatus(record)
 	requestSummary := fmt.Sprintf(
-		"Request Summary (%s/%s, system %d chars, user %d chars)",
+		"Request summary (%s/%s, system %d chars, user %d chars)",
 		record.Provider,
 		record.Model,
 		len(record.SystemPrompt),
 		len(record.UserPrompt),
 	)
 	responseSummary := fmt.Sprintf(
-		"Response Summary (%s)",
+		"Response summary (%s)",
 		debugResponseSummary(record),
 	)
 
 	attemptNode := &debugTreeNode{
-		id:    debugAttemptNodeID(record.Round, record.Attempt),
-		title: fmt.Sprintf("Try %d - %s", record.Attempt, debugAttemptOutcome(record)),
+		id:       debugAttemptNodeID(record.Round, record.Attempt),
+		parentID: parentID,
+		title:    fmt.Sprintf("Try %d - %s", record.Attempt, debugAttemptOutcome(record)),
 	}
 	statusNode := &debugTreeNode{
 		id:       debugStatusNodeID(record.Round, record.Attempt),
@@ -184,7 +251,7 @@ func (m Model) isDebugNodeExpanded(nodeID string, depth int) bool {
 	if ok {
 		return expanded
 	}
-	return depth == 0
+	return depth <= 1
 }
 
 func (m *Model) ensureDebugSelection() {
@@ -327,19 +394,18 @@ func (m *Model) moveDebugSelectionToEdge(toEnd bool) {
 
 func (m Model) renderDebugWorkspaceContent(width int) debugWorkspaceRender {
 	lines := []string{
-		fmt.Sprintf("Debug tree for %s", m.roleTitle()),
-		"View: role-scoped AI API requests and responses in a drill-down tree",
+		fmt.Sprintf("Debug inspector for %s", m.roleTitle()),
+		"View: round actions, state transitions, and AI prompt/response traces in one drill-down tree",
 		"",
-	}
-
-	if m.debugLog == nil {
-		lines = append(lines, "Debug log not available. AI logging requires a live game with AI players.")
-		return debugWorkspaceRender{lines: lines}
 	}
 
 	visible := m.visibleDebugNodes()
 	if len(visible) == 0 {
-		lines = append(lines, "No AI API calls recorded yet for this role.")
+		if len(m.state.History.RecentRounds) == 0 && m.debugLog == nil {
+			lines = append(lines, "No debug data is available yet.")
+		} else {
+			lines = append(lines, "No round inspection or AI trace entries are available yet for this role.")
+		}
 		return debugWorkspaceRender{lines: lines}
 	}
 
@@ -407,6 +473,131 @@ func wrapIndentedBlock(text string, width int, continuation string) []string {
 		}
 	}
 	return lines
+}
+
+func debugActionInspectionBody(round domain.RoundRecord, roleID domain.RoleID) string {
+	var selected *domain.ActionSubmission
+	for i := range round.Actions {
+		if round.Actions[i].RoleID == roleID {
+			clone := round.Actions[i].Clone()
+			selected = &clone
+			break
+		}
+	}
+	if selected == nil {
+		return fmt.Sprintf("No submitted action for %s was recorded in round %d.", displayRoleName(roleID), round.Round)
+	}
+
+	lines := []string{
+		fmt.Sprintf("Role: %s", displayRoleName(selected.RoleID)),
+		fmt.Sprintf("Action ID: %s", selected.ActionID),
+	}
+	if !selected.SubmittedAt.IsZero() {
+		lines = append(lines, "Submitted at: "+selected.SubmittedAt.UTC().Format(time.RFC3339))
+	}
+	lines = append(lines, "Action summary:")
+	for _, summary := range summarizeAction(selected.Action) {
+		lines = append(lines, "  - "+summary)
+	}
+	if strings.TrimSpace(selected.Commentary.Body) != "" {
+		lines = append(lines, "Commentary: "+selected.Commentary.Body)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) debugStateDiffBody(round domain.RoundNumber, metrics domain.PlantMetrics) string {
+	before, after, ok := m.roundStatePair(round)
+	if !ok {
+		return "State diff unavailable. This inspector needs round snapshots from the current live session or persisted replay store."
+	}
+
+	type diffLine struct {
+		label string
+		from  int
+		to    int
+	}
+	diffs := []diffLine{
+		{label: "Cash", from: int(before.Plant.Cash), to: int(after.Plant.Cash)},
+		{label: "Debt", from: int(before.Plant.Debt), to: int(after.Plant.Debt)},
+		{label: "Backlog lines", from: len(before.Plant.Backlog), to: len(after.Plant.Backlog)},
+		{label: "Parts on hand units", from: int(before.Metrics.PartsOnHandUnits), to: int(after.Metrics.PartsOnHandUnits)},
+		{label: "Finished goods units", from: int(before.Metrics.FinishedGoodsUnits), to: int(after.Metrics.FinishedGoodsUnits)},
+		{label: "Inspection hold units", from: int(before.Metrics.InspectionHoldUnits), to: int(after.Metrics.InspectionHoldUnits)},
+		{label: "Receivables open", from: len(before.Plant.Receivables), to: len(after.Plant.Receivables)},
+		{label: "Payables open", from: len(before.Plant.Payables), to: len(after.Plant.Payables)},
+	}
+
+	lines := []string{
+		fmt.Sprintf("State transition: round %d -> %d", before.CurrentRound, after.CurrentRound),
+		fmt.Sprintf("Round profit: %d", metrics.RoundProfit),
+		fmt.Sprintf("Net cash change: %d", metrics.NetCashChange),
+	}
+	changed := 0
+	for _, diff := range diffs {
+		if diff.from == diff.to {
+			continue
+		}
+		changed++
+		lines = append(lines, fmt.Sprintf("%s: %d -> %d (%+d)", diff.label, diff.from, diff.to, diff.to-diff.from))
+	}
+	if changed == 0 {
+		lines = append(lines, "No tracked aggregate counters changed across the stored snapshots.")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func debugTimelineBody(round domain.RoundRecord) string {
+	timeline := round.CanonicalTimeline()
+	if len(timeline) == 0 {
+		return "No timeline entries were recorded for this round."
+	}
+
+	lines := make([]string, 0, min(len(timeline), 8)+1)
+	lines = append(lines, fmt.Sprintf("Showing %d of %d timeline entries.", min(len(timeline), 8), len(timeline)))
+	for _, entry := range timeline[:min(len(timeline), 8)] {
+		switch entry.Kind {
+		case domain.RoundTimelineKindCommentary:
+			if entry.Commentary != nil {
+				lines = append(lines, fmt.Sprintf("%s #%d: %s said %q", timelinePhaseLabel(entry.Phase), entry.Sequence, displayRoleName(entry.Commentary.RoleID), entry.Commentary.Body))
+			}
+		case domain.RoundTimelineKindEvent:
+			if entry.Event != nil {
+				lines = append(lines, fmt.Sprintf("%s #%d: %s", timelinePhaseLabel(entry.Phase), entry.Sequence, entry.Event.Summary))
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (m Model) roundStatePair(round domain.RoundNumber) (domain.MatchState, domain.MatchState, bool) {
+	snapshots := m.stateSnapshots()
+	if len(snapshots) == 0 {
+		return domain.MatchState{}, domain.MatchState{}, false
+	}
+
+	var before domain.MatchState
+	var after domain.MatchState
+	foundBefore := false
+	foundAfter := false
+	for _, snapshot := range snapshots {
+		switch snapshot.CurrentRound {
+		case round:
+			before = snapshot.Clone()
+			foundBefore = true
+		case round + 1:
+			after = snapshot.Clone()
+			foundAfter = true
+		}
+	}
+	return before, after, foundBefore && foundAfter
+}
+
+func (m Model) stateSnapshots() []domain.MatchState {
+	source, ok := m.source.(StateSnapshotSource)
+	if !ok {
+		return nil
+	}
+	return source.StateSnapshots()
 }
 
 func debugAttemptOutcome(record ports.AICallRecord) string {
@@ -479,6 +670,22 @@ func debugResponseDetails(record ports.AICallRecord) string {
 
 func sanitizeDebugText(text string) string {
 	return strings.ReplaceAll(text, "\t", " ")
+}
+
+func debugInspectionRoundNodeID(round domain.RoundNumber) string {
+	return fmt.Sprintf("debug:inspection:round:%06d", round)
+}
+
+func debugInspectionActionNodeID(round domain.RoundNumber) string {
+	return debugInspectionRoundNodeID(round) + ":action"
+}
+
+func debugInspectionStateNodeID(round domain.RoundNumber) string {
+	return debugInspectionRoundNodeID(round) + ":state"
+}
+
+func debugInspectionTimelineNodeID(round domain.RoundNumber) string {
+	return debugInspectionRoundNodeID(round) + ":timeline"
 }
 
 func debugRoundNodeID(round domain.RoundNumber) string {

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -937,7 +937,7 @@ func (mode workspaceMode) label() string {
 	case workspaceHistoryArchive:
 		return "history archive"
 	case workspaceDebug:
-		return "debug (AI API calls)"
+		return "debug inspector"
 	default:
 		return "round feed"
 	}
@@ -988,7 +988,7 @@ func workspaceInteractionHint(active workspaceMode) string {
 	case workspaceHistoryArchive:
 		return "up/down/pgup/pgdn/home/end scroll archive history"
 	case workspaceDebug:
-		return "up/down move, enter expand, esc collapse, pgup/pgdn/home/end jump through debug tree"
+		return "up/down move, enter expand, esc collapse, pgup/pgdn/home/end jump through inspector tree"
 	default:
 		return "up/down/pgup/pgdn/home/end scroll round feed history"
 	}

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -17,8 +17,9 @@ import (
 )
 
 type testStateSource struct {
-	snapshot domain.MatchState
-	updates  <-chan domain.MatchState
+	snapshot  domain.MatchState
+	snapshots []domain.MatchState
+	updates   <-chan domain.MatchState
 }
 
 func (s testStateSource) Snapshot() domain.MatchState {
@@ -27,6 +28,18 @@ func (s testStateSource) Snapshot() domain.MatchState {
 
 func (s testStateSource) Updates() <-chan domain.MatchState {
 	return s.updates
+}
+
+func (s testStateSource) StateSnapshots() []domain.MatchState {
+	snapshots := s.snapshots
+	if len(snapshots) == 0 {
+		snapshots = []domain.MatchState{s.snapshot}
+	}
+	cloned := make([]domain.MatchState, len(snapshots))
+	for i := range snapshots {
+		cloned[i] = snapshots[i].Clone()
+	}
+	return cloned
 }
 
 type testDebugSource struct {
@@ -1015,7 +1028,9 @@ func TestModelDebugWorkspaceFiltersRecordsBySelectedRole(t *testing.T) {
 
 	view := shell.View()
 	for _, want := range []string{
-		"Debug tree for Procurement Manager",
+		"Debug inspector for Procurement Manager",
+		"Prompt/response traces for Procurement Manager (1",
+		"total)",
 		"Round 1 (1 tries)",
 		"Try 1 - Success",
 	} {
@@ -1041,7 +1056,7 @@ func TestModelDebugWorkspaceFiltersRecordsBySelectedRole(t *testing.T) {
 	salesShell.debugExpanded[debugRoundNodeID(2)] = true
 
 	salesView := salesShell.View()
-	if !strings.Contains(salesView, "Debug tree for Sales Manager") || !strings.Contains(salesView, "Round 2 (1 tries)") {
+	if !strings.Contains(salesView, "Debug inspector for Sales Manager") || !strings.Contains(salesView, "Round 2 (1 tries)") {
 		t.Fatalf("sales debug view did not follow role selection\n%s", salesView)
 	}
 	if strings.Contains(salesView, "Procurement system prompt") {
@@ -1075,14 +1090,20 @@ func TestModelDebugTreeNavigationExpandsAndCollapses(t *testing.T) {
 	shell.height = 30
 	shell.ensureDebugSelection()
 
-	if got := shell.debugSelected; got != debugRoundNodeID(1) {
-		t.Fatalf("initial debugSelected = %q, want round node", got)
+	if got := shell.debugSelected; got != "debug:traces" {
+		t.Fatalf("initial debugSelected = %q, want root trace node", got)
 	}
 
 	next, _ := shell.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	shell = next.(Model)
+	if shell.debugSelected != debugRoundNodeID(1) {
+		t.Fatalf("enter on trace root did not select round child: selected=%q", shell.debugSelected)
+	}
+
+	next, _ = shell.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	shell = next.(Model)
 	if !shell.debugExpanded[debugRoundNodeID(1)] || shell.debugSelected != debugAttemptNodeID(1, 1) {
-		t.Fatalf("enter on round did not expand/select first child: expanded=%v selected=%q", shell.debugExpanded[debugRoundNodeID(1)], shell.debugSelected)
+		t.Fatalf("enter on round did not expand/select first attempt: expanded=%v selected=%q", shell.debugExpanded[debugRoundNodeID(1)], shell.debugSelected)
 	}
 
 	next, _ = shell.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -1112,6 +1133,66 @@ func TestModelDebugTreeNavigationExpandsAndCollapses(t *testing.T) {
 	shell = next.(Model)
 	if shell.debugExpanded[debugRoundNodeID(1)] || shell.debugSelected != debugRoundNodeID(1) {
 		t.Fatalf("esc on attempt did not collapse to round: expanded=%v selected=%q", shell.debugExpanded[debugRoundNodeID(1)], shell.debugSelected)
+	}
+}
+
+func TestModelDebugInspectorShowsActionInspectionAndStateDiff(t *testing.T) {
+	before := scenario.Starter().InitialState("starter-match", starterAssignments())
+	after := before.Clone()
+	after.CurrentRound = 2
+	after.Plant.Cash = 31
+	after.Plant.Debt = 2
+	after.Plant.Backlog = after.Plant.Backlog[:1]
+	after.Metrics.RoundProfit = 7
+	after.Metrics.NetCashChange = 7
+	after.Metrics.PartsOnHandUnits = 3
+	after.Metrics.FinishedGoodsUnits = 1
+	round := domain.RoundRecord{
+		Round: 1,
+		Actions: []domain.ActionSubmission{
+			{
+				ActionID: "proc-1",
+				MatchID:  before.MatchID,
+				Round:    1,
+				RoleID:   domain.RoleProcurementManager,
+				Action: domain.RoleAction{
+					Procurement: &domain.ProcurementAction{
+						Orders: []domain.PurchaseOrderIntent{{PartID: "housing", SupplierID: "forgeco", Quantity: 2}},
+					},
+				},
+				Commentary: domain.CommentaryRecord{Body: "Buying only what assembly can absorb."},
+			},
+		},
+		Metrics: after.Metrics,
+	}
+	after.History.RecentRounds = []domain.RoundRecord{round}
+
+	model := NewModel(scenario.Starter(), testStateSource{
+		snapshot:  after,
+		snapshots: []domain.MatchState{before, after},
+	})
+	loaded, _ := model.Update(stateLoadedMsg{state: after})
+	shell := loaded.(Model)
+	shell.workspace = workspaceDebug
+	shell.width = 120
+	shell.height = 30
+	shell.debugExpanded["debug:inspection"] = true
+	shell.debugExpanded[debugInspectionRoundNodeID(1)] = true
+
+	view := shell.View()
+	for _, want := range []string{
+		"Round inspections (1 retained)",
+		"Action inspection for Procurement Manager",
+		"Order 2 of housing from forgeco",
+		"Commentary: Buying only what assembly can absorb.",
+		"State transition summary",
+		"Cash: 24 -> 31 (+7)",
+		"Debt: 0 -> 2 (+2)",
+		"Round profit: 7",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("debug inspector missing %q\n%s", want, view)
+		}
 	}
 }
 

--- a/internal/adapters/tui/run.go
+++ b/internal/adapters/tui/run.go
@@ -3,12 +3,21 @@ package tui
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
 	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
 // Run launches the main Bubble Tea shell for the current match snapshot.
 func Run(definition scenario.Definition, initial domain.MatchState) error {
 	return RunWithSource(definition, newStaticStateSource(initial), nil, tea.WithAltScreen())
+}
+
+// RunReplay launches the shell with persisted state snapshots and optional AI traces.
+func RunReplay(definition scenario.Definition, current domain.MatchState, snapshots []domain.MatchState, debugRecords []ports.AICallRecord) error {
+	source := newReplayStateSource(current, snapshots)
+	program := NewProgram(definition, source, nil, newStaticDebugSource(debugRecords), tea.WithAltScreen())
+	_, err := program.Run()
+	return err
 }
 
 // NewProgram constructs the Bubble Tea program for the supplied match source.

--- a/internal/adapters/tui/state_source.go
+++ b/internal/adapters/tui/state_source.go
@@ -11,17 +11,37 @@ type StateSource interface {
 	Updates() <-chan domain.MatchState
 }
 
+// StateSnapshotSource exposes canonical match-state checkpoints for replay inspection.
+type StateSnapshotSource interface {
+	StateSnapshots() []domain.MatchState
+}
+
 // DebugSource provides read access to recorded AI provider request/response exchanges.
 type DebugSource interface {
 	Records() []ports.AICallRecord
 }
 
 type staticStateSource struct {
-	state domain.MatchState
+	state     domain.MatchState
+	snapshots []domain.MatchState
 }
 
 func newStaticStateSource(state domain.MatchState) staticStateSource {
-	return staticStateSource{state: state.Clone()}
+	return newReplayStateSource(state, []domain.MatchState{state})
+}
+
+func newReplayStateSource(state domain.MatchState, snapshots []domain.MatchState) staticStateSource {
+	clonedSnapshots := make([]domain.MatchState, 0, len(snapshots))
+	for _, snapshot := range snapshots {
+		clonedSnapshots = append(clonedSnapshots, snapshot.Clone())
+	}
+	if len(clonedSnapshots) == 0 {
+		clonedSnapshots = append(clonedSnapshots, state.Clone())
+	}
+	return staticStateSource{
+		state:     state.Clone(),
+		snapshots: clonedSnapshots,
+	}
 }
 
 func (s staticStateSource) Snapshot() domain.MatchState {
@@ -30,4 +50,28 @@ func (s staticStateSource) Snapshot() domain.MatchState {
 
 func (staticStateSource) Updates() <-chan domain.MatchState {
 	return nil
+}
+
+func (s staticStateSource) StateSnapshots() []domain.MatchState {
+	cloned := make([]domain.MatchState, len(s.snapshots))
+	for i := range s.snapshots {
+		cloned[i] = s.snapshots[i].Clone()
+	}
+	return cloned
+}
+
+type staticDebugSource struct {
+	records []ports.AICallRecord
+}
+
+func newStaticDebugSource(records []ports.AICallRecord) staticDebugSource {
+	cloned := make([]ports.AICallRecord, len(records))
+	copy(cloned, records)
+	return staticDebugSource{records: cloned}
+}
+
+func (s staticDebugSource) Records() []ports.AICallRecord {
+	cloned := make([]ports.AICallRecord, len(s.records))
+	copy(cloned, s.records)
+	return cloned
 }


### PR DESCRIPTION
## Summary
- upgrade the TUI debug workspace into an inspector that shows round action inspection, state-transition summaries, and AI prompt/response traces together
- persist and expose canonical state snapshots alongside replay data so state diffs work in resumed SQLite-backed sessions
- seed live/static TUI sources with persisted snapshots and traces, and add coverage for the new replay inspection behavior

## Testing
- go test ./...
- staticcheck ./...
