### PR TITLE
Add scenario registry to runtime bootstrap

### DIFF
--- a/herbiego.yaml
+++ b/herbiego.yaml
@@ -1,4 +1,5 @@
 environment: local
+scenario_id: starter
 random:
   seed: 1
 human_players: 1

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
 	"gopkg.in/yaml.v3"
 )
 
@@ -17,6 +18,7 @@ const (
 	defaultEnvironment    = "local"
 	defaultRandomSeed     = uint64(1)
 	defaultAIRevealDelay  = 15
+	defaultScenarioID     = scenario.DefaultID
 )
 
 var preferredHumanRoleOrder = []domain.RoleID{
@@ -45,6 +47,7 @@ const (
 // Config holds process-level runtime configuration.
 type Config struct {
 	Environment  string                       `yaml:"environment"`
+	ScenarioID   domain.ScenarioID            `yaml:"scenario_id"`
 	MatchID      domain.MatchID               `yaml:"match_id"`
 	Random       RandomConfig                 `yaml:"random"`
 	HumanPlayers int                          `yaml:"human_players"`
@@ -189,6 +192,11 @@ func (c Config) ApplyOverrides(options BootstrapOptions) Config {
 
 // Validate checks that the configuration is internally consistent.
 func (c *Config) Validate() error {
+	return c.ValidateForRoles(domain.CanonicalRoles())
+}
+
+// ValidateForRoles checks that configuration is internally consistent for one role roster.
+func (c *Config) ValidateForRoles(expectedRoles []domain.RoleID) error {
 	c.normalize()
 
 	var errs []error
@@ -196,10 +204,12 @@ func (c *Config) Validate() error {
 	if strings.TrimSpace(c.Environment) == "" {
 		errs = append(errs, errors.New("environment must not be empty"))
 	}
+	if strings.TrimSpace(string(c.ScenarioID)) == "" {
+		errs = append(errs, errors.New("scenario_id must not be empty"))
+	}
 
-	expectedRoles := domain.CanonicalRoles()
 	if len(c.Roles) != len(expectedRoles) {
-		errs = append(errs, fmt.Errorf("roles must include exactly %d canonical roles", len(expectedRoles)))
+		errs = append(errs, fmt.Errorf("roles must include exactly %d expected roles", len(expectedRoles)))
 	}
 
 	if c.HumanPlayers < 0 || c.HumanPlayers > len(expectedRoles) {
@@ -235,6 +245,9 @@ func (c *Config) Validate() error {
 func (c *Config) normalize() {
 	if strings.TrimSpace(c.Environment) == "" {
 		c.Environment = defaultEnvironment
+	}
+	if strings.TrimSpace(string(c.ScenarioID)) == "" {
+		c.ScenarioID = defaultScenarioID
 	}
 
 	if c.Random.Seed == 0 {

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -56,6 +56,9 @@ models:
 	if cfg.Environment != "local" {
 		t.Fatalf("Environment = %q, want %q", cfg.Environment, "local")
 	}
+	if cfg.ScenarioID != "starter" {
+		t.Fatalf("ScenarioID = %q, want starter default", cfg.ScenarioID)
+	}
 
 	if cfg.Random.Seed != 7 {
 		t.Fatalf("Random.Seed = %d, want 7", cfg.Random.Seed)
@@ -180,7 +183,7 @@ roles:
 	message := err.Error()
 	for _, want := range []string{
 		"human_players must be between 0 and 4",
-		"roles must include exactly 4 canonical roles",
+		"roles must include exactly 4 expected roles",
 		"procurement_manager provider must not be empty",
 	} {
 		if !strings.Contains(message, want) {

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -42,19 +42,23 @@ func Bootstrap(options BootstrapOptions) (Runtime, error) {
 
 // NewRuntime validates runtime config and constructs startup dependencies.
 func NewRuntime(cfg Config) (Runtime, error) {
-	if err := cfg.Validate(); err != nil {
+	cfg.normalize()
+	selected, ok := scenario.Lookup(cfg.ScenarioID)
+	if !ok {
+		return Runtime{}, fmt.Errorf("resolve scenario %q: scenario is not registered", cfg.ScenarioID)
+	}
+	if err := cfg.ValidateForRoles(selected.Setup.RoleRoster); err != nil {
 		return Runtime{}, fmt.Errorf("validate runtime config: %w", err)
 	}
 
-	starter := scenario.Default()
-	initialMatch := starter.InitialState(runtimeMatchID(cfg, starter.ID), runtimeRoles(cfg))
+	initialMatch := selected.InitialState(runtimeMatchID(cfg, selected.ID), runtimeRoles(cfg, selected))
 	initialMatch.RoundFlow.AIRevealDelaySeconds = cfg.UI.AIRevealDelaySeconds
 
 	return Runtime{
 		Config:       cfg,
 		Logger:       newProcessLogger(),
 		Random:       seeded.New(cfg.Random.Seed),
-		Scenario:     starter,
+		Scenario:     selected,
 		InitialMatch: initialMatch,
 	}, nil
 }
@@ -75,7 +79,7 @@ func runtimeMatchID(cfg Config, scenarioID domain.ScenarioID) domain.MatchID {
 // RoleSummaries returns a stable summary of role runtime assignments.
 func (r Runtime) RoleSummaries() []string {
 	summaries := make([]string, 0, len(r.Config.Roles))
-	for _, roleID := range domain.CanonicalRoles() {
+	for _, roleID := range r.Scenario.Setup.RoleRoster {
 		roleCfg, ok := r.Config.Roles[roleID]
 		if !ok {
 			continue
@@ -93,9 +97,9 @@ func (r Runtime) RoleSummaries() []string {
 	return summaries
 }
 
-func runtimeRoles(cfg Config) []domain.RoleAssignment {
+func runtimeRoles(cfg Config, selected scenario.Definition) []domain.RoleAssignment {
 	roles := make([]domain.RoleAssignment, 0, len(cfg.Roles))
-	for _, roleID := range domain.CanonicalRoles() {
+	for _, roleID := range selected.Setup.RoleRoster {
 		roleCfg, ok := cfg.Roles[roleID]
 		if !ok {
 			continue

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -3,6 +3,9 @@ package app
 import (
 	"testing"
 	"time"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
 func TestNewRuntimeSeedsGeneratedStarterMatch(t *testing.T) {
@@ -16,6 +19,7 @@ func TestNewRuntimeSeedsGeneratedStarterMatch(t *testing.T) {
 
 	runtime, err := NewRuntime(Config{
 		Environment:  "test",
+		ScenarioID:   scenario.StarterID,
 		HumanPlayers: 1,
 		UI: UIConfig{
 			AIRevealDelaySeconds: 12,
@@ -81,6 +85,7 @@ func TestNewRuntimeSeedsGeneratedStarterMatch(t *testing.T) {
 func TestNewRuntimeUsesConfiguredMatchIDWhenProvided(t *testing.T) {
 	runtime, err := NewRuntime(Config{
 		Environment:  "test",
+		ScenarioID:   scenario.StarterID,
 		MatchID:      "fixture-match-42",
 		HumanPlayers: 1,
 		UI: UIConfig{
@@ -108,5 +113,104 @@ func TestNewRuntimeUsesConfiguredMatchIDWhenProvided(t *testing.T) {
 
 	if got := runtime.InitialMatch.MatchID; got != "fixture-match-42" {
 		t.Fatalf("InitialMatch.MatchID = %q, want configured match id", got)
+	}
+}
+
+func TestNewRuntimeUsesRegisteredScenarioFromConfig(t *testing.T) {
+	definition := scenario.NewDefinition(
+		"runtime-test-scenario",
+		"Runtime Test Scenario",
+		"Ensures runtime selection comes from the scenario registry.",
+		scenario.MatchSetup{
+			ID:          "single-role",
+			DisplayName: "Single Role",
+			RoleRoster:  []domain.RoleID{domain.RoleSalesManager},
+		},
+		scenario.StartingConditions{
+			ID:          "test-start",
+			DisplayName: "Test Start",
+			StartingTargets: domain.BudgetTargets{
+				EffectiveRound:        1,
+				RevenueTarget:         77,
+				DebtCeilingTarget:     5,
+				ProcurementBudget:     1,
+				ProductionSpendBudget: 1,
+				CashFloorTarget:       1,
+			},
+			StartingPlant: domain.PlantState{
+				Cash:        99,
+				DebtCeiling: 5,
+			},
+			Customers: []scenario.CustomerSeed{
+				{ID: "runtime-test-customer", DisplayName: "Runtime Test Customer", Sentiment: 5, PaymentDelayRounds: 1},
+			},
+		},
+		scenario.MarketModel{
+			ID:          "test-market",
+			DisplayName: "Test Market",
+			Customers: []scenario.CustomerMarket{
+				{
+					ID:          "runtime-test-customer",
+					DisplayName: "Runtime Test Customer",
+					DemandByProduct: map[domain.ProductID]scenario.DemandProfile{
+						"runtime-test-product": {ReferencePrice: 10, BaseDemand: 1, PriceSensitivity: 1},
+					},
+				},
+			},
+			DemandAssumptions: scenario.DemandAssumptions{BacklogExpiryRounds: 1},
+		},
+		scenario.ProductionModel{
+			ID:          "test-production",
+			DisplayName: "Test Production",
+			Products: []scenario.Product{
+				{ID: "runtime-test-product", DisplayName: "Runtime Test Product", BaseUnitCost: 4},
+			},
+		},
+		scenario.FinanceModel{
+			ID:                    "test-finance",
+			DisplayName:           "Test Finance",
+			ReceivableDelayRounds: 1,
+			PayableDelayRounds:    1,
+			PayrollDelayRounds:    1,
+		},
+	)
+	if err := scenario.Register(definition); err != nil && err.Error() != `scenario "runtime-test-scenario" already registered` {
+		t.Fatalf("scenario.Register() error = %v", err)
+	}
+
+	runtime, err := NewRuntime(Config{
+		Environment:  "test",
+		ScenarioID:   definition.ID,
+		HumanPlayers: 0,
+		UI: UIConfig{
+			AIRevealDelaySeconds: 12,
+		},
+		Random: RandomConfig{
+			Seed: 9,
+		},
+		LLMCatalog: LLMCatalog{
+			Entries: []LLMCatalogEntry{
+				{Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: APISDKTypeOpenAI},
+			},
+		},
+		RoleConfigs: []RoleConfigFile{
+			{RoleID: domain.RoleSalesManager, Provider: "openrouter"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime() error = %v", err)
+	}
+
+	if got := runtime.Scenario.ID; got != definition.ID {
+		t.Fatalf("Scenario.ID = %q, want %q", got, definition.ID)
+	}
+	if got := runtime.InitialMatch.ScenarioID; got != definition.ID {
+		t.Fatalf("InitialMatch.ScenarioID = %q, want %q", got, definition.ID)
+	}
+	if got := len(runtime.InitialMatch.Roles); got != 1 {
+		t.Fatalf("InitialMatch.Roles len = %d, want 1", got)
+	}
+	if got := runtime.InitialMatch.Plant.Cash; got != 99 {
+		t.Fatalf("InitialMatch.Plant.Cash = %d, want 99", got)
 	}
 }

--- a/internal/scenario/registry.go
+++ b/internal/scenario/registry.go
@@ -1,0 +1,61 @@
+package scenario
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+)
+
+const DefaultID = StarterID
+
+var registry = map[domain.ScenarioID]Definition{}
+
+// Register adds a scenario definition to the process registry.
+func Register(definition Definition) error {
+	if definition.ID == "" {
+		return fmt.Errorf("scenario id must not be empty")
+	}
+	if _, exists := registry[definition.ID]; exists {
+		return fmt.Errorf("scenario %q already registered", definition.ID)
+	}
+	registry[definition.ID] = definition
+	return nil
+}
+
+// MustRegister adds a scenario definition to the process registry and panics on error.
+func MustRegister(definition Definition) {
+	if err := Register(definition); err != nil {
+		panic(err)
+	}
+}
+
+// Lookup resolves one scenario definition from the registry.
+func Lookup(id domain.ScenarioID) (Definition, bool) {
+	definition, ok := registry[id]
+	return definition, ok
+}
+
+// Default returns the configured default scenario definition.
+func Default() Definition {
+	return MustLookup(DefaultID)
+}
+
+// MustLookup resolves one scenario definition from the registry and panics when missing.
+func MustLookup(id domain.ScenarioID) Definition {
+	definition, ok := Lookup(id)
+	if !ok {
+		panic(fmt.Sprintf("scenario %q is not registered", id))
+	}
+	return definition
+}
+
+// RegisteredIDs returns the known scenario ids in stable order.
+func RegisteredIDs() []domain.ScenarioID {
+	ids := make([]domain.ScenarioID, 0, len(registry))
+	for id := range registry {
+		ids = append(ids, id)
+	}
+	slices.Sort(ids)
+	return ids
+}

--- a/internal/scenario/registry_test.go
+++ b/internal/scenario/registry_test.go
@@ -1,0 +1,23 @@
+package scenario
+
+import "testing"
+
+func TestDefaultScenarioIsRegistered(t *testing.T) {
+	definition, ok := Lookup(DefaultID)
+	if !ok {
+		t.Fatalf("Lookup(%q) = false, want registered default scenario", DefaultID)
+	}
+	if got := definition.ID; got != StarterID {
+		t.Fatalf("definition.ID = %q, want %q", got, StarterID)
+	}
+}
+
+func TestRegisteredIDsIncludesStarter(t *testing.T) {
+	ids := RegisteredIDs()
+	if len(ids) == 0 {
+		t.Fatal("RegisteredIDs() = empty, want at least starter")
+	}
+	if ids[0] != StarterID {
+		t.Fatalf("RegisteredIDs()[0] = %q, want %q", ids[0], StarterID)
+	}
+}

--- a/internal/scenario/starter.go
+++ b/internal/scenario/starter.go
@@ -7,8 +7,8 @@ const (
 	StarterID domain.ScenarioID = "starter"
 )
 
-func Default() Definition {
-	return Starter()
+func init() {
+	MustRegister(Starter())
 }
 
 func Starter() Definition {


### PR DESCRIPTION
## Summary
- add a scenario registry in the scenario package and register the starter scenario through that path
- add `scenario_id` to runtime config and have `NewRuntime` resolve scenarios from the registry instead of hardwiring `scenario.Default()`
- validate runtime roles against the selected scenario roster and add coverage proving custom registered scenarios can bootstrap successfully

## Testing
- go test ./...
- staticcheck ./...
