### PR TITLE
Move role roster validation into runtime

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -190,13 +190,8 @@ func (c Config) ApplyOverrides(options BootstrapOptions) Config {
 	return c
 }
 
-// Validate checks that the configuration is internally consistent.
+// Validate checks that the configuration is internally consistent without assuming a scenario roster.
 func (c *Config) Validate() error {
-	return c.ValidateForRoles(domain.CanonicalRoles())
-}
-
-// ValidateForRoles checks that configuration is internally consistent for one role roster.
-func (c *Config) ValidateForRoles(expectedRoles []domain.RoleID) error {
 	c.normalize()
 
 	var errs []error
@@ -208,12 +203,8 @@ func (c *Config) ValidateForRoles(expectedRoles []domain.RoleID) error {
 		errs = append(errs, errors.New("scenario_id must not be empty"))
 	}
 
-	if len(c.Roles) != len(expectedRoles) {
-		errs = append(errs, fmt.Errorf("roles must include exactly %d expected roles", len(expectedRoles)))
-	}
-
-	if c.HumanPlayers < 0 || c.HumanPlayers > len(expectedRoles) {
-		errs = append(errs, fmt.Errorf("human_players must be between 0 and %d", len(expectedRoles)))
+	if c.HumanPlayers < 0 {
+		errs = append(errs, errors.New("human_players must be greater than or equal to 0"))
 	}
 	if c.UI.AIRevealDelaySeconds <= 0 {
 		errs = append(errs, errors.New("ui.ai_reveal_delay_seconds must be greater than 0"))
@@ -223,13 +214,7 @@ func (c *Config) ValidateForRoles(expectedRoles []domain.RoleID) error {
 		errs = append(errs, fmt.Errorf("llm catalog: %w", err))
 	}
 
-	for _, roleID := range expectedRoles {
-		roleCfg, ok := c.Roles[roleID]
-		if !ok {
-			errs = append(errs, fmt.Errorf("role configuration missing for %s", roleID))
-			continue
-		}
-
+	for roleID, roleCfg := range c.Roles {
 		if err := validateRoleConfig(roleID, roleCfg, len(c.LLMCatalog.Entries) > 0); err != nil {
 			errs = append(errs, err)
 		}

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -182,13 +182,31 @@ roles:
 
 	message := err.Error()
 	for _, want := range []string{
-		"human_players must be between 0 and 4",
-		"roles must include exactly 4 expected roles",
 		"procurement_manager provider must not be empty",
 	} {
 		if !strings.Contains(message, want) {
 			t.Fatalf("error %q does not contain %q", message, want)
 		}
+	}
+}
+
+func TestLoadConfigAllowsPartialRoleSetsBeforeScenarioRuntimeValidation(t *testing.T) {
+	configPath := writeConfigFile(t, `
+human_players: 3
+roles:
+  - role_id: sales_manager
+    provider: openrouter
+`)
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if got := len(cfg.Roles); got != 1 {
+		t.Fatalf("len(cfg.Roles) = %d, want 1", got)
+	}
+	if got := cfg.HumanPlayers; got != 3 {
+		t.Fatalf("HumanPlayers = %d, want 3", got)
 	}
 }
 

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -47,7 +48,10 @@ func NewRuntime(cfg Config) (Runtime, error) {
 	if !ok {
 		return Runtime{}, fmt.Errorf("resolve scenario %q: scenario is not registered", cfg.ScenarioID)
 	}
-	if err := cfg.ValidateForRoles(selected.Setup.RoleRoster); err != nil {
+	if err := cfg.Validate(); err != nil {
+		return Runtime{}, fmt.Errorf("validate runtime config: %w", err)
+	}
+	if err := validateRuntimeRoles(cfg, selected.Setup.RoleRoster); err != nil {
 		return Runtime{}, fmt.Errorf("validate runtime config: %w", err)
 	}
 
@@ -61,6 +65,34 @@ func NewRuntime(cfg Config) (Runtime, error) {
 		Scenario:     selected,
 		InitialMatch: initialMatch,
 	}, nil
+}
+
+func validateRuntimeRoles(cfg Config, expectedRoles []domain.RoleID) error {
+	var errs []error
+
+	if len(cfg.Roles) != len(expectedRoles) {
+		errs = append(errs, fmt.Errorf("roles must include exactly %d expected roles", len(expectedRoles)))
+	}
+	if cfg.HumanPlayers > len(expectedRoles) {
+		errs = append(errs, fmt.Errorf("human_players must be between 0 and %d", len(expectedRoles)))
+	}
+
+	for _, roleID := range expectedRoles {
+		if _, ok := cfg.Roles[roleID]; !ok {
+			errs = append(errs, fmt.Errorf("role configuration missing for %s", roleID))
+		}
+	}
+
+	for roleID := range cfg.Roles {
+		if !slices.Contains(expectedRoles, roleID) {
+			errs = append(errs, fmt.Errorf("role configuration %s is not part of scenario %s", roleID, cfg.ScenarioID))
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+	return errors.Join(errs...)
 }
 
 func runtimeMatchID(cfg Config, scenarioID domain.ScenarioID) domain.MatchID {

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -212,5 +213,40 @@ func TestNewRuntimeUsesRegisteredScenarioFromConfig(t *testing.T) {
 	}
 	if got := runtime.InitialMatch.Plant.Cash; got != 99 {
 		t.Fatalf("InitialMatch.Plant.Cash = %d, want 99", got)
+	}
+}
+
+func TestNewRuntimeRejectsConfigThatDoesNotMatchScenarioRoleRoster(t *testing.T) {
+	_, err := NewRuntime(Config{
+		Environment:  "test",
+		ScenarioID:   scenario.StarterID,
+		HumanPlayers: 0,
+		UI: UIConfig{
+			AIRevealDelaySeconds: 12,
+		},
+		Random: RandomConfig{
+			Seed: 9,
+		},
+		LLMCatalog: LLMCatalog{
+			Entries: []LLMCatalogEntry{
+				{Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: APISDKTypeOpenAI},
+			},
+		},
+		RoleConfigs: []RoleConfigFile{
+			{RoleID: domain.RoleSalesManager, Provider: "openrouter"},
+		},
+	})
+	if err == nil {
+		t.Fatal("NewRuntime() error = nil, want scenario role-roster validation")
+	}
+	for _, want := range []string{
+		"roles must include exactly 4 expected roles",
+		"role configuration missing for procurement_manager",
+		"role configuration missing for production_manager",
+		"role configuration missing for finance_controller",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("NewRuntime() error = %v, want substring %q", err, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- make `app.Config.Validate()` scenario-agnostic by removing canonical role-roster completeness checks from config loading
- validate role roster completeness and mismatches in `NewRuntime`, where the selected scenario roster is available
- add tests showing partial config files can load while runtime still rejects configs that do not match the selected scenario

## Testing
- go test ./...
- staticcheck ./...
