### PR TITLE
Resolve live match scenario from match state

### DIFF
--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/engine"
 	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
 func main() {
@@ -59,6 +60,11 @@ func main() {
 }
 
 func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState domain.MatchState, store persistentStore, rounds int, persistAIDebug bool) error {
+	definition, err := resolveScenarioForMatch(initialState)
+	if err != nil {
+		return err
+	}
+
 	stateSnapshots := []domain.MatchState{initialState.Clone()}
 	if store != nil {
 		persistedSnapshots, err := store.StateSnapshots(initialState.MatchID)
@@ -68,7 +74,7 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 		stateSnapshots = persistedSnapshots
 	}
 	controller := newLiveGameplayController(initialState, stateSnapshots)
-	players, debugLog, err := buildPlayersWithHumanSubmit(runtime, initialState, controller.SubmitRound)
+	players, debugLog, err := buildPlayersWithHumanSubmit(runtime.Config, definition, initialState, controller.SubmitRound, runtime.Logger)
 	if err != nil {
 		return fmt.Errorf("player setup: %w", err)
 	}
@@ -89,7 +95,7 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 
 	runner := app.MatchRunner{
 		Collector: app.RoundCollector{Players: players, Logger: runtime.Logger},
-		Resolver:  engine.NewResolver(runtime.Scenario.ResolverOptions()),
+		Resolver:  engine.NewResolver(definition.ResolverOptions()),
 		Random:    runtime.Random,
 		Store:     store,
 		OnState:   controller.Publish,
@@ -100,7 +106,7 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 	defer cancel()
 
 	program := tui.NewProgram(
-		runtime.Scenario,
+		definition,
 		controller,
 		controller.Submit,
 		debugSource,
@@ -145,6 +151,14 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 		return playErr
 	}
 	return nil
+}
+
+func resolveScenarioForMatch(state domain.MatchState) (scenario.Definition, error) {
+	definition, ok := scenario.Lookup(state.ScenarioID)
+	if !ok {
+		return scenario.Definition{}, fmt.Errorf("resolve scenario %q for match %q: scenario is not registered", state.ScenarioID, state.MatchID)
+	}
+	return definition, nil
 }
 
 type combinedDebugSource struct {

--- a/cmd/herbiego/main_test.go
+++ b/cmd/herbiego/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/player/human"
@@ -34,9 +35,9 @@ func TestBuildPlayersCreatesMixedHumanAndAIPlayers(t *testing.T) {
 		},
 	}
 
-	players, _, err := buildPlayersWithHumanSubmit(runtime, runtime.InitialMatch, func(context.Context, ports.RoundRequest) (domain.ActionSubmission, error) {
+	players, _, err := buildPlayersWithHumanSubmit(runtime.Config, runtime.Scenario, runtime.InitialMatch, func(context.Context, ports.RoundRequest) (domain.ActionSubmission, error) {
 		return domain.ActionSubmission{}, nil
-	})
+	}, runtime.Logger)
 	if err != nil {
 		t.Fatalf("buildPlayersWithHumanSubmit() error = %v, want nil", err)
 	}
@@ -64,13 +65,81 @@ func TestBuildPlayersRejectsUnsupportedAIProvider(t *testing.T) {
 		},
 	}
 
-	players, _, err := buildPlayersWithHumanSubmit(runtime, runtime.InitialMatch, func(context.Context, ports.RoundRequest) (domain.ActionSubmission, error) {
+	players, _, err := buildPlayersWithHumanSubmit(runtime.Config, runtime.Scenario, runtime.InitialMatch, func(context.Context, ports.RoundRequest) (domain.ActionSubmission, error) {
 		return domain.ActionSubmission{}, nil
-	})
+	}, runtime.Logger)
 	if err != nil {
 		t.Fatalf("buildPlayersWithHumanSubmit() error = %v, want nil", err)
 	}
 	if _, ok := players[domain.RoleProductionManager].(*llm.Player); !ok {
 		t.Fatalf("production player type = %T, want *llm.Player", players[domain.RoleProductionManager])
+	}
+}
+
+func TestResolveScenarioForMatchUsesMatchScenarioID(t *testing.T) {
+	definition := scenario.NewDefinition(
+		"cmd-runtime-test-scenario",
+		"Command Runtime Test Scenario",
+		"Ensures match execution resolves the scenario from the match record.",
+		scenario.MatchSetup{
+			ID:          "single-role",
+			DisplayName: "Single Role",
+			RoleRoster:  []domain.RoleID{domain.RoleSalesManager},
+		},
+		scenario.StartingConditions{
+			ID:          "start",
+			DisplayName: "Start",
+			StartingTargets: domain.BudgetTargets{
+				EffectiveRound:        1,
+				RevenueTarget:         20,
+				ProcurementBudget:     1,
+				ProductionSpendBudget: 1,
+				CashFloorTarget:       1,
+				DebtCeilingTarget:     1,
+			},
+		},
+		scenario.MarketModel{
+			ID:                "market",
+			DisplayName:       "Market",
+			DemandAssumptions: scenario.DemandAssumptions{BacklogExpiryRounds: 1},
+		},
+		scenario.ProductionModel{
+			ID:          "production",
+			DisplayName: "Production",
+		},
+		scenario.FinanceModel{
+			ID:                    "finance",
+			DisplayName:           "Finance",
+			ReceivableDelayRounds: 1,
+			PayableDelayRounds:    1,
+			PayrollDelayRounds:    1,
+		},
+	)
+	if err := scenario.Register(definition); err != nil && err.Error() != `scenario "cmd-runtime-test-scenario" already registered` {
+		t.Fatalf("scenario.Register() error = %v", err)
+	}
+
+	resolved, err := resolveScenarioForMatch(domain.MatchState{
+		MatchID:    "match-1",
+		ScenarioID: definition.ID,
+	})
+	if err != nil {
+		t.Fatalf("resolveScenarioForMatch() error = %v", err)
+	}
+	if got := resolved.ID; got != definition.ID {
+		t.Fatalf("resolved.ID = %q, want %q", got, definition.ID)
+	}
+}
+
+func TestResolveScenarioForMatchRejectsUnknownScenario(t *testing.T) {
+	_, err := resolveScenarioForMatch(domain.MatchState{
+		MatchID:    "match-404",
+		ScenarioID: "missing-scenario",
+	})
+	if err == nil {
+		t.Fatal("resolveScenarioForMatch() error = nil, want unknown-scenario validation")
+	}
+	if !strings.Contains(err.Error(), `resolve scenario "missing-scenario"`) {
+		t.Fatalf("resolveScenarioForMatch() error = %v, want missing-scenario context", err)
 	}
 }

--- a/cmd/herbiego/players.go
+++ b/cmd/herbiego/players.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/ai"
 	"github.com/jpconstantineau/herbiego/internal/adapters/ai/openai"
@@ -10,18 +11,19 @@ import (
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/ports"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
-func buildPlayersWithHumanSubmit(runtime app.Runtime, initial domain.MatchState, submit human.SubmitFunc) (map[domain.RoleID]ports.Player, *app.DebugLog, error) {
-	providers, err := buildDecisionClients(runtime.Config)
+func buildPlayersWithHumanSubmit(cfg app.Config, definition scenario.Definition, initial domain.MatchState, submit human.SubmitFunc, logger *slog.Logger) (map[domain.RoleID]ports.Player, *app.DebugLog, error) {
+	providers, err := buildDecisionClients(cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 	decisionClient := ai.NewRoutingClient(providers)
 	debugLog := app.NewDebugLog(0)
-	orchestrator := app.NewAIOrchestrator(runtime.Scenario, decisionClient)
+	orchestrator := app.NewAIOrchestrator(definition, decisionClient)
 	orchestrator.DebugLog = debugLog
-	orchestrator.Logger = runtime.Logger
+	orchestrator.Logger = logger
 
 	players := make(map[domain.RoleID]ports.Player, len(initial.Roles))
 	for _, assignment := range initial.Roles {


### PR DESCRIPTION
## Summary
- resolve the active scenario for live gameplay from `initialState.ScenarioID` instead of using `runtime.Scenario` as the execution source of truth
- thread the match-scoped scenario into player setup, resolver construction, and TUI startup
- add regression tests covering match-scenario lookup and unknown-scenario failures in the CLI runtime path

## Testing
- go test ./...
- staticcheck ./...
