### PR TITLE
Remove hardcoded tool sections from prompts

### DIFF
--- a/internal/app/ai_orchestrator_test.go
+++ b/internal/app/ai_orchestrator_test.go
@@ -51,8 +51,13 @@ func TestAIOrchestratorBuildsPromptAndParsesValidDecision(t *testing.T) {
 	if !strings.Contains(client.requests[0].SystemPrompt, "# Role") || !strings.Contains(client.requests[0].SystemPrompt, "# Instructions") || !strings.Contains(client.requests[0].SystemPrompt, "# Tools") || !strings.Contains(client.requests[0].SystemPrompt, "# Response") {
 		t.Fatalf("SystemPrompt = %q, want structured prompt sections", client.requests[0].SystemPrompt)
 	}
-	if !strings.Contains(client.requests[0].SystemPrompt, "## Parts") || !strings.Contains(client.requests[0].SystemPrompt, "## Products") || !strings.Contains(client.requests[0].SystemPrompt, "## Vendors") || !strings.Contains(client.requests[0].SystemPrompt, "## Customers") {
-		t.Fatalf("SystemPrompt = %q, want grouped tool sections", client.requests[0].SystemPrompt)
+	if !strings.Contains(client.requests[0].SystemPrompt, "## Tool Catalog") {
+		t.Fatalf("SystemPrompt = %q, want generic tool catalog section", client.requests[0].SystemPrompt)
+	}
+	for _, unwanted := range []string{"## Parts", "## Products", "## Vendors", "## Customers"} {
+		if strings.Contains(client.requests[0].SystemPrompt, unwanted) {
+			t.Fatalf("SystemPrompt = %q, want no hardcoded tool section %q", client.requests[0].SystemPrompt, unwanted)
+		}
 	}
 	if !strings.Contains(client.requests[0].UserPrompt, "## Allowed Action Schema") {
 		t.Fatalf("UserPrompt = %q, want schema section", client.requests[0].UserPrompt)

--- a/internal/prompting/ai.go
+++ b/internal/prompting/ai.go
@@ -47,9 +47,7 @@ func BuildSystemPrompt(request ports.AIDecisionRequest) string {
 	lines = append(lines, "# Tools")
 	lines = append(lines, "You have the following tools available to you:")
 	lines = append(lines, "")
-	for _, section := range groupedToolSections(request.Tools) {
-		lines = append(lines, section...)
-	}
+	lines = append(lines, renderToolCatalog(request.Tools)...)
 	lines = append(lines, "# Response")
 	lines = append(lines, "")
 	lines = append(lines, "Once you have your decision, communicate it to the rest of the team in JSON format according to the example below.")
@@ -377,63 +375,26 @@ func roleDecisionScope(roleID domain.RoleID) string {
 	}
 }
 
-func groupedToolSections(tools []ports.LookupToolSpec) [][]string {
-	byCategory := map[string][]ports.LookupToolSpec{
-		"Parts":     nil,
-		"Products":  nil,
-		"Vendors":   nil,
-		"Customers": nil,
+func renderToolCatalog(tools []ports.LookupToolSpec) []string {
+	if len(tools) == 0 {
+		return []string{"No scenario lookup tools are available for this match.", ""}
 	}
 
+	lines := []string{"## Tool Catalog"}
 	for _, tool := range tools {
-		for _, category := range toolCategories(tool.Name) {
-			byCategory[category] = append(byCategory[category], tool)
-		}
-	}
-
-	order := []string{"Parts", "Products", "Vendors", "Customers"}
-	sections := make([][]string, 0, len(order))
-	for _, category := range order {
-		lines := []string{"## " + category}
-		toolsForCategory := byCategory[category]
-		if len(toolsForCategory) == 0 {
-			lines = append(lines, "No dedicated lookup tool is available in this category yet.")
-			lines = append(lines, "")
-			sections = append(sections, lines)
+		lines = append(lines, fmt.Sprintf("- `%s`: %s", tool.Name, tool.Description))
+		if len(tool.Arguments) == 0 {
 			continue
 		}
-
-		for _, tool := range toolsForCategory {
-			lines = append(lines, fmt.Sprintf("- `%s`: %s", tool.Name, tool.Description))
-			if len(tool.Arguments) > 0 {
-				lines = append(lines, "  Arguments:")
-				for _, argument := range tool.Arguments {
-					required := "optional"
-					if argument.Required {
-						required = "required"
-					}
-					lines = append(lines, fmt.Sprintf("  - %s (%s): %s", argument.Name, required, argument.Description))
-				}
+		lines = append(lines, "  Arguments:")
+		for _, argument := range tool.Arguments {
+			required := "optional"
+			if argument.Required {
+				required = "required"
 			}
+			lines = append(lines, fmt.Sprintf("  - %s (%s): %s", argument.Name, required, argument.Description))
 		}
-		lines = append(lines, "")
-		sections = append(sections, lines)
 	}
-
-	return sections
-}
-
-func toolCategories(toolName string) []string {
-	switch toolName {
-	case "show_product_bom":
-		return []string{"Parts", "Products"}
-	case "show_product_route":
-		return []string{"Products"}
-	case "list_valid_suppliers":
-		return []string{"Parts", "Vendors"}
-	case "show_customer_demand_profile":
-		return []string{"Customers"}
-	default:
-		return []string{"Parts"}
-	}
+	lines = append(lines, "")
+	return lines
 }

--- a/internal/prompting/ai_test.go
+++ b/internal/prompting/ai_test.go
@@ -40,6 +40,14 @@ func TestBuildSystemPromptUsesRoundViewEntitiesInExamples(t *testing.T) {
 	if strings.Contains(sales, `"product_id": "pump"`) {
 		t.Fatalf("sales prompt = %q, want no starter sales ids", sales)
 	}
+	if !strings.Contains(sales, "## Tool Catalog") {
+		t.Fatalf("sales prompt = %q, want generic tool catalog section", sales)
+	}
+	for _, unwanted := range []string{"## Parts", "## Products", "## Vendors", "## Customers"} {
+		if strings.Contains(sales, unwanted) {
+			t.Fatalf("sales prompt = %q, want no hardcoded tool categories like %q", sales, unwanted)
+		}
+	}
 }
 
 func TestBuildUserPromptUsesRoundViewEntitiesInDecisionAndToolExamples(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace the hardcoded prompt tool categories and category switch with a generic tool catalog rendered from the tools actually provided on the request
- keep the scenario-derived action and tool-call examples introduced by `#202`, while removing starter-shaped template language from the remaining prompt structure
- update prompting and orchestrator tests to assert the generic catalog shape instead of starter-specific grouped sections

## Testing
- go test ./...
- staticcheck ./...
