### PR TITLE
Refactor TUI to depend on a scenario reader

### DIFF
--- a/internal/adapters/tui/action_entry.go
+++ b/internal/adapters/tui/action_entry.go
@@ -685,7 +685,7 @@ func parseNonNegativeInt(raw string) (int, error) {
 }
 
 func (m Model) validProduct(productID domain.ProductID) bool {
-	for _, product := range m.scenario.ProductionModel.Products {
+	for _, product := range m.scenario.Products() {
 		if product.ID == productID {
 			return true
 		}
@@ -694,7 +694,7 @@ func (m Model) validProduct(productID domain.ProductID) bool {
 }
 
 func (m Model) validWorkstation(workstationID domain.WorkstationID) bool {
-	for _, workstation := range m.scenario.ProductionModel.Workstations {
+	for _, workstation := range m.scenario.Workstations() {
 		if workstation.ID == workstationID {
 			return true
 		}
@@ -703,7 +703,7 @@ func (m Model) validWorkstation(workstationID domain.WorkstationID) bool {
 }
 
 func (m Model) supplierForPart(partID domain.PartID) (domain.SupplierID, bool) {
-	for _, part := range m.scenario.ProductionModel.Parts {
+	for _, part := range m.scenario.Parts() {
 		if part.ID == partID {
 			return part.SupplierID, true
 		}

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -10,7 +10,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/projection"
-	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
 const (
@@ -63,7 +62,7 @@ type SubmitFunc func(domain.ActionSubmission) error
 
 // Model is the Bubble Tea shell for the round-based gameplay UI.
 type Model struct {
-	scenario      scenario.Definition
+	scenario      ScenarioReader
 	source        StateSource
 	debugLog      DebugSource
 	updates       <-chan domain.MatchState
@@ -87,13 +86,13 @@ type Model struct {
 }
 
 // NewModel constructs the main gameplay shell model.
-func NewModel(definition scenario.Definition, source StateSource) Model {
+func NewModel(definition ScenarioReader, source StateSource) Model {
 	return NewModelWithSubmit(definition, source, nil)
 }
 
 // NewModelWithSubmit constructs the gameplay shell with an optional live
 // submission hook for forwarding locked human actions into the shared runner.
-func NewModelWithSubmit(definition scenario.Definition, source StateSource, submit SubmitFunc) Model {
+func NewModelWithSubmit(definition ScenarioReader, source StateSource, submit SubmitFunc) Model {
 	return Model{
 		scenario:      definition,
 		source:        source,
@@ -343,7 +342,7 @@ func (m Model) renderDepartmentsPane(width, height int) string {
 	report := m.selectedRoleReport()
 
 	lines := []string{
-		fmt.Sprintf("Scenario: %s", m.scenario.DisplayName),
+		fmt.Sprintf("Scenario: %s", m.scenario.ScenarioDisplayName()),
 		fmt.Sprintf("Match: %s", m.state.MatchID),
 		fmt.Sprintf("Mode: %s", modeLabel(m.focusedPane)),
 		"",

--- a/internal/adapters/tui/model_test.go
+++ b/internal/adapters/tui/model_test.go
@@ -16,6 +16,72 @@ import (
 	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
+type fakeScenarioReader struct {
+	name         string
+	parts        []scenario.Part
+	products     []scenario.Product
+	workstations []scenario.Workstation
+	demandRefs   []scenario.DemandProfileReference
+}
+
+func (f fakeScenarioReader) ScenarioDisplayName() string {
+	return f.name
+}
+
+func (f fakeScenarioReader) Parts() []scenario.Part {
+	return append([]scenario.Part(nil), f.parts...)
+}
+
+func (f fakeScenarioReader) Products() []scenario.Product {
+	return append([]scenario.Product(nil), f.products...)
+}
+
+func (f fakeScenarioReader) Workstations() []scenario.Workstation {
+	return append([]scenario.Workstation(nil), f.workstations...)
+}
+
+func (f fakeScenarioReader) DemandProfileReferences() []scenario.DemandProfileReference {
+	return append([]scenario.DemandProfileReference(nil), f.demandRefs...)
+}
+
+func (f fakeScenarioReader) ListValidSuppliers(partID domain.PartID) (scenario.ValidSuppliersLookup, error) {
+	return scenario.ValidSuppliersLookup{
+		PartID:      partID,
+		DisplayName: "Mock Part",
+		Suppliers:   []domain.SupplierID{"mock-supplier"},
+	}, nil
+}
+
+func (f fakeScenarioReader) ShowProductRoute(productID domain.ProductID) (scenario.ProductRouteLookup, error) {
+	return scenario.ProductRouteLookup{
+		ProductID:    productID,
+		DisplayName:  "Mock Product",
+		Route:        []domain.WorkstationID{"mock-station"},
+		BottleneckID: "mock-station",
+	}, nil
+}
+
+func (f fakeScenarioReader) ShowProductBOM(productID domain.ProductID) (scenario.ProductBOMLookup, error) {
+	return scenario.ProductBOMLookup{
+		ProductID:    productID,
+		DisplayName:  "Mock Product",
+		BOM:          []domain.BOMLine{{PartID: "mock-part", Quantity: 1}},
+		BaseUnitCost: 3,
+	}, nil
+}
+
+func (f fakeScenarioReader) ShowCustomerDemandProfile(customerID domain.CustomerID, productID domain.ProductID) (scenario.CustomerDemandProfileLookup, error) {
+	return scenario.CustomerDemandProfileLookup{
+		CustomerID:       customerID,
+		CustomerName:     "Mock Customer",
+		ProductID:        productID,
+		ProductName:      "Mock Product",
+		ReferencePrice:   9,
+		BaseDemand:       4,
+		PriceSensitivity: 1,
+	}, nil
+}
+
 type testStateSource struct {
 	snapshot  domain.MatchState
 	snapshots []domain.MatchState
@@ -106,6 +172,35 @@ func TestModelLoadsInitialSnapshotAndRendersShell(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("View() missing %q\n%s", want, view)
 		}
+	}
+}
+
+func TestModelRendersWithScenarioReaderInsteadOfConcreteDefinition(t *testing.T) {
+	initial := scenario.Starter().InitialState("starter-match", starterAssignments())
+	model := NewModel(fakeScenarioReader{
+		name: "Mock Scenario",
+		parts: []scenario.Part{
+			{ID: "mock-part", DisplayName: "Mock Part", SupplierID: "mock-supplier"},
+		},
+		products: []scenario.Product{
+			{ID: "mock-product", DisplayName: "Mock Product"},
+		},
+		workstations: []scenario.Workstation{
+			{ID: "mock-station", DisplayName: "Mock Station"},
+		},
+		demandRefs: []scenario.DemandProfileReference{
+			{CustomerID: "mock-customer", CustomerName: "Mock Customer", ProductID: "mock-product", ProductName: "Mock Product"},
+		},
+	}, testStateSource{snapshot: initial})
+
+	loaded, _ := model.Update(stateLoadedMsg{state: model.source.Snapshot()})
+	shell := loaded.(Model)
+	shell.width = 120
+	shell.height = 32
+
+	view := shell.View()
+	if !strings.Contains(view, "Scenario: Mock Scenario") {
+		t.Fatalf("View() did not render mock scenario reader name\n%s", view)
 	}
 }
 

--- a/internal/adapters/tui/run.go
+++ b/internal/adapters/tui/run.go
@@ -4,16 +4,15 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/ports"
-	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
 // Run launches the main Bubble Tea shell for the current match snapshot.
-func Run(definition scenario.Definition, initial domain.MatchState) error {
+func Run(definition ScenarioReader, initial domain.MatchState) error {
 	return RunWithSource(definition, newStaticStateSource(initial), nil, tea.WithAltScreen())
 }
 
 // RunReplay launches the shell with persisted state snapshots and optional AI traces.
-func RunReplay(definition scenario.Definition, current domain.MatchState, snapshots []domain.MatchState, debugRecords []ports.AICallRecord) error {
+func RunReplay(definition ScenarioReader, current domain.MatchState, snapshots []domain.MatchState, debugRecords []ports.AICallRecord) error {
 	source := newReplayStateSource(current, snapshots)
 	program := NewProgram(definition, source, nil, newStaticDebugSource(debugRecords), tea.WithAltScreen())
 	_, err := program.Run()
@@ -21,7 +20,7 @@ func RunReplay(definition scenario.Definition, current domain.MatchState, snapsh
 }
 
 // NewProgram constructs the Bubble Tea program for the supplied match source.
-func NewProgram(definition scenario.Definition, source StateSource, submit SubmitFunc, debug DebugSource, options ...tea.ProgramOption) *tea.Program {
+func NewProgram(definition ScenarioReader, source StateSource, submit SubmitFunc, debug DebugSource, options ...tea.ProgramOption) *tea.Program {
 	opts := append([]tea.ProgramOption{tea.WithMouseCellMotion()}, options...)
 	model := NewModelWithSubmit(definition, source, submit)
 	model.debugLog = debug
@@ -29,7 +28,7 @@ func NewProgram(definition scenario.Definition, source StateSource, submit Submi
 }
 
 // RunWithSource launches the Bubble Tea shell for a live or static match source.
-func RunWithSource(definition scenario.Definition, source StateSource, submit SubmitFunc, options ...tea.ProgramOption) error {
+func RunWithSource(definition ScenarioReader, source StateSource, submit SubmitFunc, options ...tea.ProgramOption) error {
 	program := NewProgram(definition, source, submit, nil, options...)
 	_, err := program.Run()
 	return err

--- a/internal/adapters/tui/scenario_lookup.go
+++ b/internal/adapters/tui/scenario_lookup.go
@@ -86,7 +86,7 @@ func (m *Model) shiftLookupSelection(delta int) {
 
 func (m Model) renderScenarioLookupWorkspace(width int) []string {
 	lines := []string{
-		fmt.Sprintf("Scenario lookups for %s", m.scenario.DisplayName),
+		fmt.Sprintf("Scenario lookups for %s", m.scenario.ScenarioDisplayName()),
 		"View: browse the same canonical scenario lookup surface used by AI tool calls",
 		selectedLookupTabsLine(m.lookup.active),
 		"Use v/r/b/d to switch lookup type and up/down to browse entries.",

--- a/internal/adapters/tui/scenario_reader.go
+++ b/internal/adapters/tui/scenario_reader.go
@@ -1,0 +1,20 @@
+package tui
+
+import (
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+// ScenarioReader defines the scenario surface the TUI needs for browse and
+// validation workflows without depending on a concrete scenario.Definition.
+type ScenarioReader interface {
+	ScenarioDisplayName() string
+	Parts() []scenario.Part
+	Products() []scenario.Product
+	Workstations() []scenario.Workstation
+	DemandProfileReferences() []scenario.DemandProfileReference
+	ListValidSuppliers(partID domain.PartID) (scenario.ValidSuppliersLookup, error)
+	ShowProductRoute(productID domain.ProductID) (scenario.ProductRouteLookup, error)
+	ShowProductBOM(productID domain.ProductID) (scenario.ProductBOMLookup, error)
+	ShowCustomerDemandProfile(customerID domain.CustomerID, productID domain.ProductID) (scenario.CustomerDemandProfileLookup, error)
+}

--- a/internal/scenario/lookups.go
+++ b/internal/scenario/lookups.go
@@ -126,6 +126,23 @@ func (d Definition) Products() []Product {
 	return products
 }
 
+// ScenarioDisplayName returns the stable human-facing scenario name.
+func (d Definition) ScenarioDisplayName() string {
+	return d.DisplayName
+}
+
+// Workstations returns all canonical workstation definitions in stable display order.
+func (d Definition) Workstations() []Workstation {
+	workstations := slices.Clone(d.ProductionModel.Workstations)
+	slices.SortFunc(workstations, func(left, right Workstation) int {
+		if byName := cmp.Compare(left.DisplayName, right.DisplayName); byName != 0 {
+			return byName
+		}
+		return cmp.Compare(left.ID, right.ID)
+	})
+	return workstations
+}
+
 // Workstation returns one canonical workstation definition.
 func (d Definition) Workstation(workstationID domain.WorkstationID) (Workstation, bool) {
 	workstation, ok := d.workstationsByID()[workstationID]


### PR DESCRIPTION
## Summary
- introduce a `tui.ScenarioReader` interface and update the TUI model/program constructors to depend on it instead of `scenario.Definition`
- route action-entry validation and scenario lookup browsing through the narrower reader surface, adding a stable `Workstations()` accessor on `scenario.Definition`
- add a mock-based TUI test proving the shell can render from a non-`scenario.Definition` implementation

Closes #204

## Testing
- `go test ./...`
- `staticcheck ./...`