### PR TITLE
Adopt sentinel AI provider timeout errors

### DIFF
--- a/internal/adapters/ai/openai/client.go
+++ b/internal/adapters/ai/openai/client.go
@@ -2,7 +2,9 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -108,7 +110,7 @@ func (c *Client) RequestDecision(ctx context.Context, request ports.ProviderDeci
 		&envelope,
 	)
 	if err != nil {
-		return ports.ProviderDecisionResult{}, fmt.Errorf("call openai chat completions API: %w", err)
+		return ports.ProviderDecisionResult{}, classifyRequestError(err)
 	}
 
 	content, err := firstChoiceContent(response)
@@ -152,4 +154,24 @@ func firstChoiceContent(response openaiSDK.ChatCompletionResponse) (string, erro
 		return "", fmt.Errorf("openai response choice content was empty")
 	}
 	return content, nil
+}
+
+func classifyRequestError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case isProviderTimeout(err):
+		return fmt.Errorf("call openai chat completions API: %w", fmt.Errorf("%w: %w", ports.ErrProviderTimeout, err))
+	default:
+		return fmt.Errorf("call openai chat completions API: %w", fmt.Errorf("%w: %w", ports.ErrProviderFailure, err))
+	}
+}
+
+func isProviderTimeout(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }

--- a/internal/adapters/ai/openai/client_test.go
+++ b/internal/adapters/ai/openai/client_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -86,6 +87,35 @@ func TestClientReturnsHTTPFailures(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bad api key") {
 		t.Fatalf("RequestDecision() error = %v, want response body", err)
+	}
+	if !errors.Is(err, ports.ErrProviderFailure) {
+		t.Fatalf("RequestDecision() error = %v, want ErrProviderFailure", err)
+	}
+}
+
+func TestClientClassifiesContextDeadlineAsProviderTimeout(t *testing.T) {
+	client, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	_, err = client.RequestDecision(context.Background(), ports.ProviderDecisionRequest{
+		Model: "openai/gpt-5-mini",
+	})
+	if err == nil {
+		t.Fatal("RequestDecision() error = nil, want configuration or request failure")
+	}
+
+	timeoutErr := classifyRequestError(context.DeadlineExceeded)
+	if !errors.Is(timeoutErr, ports.ErrProviderTimeout) {
+		t.Fatalf("classifyRequestError(deadline) = %v, want ErrProviderTimeout", timeoutErr)
+	}
+}
+
+func TestClassifyRequestErrorWrapsProviderFailures(t *testing.T) {
+	err := classifyRequestError(errors.New("provider returned 500"))
+	if !errors.Is(err, ports.ErrProviderFailure) {
+		t.Fatalf("classifyRequestError() = %v, want ErrProviderFailure", err)
 	}
 }
 

--- a/internal/adapters/player/llm/player.go
+++ b/internal/adapters/player/llm/player.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/ports"
@@ -112,5 +111,7 @@ func fallbackCommentary(request ports.RoundRequest, body string) domain.Commenta
 }
 
 func nonResponsive(err error) bool {
-	return errors.Is(err, ports.ErrNonResponsive) || errors.Is(err, context.DeadlineExceeded) || strings.Contains(strings.ToLower(err.Error()), "timeout")
+	return errors.Is(err, ports.ErrNonResponsive) ||
+		errors.Is(err, ports.ErrProviderTimeout) ||
+		errors.Is(err, context.DeadlineExceeded)
 }

--- a/internal/adapters/player/llm/player_test.go
+++ b/internal/adapters/player/llm/player_test.go
@@ -1,0 +1,49 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/ports"
+)
+
+func TestRecoverFromNonResponseTreatsProviderTimeoutAsRecoverable(t *testing.T) {
+	player := New(nil)
+	request := ports.RoundRequest{
+		Assignment: domain.RoleAssignment{
+			RoleID:   domain.RoleSalesManager,
+			PlayerID: "sales-player",
+		},
+		RoleView: domain.RoundView{
+			ActiveTargets: domain.BudgetTargets{EffectiveRound: 3},
+		},
+	}
+
+	submission, err := player.RecoverFromNonResponse(context.Background(), request, ports.ErrProviderTimeout)
+	if err != nil {
+		t.Fatalf("RecoverFromNonResponse() error = %v", err)
+	}
+	if submission.Action.Sales == nil {
+		t.Fatalf("RecoverFromNonResponse() = %#v, want sales no-op fallback", submission.Action)
+	}
+	if got := submission.Commentary.Body; got != "Safe no-op submitted after AI timeout." {
+		t.Fatalf("submission.Commentary.Body = %q, want timeout fallback message", got)
+	}
+}
+
+func TestRecoverFromNonResponseRejectsGenericProviderFailures(t *testing.T) {
+	player := New(nil)
+	request := ports.RoundRequest{
+		Assignment: domain.RoleAssignment{RoleID: domain.RoleSalesManager},
+	}
+
+	_, err := player.RecoverFromNonResponse(context.Background(), request, ports.ErrProviderFailure)
+	if err == nil {
+		t.Fatal("RecoverFromNonResponse() error = nil, want wrapped provider failure")
+	}
+	if !errors.Is(err, ports.ErrProviderFailure) {
+		t.Fatalf("RecoverFromNonResponse() error = %v, want ErrProviderFailure", err)
+	}
+}

--- a/internal/ports/errors.go
+++ b/internal/ports/errors.go
@@ -1,0 +1,9 @@
+package ports
+
+import "errors"
+
+var (
+	ErrNonResponsive   = errors.New("player did not respond")
+	ErrProviderFailure = errors.New("ai provider request failed")
+	ErrProviderTimeout = errors.New("ai provider request timed out")
+)

--- a/internal/ports/player.go
+++ b/internal/ports/player.go
@@ -2,12 +2,9 @@ package ports
 
 import (
 	"context"
-	"errors"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
 )
-
-var ErrNonResponsive = errors.New("player did not respond")
 
 // Player presents one role-facing round contract regardless of whether the
 // controller behind it is human, AI, or another future player type.


### PR DESCRIPTION
## Summary
- add shared sentinel provider error types for AI timeout vs generic provider failures
- classify OpenAI transport failures into those sentinel categories instead of leaving callers to inspect error strings
- update the LLM player recovery path to rely on `errors.Is` only, with focused tests around timeout recovery and non-timeout provider failures

Closes #205

## Testing
- `go test ./...`
- `staticcheck ./...`