### PR TITLE
Fix live TUI logger writing into the terminal

### DIFF
--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -64,6 +64,7 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 	if err != nil {
 		return err
 	}
+	liveLogger := app.NewDiscardLogger()
 
 	stateSnapshots := []domain.MatchState{initialState.Clone()}
 	if store != nil {
@@ -74,12 +75,12 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 		stateSnapshots = persistedSnapshots
 	}
 	controller := newLiveGameplayController(initialState, stateSnapshots)
-	players, debugLog, err := buildPlayersWithHumanSubmit(runtime.Config, definition, initialState, controller.SubmitRound, runtime.Logger)
+	players, debugLog, err := buildPlayersWithHumanSubmit(runtime.Config, definition, initialState, controller.SubmitRound, liveLogger)
 	if err != nil {
 		return fmt.Errorf("player setup: %w", err)
 	}
 	if store != nil && persistAIDebug {
-		configureAICallPersistence(debugLog, runtime.Logger, store, initialState.MatchID)
+		configureAICallPersistence(debugLog, liveLogger, store, initialState.MatchID)
 	}
 	debugSource := tui.DebugSource(debugLog)
 	if store != nil {
@@ -94,12 +95,12 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 	}
 
 	runner := app.MatchRunner{
-		Collector: app.RoundCollector{Players: players, Logger: runtime.Logger},
+		Collector: app.RoundCollector{Players: players, Logger: liveLogger},
 		Resolver:  engine.NewResolver(definition.ResolverOptions()),
 		Random:    runtime.Random,
 		Store:     store,
 		OnState:   controller.Publish,
-		Logger:    runtime.Logger,
+		Logger:    liveLogger,
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/internal/app/logging.go
+++ b/internal/app/logging.go
@@ -14,7 +14,17 @@ func loggerOrDiscard(logger *slog.Logger) *slog.Logger {
 }
 
 func newProcessLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+	return newTextLogger(os.Stderr)
+}
+
+// NewDiscardLogger constructs a logger that drops process logs instead of
+// writing into an active terminal UI.
+func NewDiscardLogger() *slog.Logger {
+	return newTextLogger(io.Discard)
+}
+
+func newTextLogger(writer io.Writer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(writer, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
 }

--- a/internal/app/logging_test.go
+++ b/internal/app/logging_test.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestNewDiscardLoggerDropsOutput(t *testing.T) {
+	originalStderr := os.Stderr
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stderr = writePipe
+	t.Cleanup(func() {
+		os.Stderr = originalStderr
+		_ = writePipe.Close()
+		_ = readPipe.Close()
+	})
+
+	logger := NewDiscardLogger()
+	logger.Info("this should not be written")
+	if err := writePipe.Close(); err != nil {
+		t.Fatalf("writePipe.Close() error = %v", err)
+	}
+
+	output, err := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+	if len(output) != 0 {
+		t.Fatalf("captured stderr = %q, want no output", string(output))
+	}
+}

--- a/internal/app/match_runner_test.go
+++ b/internal/app/match_runner_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/persistence/memory"
@@ -28,6 +29,7 @@ func TestMatchRunnerPlaysMultipleResolvedRounds(t *testing.T) {
 	initial.RoundFlow.AIRevealDelaySeconds = 15
 
 	phaseCounts := map[domain.RoundPhase]int{}
+	var phaseCountsMu sync.Mutex
 	runner := app.MatchRunner{
 		Collector: app.RoundCollector{
 			Players: scriptedPlayers(),
@@ -35,7 +37,9 @@ func TestMatchRunnerPlaysMultipleResolvedRounds(t *testing.T) {
 		Resolver: engine.NewResolver(starter.ResolverOptions()),
 		Random:   seeded.New(1),
 		OnState: func(state domain.MatchState) {
+			phaseCountsMu.Lock()
 			phaseCounts[state.RoundFlow.Phase]++
+			phaseCountsMu.Unlock()
 		},
 	}
 


### PR DESCRIPTION
## Summary
- switch live Bubble Tea gameplay logging to a discard logger so background app logs do not write into the alt-screen terminal
- keep the default process logger for non-TUI startup and failure paths
- add regression coverage for the discard logger behavior

Closes #239