### PR TITLE
Accept empty OpenAI choice content for structured replies

### DIFF
--- a/internal/adapters/ai/openai/client.go
+++ b/internal/adapters/ai/openai/client.go
@@ -113,15 +113,7 @@ func (c *Client) RequestDecision(ctx context.Context, request ports.ProviderDeci
 		return ports.ProviderDecisionResult{}, classifyRequestError(err)
 	}
 
-	content, err := firstChoiceContent(response)
-	if err != nil {
-		return ports.ProviderDecisionResult{}, err
-	}
-
-	return ports.ProviderDecisionResult{
-		RawResponse:        content,
-		StructuredResponse: &envelope,
-	}, nil
+	return providerDecisionResult(response, envelope)
 }
 
 func parseBaseURL(rawURL string) (*url.URL, error) {
@@ -149,11 +141,19 @@ func firstChoiceContent(response openaiSDK.ChatCompletionResponse) (string, erro
 		return "", fmt.Errorf("openai response did not include any choices")
 	}
 
-	content := strings.TrimSpace(response.Choices[0].Message.Content)
-	if content == "" {
-		return "", fmt.Errorf("openai response choice content was empty")
+	return strings.TrimSpace(response.Choices[0].Message.Content), nil
+}
+
+func providerDecisionResult(response openaiSDK.ChatCompletionResponse, envelope ports.AIDecisionEnvelope) (ports.ProviderDecisionResult, error) {
+	content, err := firstChoiceContent(response)
+	if err != nil {
+		return ports.ProviderDecisionResult{}, err
 	}
-	return content, nil
+
+	return ports.ProviderDecisionResult{
+		RawResponse:        content,
+		StructuredResponse: &envelope,
+	}, nil
 }
 
 func classifyRequestError(err error) error {

--- a/internal/adapters/ai/openai/client_test.go
+++ b/internal/adapters/ai/openai/client_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
-	openaiSDK "github.com/sashabaranov/go-openai"
 	"github.com/jpconstantineau/herbiego/internal/ports"
+	openaiSDK "github.com/sashabaranov/go-openai"
 )
 
 func TestClientRequestsStructuredChatCompletion(t *testing.T) {

--- a/internal/adapters/ai/openai/client_test.go
+++ b/internal/adapters/ai/openai/client_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	openaiSDK "github.com/sashabaranov/go-openai"
 	"github.com/jpconstantineau/herbiego/internal/ports"
 )
 
@@ -90,6 +92,40 @@ func TestClientReturnsHTTPFailures(t *testing.T) {
 	}
 	if !errors.Is(err, ports.ErrProviderFailure) {
 		t.Fatalf("RequestDecision() error = %v, want ErrProviderFailure", err)
+	}
+}
+
+func TestProviderDecisionResultAllowsEmptyChoiceContentWhenStructuredResponseExists(t *testing.T) {
+	result, err := providerDecisionResult(
+		openaiSDK.ChatCompletionResponse{
+			Choices: []openaiSDK.ChatCompletionChoice{
+				{
+					Message: openaiSDK.ChatCompletionMessage{
+						Content: "   ",
+					},
+				},
+			},
+		},
+		ports.AIDecisionEnvelope{
+			Action: domain.RoleAction{
+				Sales: &domain.SalesAction{
+					ProductOffers: []domain.ProductOffer{{ProductID: "pump", UnitPrice: 16}},
+				},
+			},
+			Commentary: ports.AICommentary{
+				PublicSummary: "Holding price to protect throughput.",
+				FocusTags:     []string{"throughput"},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("providerDecisionResult() error = %v, want nil", err)
+	}
+	if result.StructuredResponse == nil {
+		t.Fatal("StructuredResponse = nil, want structured envelope")
+	}
+	if result.RawResponse != "" {
+		t.Fatalf("RawResponse = %q, want empty optional raw content", result.RawResponse)
 	}
 }
 

--- a/internal/app/ai_orchestrator_test.go
+++ b/internal/app/ai_orchestrator_test.go
@@ -332,7 +332,7 @@ func TestAIOrchestratorUsesStructuredProviderResponsesWhenAvailable(t *testing.T
 	client := &stubDecisionClient{
 		responses: []ports.ProviderDecisionResult{
 			{
-				RawResponse: `{}`,
+				RawResponse: ``,
 				StructuredResponse: &ports.AIDecisionEnvelope{
 					Action: domain.RoleAction{
 						Sales: &domain.SalesAction{


### PR DESCRIPTION
## Summary
- treat structured instructor output as authoritative even when `choices[0].message.content` is empty
- keep raw text capture opportunistic for debugging instead of required for correctness
- add adapter and orchestrator coverage for structured responses with empty raw content

Closes #240