### PR TITLE
Recover from provider transport failures during matches

### DIFF
--- a/internal/adapters/player/llm/player.go
+++ b/internal/adapters/player/llm/player.go
@@ -60,13 +60,13 @@ func (p *Player) RecoverFromNonResponse(_ context.Context, request ports.RoundRe
 
 	if request.PreviousAcceptedAction != nil {
 		reused := request.PreviousAcceptedAction.Clone()
-		reused.Commentary = fallbackCommentary(request, "Previous action reused after AI timeout.")
+		reused.Commentary = fallbackCommentary(request, "Previous action reused after AI transport failure.")
 		return reused, nil
 	}
 
 	return domain.ActionSubmission{
 		Action:     safeNoOpAction(request),
-		Commentary: fallbackCommentary(request, "Safe no-op submitted after AI timeout."),
+		Commentary: fallbackCommentary(request, "Safe no-op submitted after AI transport failure."),
 	}, nil
 }
 
@@ -112,6 +112,7 @@ func fallbackCommentary(request ports.RoundRequest, body string) domain.Commenta
 
 func nonResponsive(err error) bool {
 	return errors.Is(err, ports.ErrNonResponsive) ||
+		errors.Is(err, ports.ErrProviderFailure) ||
 		errors.Is(err, ports.ErrProviderTimeout) ||
 		errors.Is(err, context.DeadlineExceeded)
 }

--- a/internal/adapters/player/llm/player_test.go
+++ b/internal/adapters/player/llm/player_test.go
@@ -2,7 +2,6 @@ package llm
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/jpconstantineau/herbiego/internal/domain"
@@ -28,22 +27,28 @@ func TestRecoverFromNonResponseTreatsProviderTimeoutAsRecoverable(t *testing.T) 
 	if submission.Action.Sales == nil {
 		t.Fatalf("RecoverFromNonResponse() = %#v, want sales no-op fallback", submission.Action)
 	}
-	if got := submission.Commentary.Body; got != "Safe no-op submitted after AI timeout." {
-		t.Fatalf("submission.Commentary.Body = %q, want timeout fallback message", got)
+	if got := submission.Commentary.Body; got != "Safe no-op submitted after AI transport failure." {
+		t.Fatalf("submission.Commentary.Body = %q, want transport fallback message", got)
 	}
 }
 
-func TestRecoverFromNonResponseRejectsGenericProviderFailures(t *testing.T) {
+func TestRecoverFromNonResponseTreatsGenericProviderFailuresAsRecoverable(t *testing.T) {
 	player := New(nil)
 	request := ports.RoundRequest{
 		Assignment: domain.RoleAssignment{RoleID: domain.RoleSalesManager},
+		RoleView: domain.RoundView{
+			ActiveTargets: domain.BudgetTargets{EffectiveRound: 3},
+		},
 	}
 
-	_, err := player.RecoverFromNonResponse(context.Background(), request, ports.ErrProviderFailure)
-	if err == nil {
-		t.Fatal("RecoverFromNonResponse() error = nil, want wrapped provider failure")
+	submission, err := player.RecoverFromNonResponse(context.Background(), request, ports.ErrProviderFailure)
+	if err != nil {
+		t.Fatalf("RecoverFromNonResponse() error = %v", err)
 	}
-	if !errors.Is(err, ports.ErrProviderFailure) {
-		t.Fatalf("RecoverFromNonResponse() error = %v, want ErrProviderFailure", err)
+	if submission.Action.Sales == nil {
+		t.Fatalf("RecoverFromNonResponse() = %#v, want sales no-op fallback", submission.Action)
+	}
+	if got := submission.Commentary.Body; got != "Safe no-op submitted after AI transport failure." {
+		t.Fatalf("submission.Commentary.Body = %q, want transport fallback message", got)
 	}
 }

--- a/internal/app/match_runner_test.go
+++ b/internal/app/match_runner_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/jpconstantineau/herbiego/internal/adapters/persistence/memory"
+	"github.com/jpconstantineau/herbiego/internal/adapters/player/llm"
 	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
@@ -228,6 +229,95 @@ func TestMatchRunnerCanResumeUsingAnExistingStore(t *testing.T) {
 	}
 	if got := len(current.History.RecentRounds); got != 2 {
 		t.Fatalf("stored history rounds = %d, want 2", got)
+	}
+}
+
+func TestMatchRunnerContinuesAfterLaterProviderTransportFailure(t *testing.T) {
+	starter := scenario.Starter()
+	initial := starter.InitialState("match-241", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", Provider: "ollama", ModelName: "gemma4:e4b"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", Provider: "openrouter", ModelName: "openai/gpt-5-mini"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "openai", ModelName: "gpt-5-mini"},
+	})
+
+	salesCalls := 0
+	runner := app.MatchRunner{
+		Collector: app.RoundCollector{
+			Players: map[domain.RoleID]ports.Player{
+				domain.RoleProcurementManager: scriptPlayer(func(request ports.RoundRequest) domain.ActionSubmission {
+					return domain.ActionSubmission{
+						Action: domain.RoleAction{Procurement: &domain.ProcurementAction{}},
+						Commentary: domain.CommentaryRecord{
+							Body: fmt.Sprintf("Round %d procurement protects cash for the bottleneck.", request.RoleView.Round),
+						},
+					}
+				}),
+				domain.RoleProductionManager: scriptPlayer(func(request ports.RoundRequest) domain.ActionSubmission {
+					return domain.ActionSubmission{
+						Action: domain.RoleAction{
+							Production: &domain.ProductionAction{
+								CapacityAllocation: []domain.CapacityAllocation{
+									{WorkstationID: "assembly", ProductID: "pump", Capacity: 2},
+								},
+							},
+						},
+						Commentary: domain.CommentaryRecord{
+							Body: fmt.Sprintf("Round %d production favors throughput over local utilization.", request.RoleView.Round),
+						},
+					}
+				}),
+				domain.RoleSalesManager: llm.New(func(_ context.Context, request ports.RoundRequest) (domain.ActionSubmission, error) {
+					salesCalls++
+					if request.RoleView.Round == 2 {
+						return domain.ActionSubmission{}, ports.ErrProviderFailure
+					}
+					return domain.ActionSubmission{
+						Action: domain.RoleAction{
+							Sales: &domain.SalesAction{
+								ProductOffers: []domain.ProductOffer{
+									{ProductID: "pump", UnitPrice: domain.Money(14 + salesCalls)},
+								},
+							},
+						},
+						Commentary: domain.CommentaryRecord{
+							Body: fmt.Sprintf("Round %d sales holds price while backlog is visible.", request.RoleView.Round),
+						},
+					}, nil
+				}),
+				domain.RoleFinanceController: scriptPlayer(func(request ports.RoundRequest) domain.ActionSubmission {
+					targets := request.RoleView.ActiveTargets
+					targets.EffectiveRound = request.RoleView.Round + 1
+					return domain.ActionSubmission{
+						Action: domain.RoleAction{
+							Finance: &domain.FinanceAction{NextRoundTargets: targets},
+						},
+						Commentary: domain.CommentaryRecord{
+							Body: fmt.Sprintf("Round %d finance keeps targets stable to compare tradeoffs.", request.RoleView.Round),
+						},
+					}
+				}),
+			},
+		},
+		Resolver: engine.NewResolver(starter.ResolverOptions()),
+		Random:   seeded.New(1),
+	}
+
+	final, results, err := runner.Play(context.Background(), initial, 3)
+	if err != nil {
+		t.Fatalf("Play() error = %v", err)
+	}
+	if got := len(results); got != 3 {
+		t.Fatalf("len(results) = %d, want 3", got)
+	}
+	if got := final.CurrentRound; got != 4 {
+		t.Fatalf("final.CurrentRound = %d, want 4", got)
+	}
+	if got := results[1].Round.Actions[2].Commentary.Body; got != "Previous action reused after AI transport failure." {
+		t.Fatalf("round 2 sales commentary = %q, want transport fallback reuse message", got)
+	}
+	if got := results[1].Round.Actions[2].Action.Sales.ProductOffers[0].UnitPrice; got != 15 {
+		t.Fatalf("round 2 fallback UnitPrice = %d, want reused prior round value 15", got)
 	}
 }
 

--- a/internal/app/round_collection_test.go
+++ b/internal/app/round_collection_test.go
@@ -200,7 +200,62 @@ func TestRoundCollectorReusesPreviousActionWhenAIPlayerTimesOut(t *testing.T) {
 	if got := sales.Action.Sales.ProductOffers[0].UnitPrice; got != 13 {
 		t.Fatalf("sales.ProductOffers[0].UnitPrice = %d, want 13", got)
 	}
-	if got := sales.Commentary.Body; got != "Previous action reused after AI timeout." {
+	if got := sales.Commentary.Body; got != "Previous action reused after AI transport failure." {
+		t.Fatalf("sales.Commentary.Body = %q, want reuse message", got)
+	}
+}
+
+func TestRoundCollectorReusesPreviousActionWhenAIPlayerHasProviderFailure(t *testing.T) {
+	state := fixtureMatchState()
+	previous := domain.ActionSubmission{
+		ActionID: "sales-r1",
+		MatchID:  state.MatchID,
+		Round:    1,
+		RoleID:   domain.RoleSalesManager,
+		Action: domain.RoleAction{
+			Sales: &domain.SalesAction{
+				ProductOffers: []domain.ProductOffer{
+					{ProductID: "pump", UnitPrice: 13},
+				},
+			},
+		},
+		Commentary: domain.CommentaryRecord{
+			Body: "Previous price held.",
+		},
+	}
+
+	collector := app.RoundCollector{
+		Players: map[domain.RoleID]ports.Player{
+			domain.RoleProcurementManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return procurementSubmission(), nil
+			}),
+			domain.RoleProductionManager: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return productionSubmission(), nil
+			}),
+			domain.RoleSalesManager: llm.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return domain.ActionSubmission{}, ports.ErrProviderFailure
+			}),
+			domain.RoleFinanceController: human.New(func(_ context.Context, _ ports.RoundRequest) (domain.ActionSubmission, error) {
+				return financeSubmission(), nil
+			}),
+		},
+	}
+
+	actions, err := collector.Collect(context.Background(), state, map[domain.RoleID]domain.ActionSubmission{
+		domain.RoleSalesManager: previous,
+	})
+	if err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+
+	sales := findAction(actions, domain.RoleSalesManager)
+	if sales == nil {
+		t.Fatal("sales action missing from collected results")
+	}
+	if got := sales.Action.Sales.ProductOffers[0].UnitPrice; got != 13 {
+		t.Fatalf("sales.ProductOffers[0].UnitPrice = %d, want 13", got)
+	}
+	if got := sales.Commentary.Body; got != "Previous action reused after AI transport failure." {
 		t.Fatalf("sales.Commentary.Body = %q, want reuse message", got)
 	}
 }


### PR DESCRIPTION
## Summary
- treat provider transport failures as recoverable for AI-backed players
- reuse the existing fallback path so one provider hiccup degrades a single turn instead of aborting the whole match
- add collector and match-runner coverage for later-round provider failure recovery

Closes #241