### PR TITLE
Add splash screen and start menu flow

### DIFF
--- a/cmd/herbiego/app_flow.go
+++ b/cmd/herbiego/app_flow.go
@@ -3,11 +3,19 @@ package main
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
+	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
+
+type activeSession struct {
+	runtime app.Runtime
+	state   domain.MatchState
+}
 
 func runApplication(ctx context.Context, baseRuntime app.Runtime, resumedState domain.MatchState, hasResumedState bool, store persistentStore, rounds int, persistAIDebug bool) error {
 	if err := runSplashScreen(); err != nil {
@@ -15,39 +23,111 @@ func runApplication(ctx context.Context, baseRuntime app.Runtime, resumedState d
 	}
 
 	menuConfig := cloneConfig(baseRuntime.Config)
-	pendingState := resumedState.Clone()
+	var current *activeSession
+	menuState := startMenuState{
+		StoreEnabled: store != nil,
+	}
+	if hasResumedState {
+		current = &activeSession{runtime: baseRuntime, state: resumedState.Clone()}
+	}
 
 	for {
-		if hasResumedState {
-			exitIntent, err := runLiveGameplay(ctx, baseRuntime, pendingState, store, rounds, persistAIDebug)
+		if store != nil {
+			slots, err := store.ListSaveSlots()
+			if err != nil {
+				return fmt.Errorf("list save slots: %w", err)
+			}
+			menuState.SaveSlots = slots
+			menuState.clampSelections()
+		}
+
+		if hasResumedState && current != nil {
+			exitIntent, latest, err := runLiveGameplay(ctx, current.runtime, current.state, store, rounds, persistAIDebug)
 			if err != nil {
 				return err
 			}
+			current.state = latest.Clone()
+			menuConfig = cloneConfig(current.runtime.Config)
+			hasResumedState = false
 			if exitIntent != gameplayExitToMenu {
 				return nil
 			}
-			hasResumedState = false
+			menuState.ActiveSession = current
+			menuState.StatusText = currentSessionStatus(current.state)
 			continue
 		}
 
-		action, updatedConfig, err := runStartMenu(menuConfig)
+		menuState.ActiveSession = current
+		result, err := runStartMenu(menuConfig, menuState)
 		if err != nil {
 			return fmt.Errorf("run start menu: %w", err)
 		}
-		menuConfig = updatedConfig
-		if action == startMenuActionExit {
+		menuConfig = result.Config
+		menuState = result.State
+
+		switch result.Action {
+		case startMenuActionExit:
 			return nil
+		case startMenuActionSaveGame:
+			if current == nil || store == nil {
+				menuState.StatusText = "Saving requires an active session and SQLite persistence."
+				continue
+			}
+
+			slotName := result.SlotName
+			if strings.TrimSpace(slotName) == "" {
+				slotName = defaultSaveSlotName(current.state)
+			}
+			summary, err := store.SaveSlot(slotName, current.state.MatchID)
+			if err != nil {
+				menuState.StatusText = fmt.Sprintf("Save failed: %v", err)
+				continue
+			}
+			menuState.StatusText = fmt.Sprintf("Saved round %d to slot %s.", summary.CurrentRound, summary.SlotName)
+			continue
+		case startMenuActionLoadGame:
+			if store == nil {
+				menuState.StatusText = "Load saved game requires -sqlite-db."
+				continue
+			}
+			state, summary, err := store.LoadSaveSlot(result.SlotName)
+			if err != nil {
+				menuState.StatusText = fmt.Sprintf("Load failed: %v", err)
+				continue
+			}
+			runtime, err := runtimeForLoadedState(menuConfig, state)
+			if err != nil {
+				return fmt.Errorf("build runtime for save slot %q: %w", summary.SlotName, err)
+			}
+			current = &activeSession{runtime: runtime, state: state.Clone()}
+		case startMenuActionResumeGame:
+			if current == nil {
+				menuState.StatusText = "No current session is available to resume."
+				continue
+			}
+		case startMenuActionStartNewGame:
+			runtime, err := app.NewRuntime(runtimeConfigFromMenu(menuConfig))
+			if err != nil {
+				menuState.StatusText = fmt.Sprintf("Start failed: %v", err)
+				continue
+			}
+			current = &activeSession{runtime: runtime, state: runtime.InitialMatch.Clone()}
+		default:
+			continue
 		}
 
-		runtime, err := app.NewRuntime(runtimeConfigFromMenu(menuConfig))
-		if err != nil {
-			return fmt.Errorf("build runtime from start menu: %w", err)
+		if current == nil {
+			continue
 		}
 
-		exitIntent, err := runLiveGameplay(ctx, runtime, runtime.InitialMatch, store, rounds, persistAIDebug)
+		exitIntent, latest, err := runLiveGameplay(ctx, current.runtime, current.state, store, rounds, persistAIDebug)
 		if err != nil {
 			return err
 		}
+		current.state = latest.Clone()
+		menuConfig = cloneConfig(current.runtime.Config)
+		menuState.ActiveSession = current
+		menuState.StatusText = currentSessionStatus(current.state)
 		if exitIntent != gameplayExitToMenu {
 			return nil
 		}
@@ -73,4 +153,40 @@ func runtimeConfigFromMenu(cfg app.Config) app.Config {
 	cloned.Roles = filteredRoles
 	cloned.RoleConfigs = nil
 	return cloned
+}
+
+func runtimeForLoadedState(cfg app.Config, state domain.MatchState) (app.Runtime, error) {
+	runtimeCfg := cloneConfig(cfg)
+	runtimeCfg.ScenarioID = state.ScenarioID
+	runtimeCfg.Roles = make(map[domain.RoleID]app.RoleConfig, len(state.Roles))
+	runtimeCfg.RoleConfigs = nil
+	for _, assignment := range state.Roles {
+		roleCfg := defaultRoleConfig(runtimeCfg)
+		if assignment.IsHuman {
+			roleCfg.Kind = app.PlayerKindHuman
+		}
+		if strings.TrimSpace(assignment.Provider) != "" {
+			roleCfg.Provider = app.ProviderName(assignment.Provider)
+		}
+		if strings.TrimSpace(assignment.ModelName) != "" {
+			roleCfg.Model = assignment.ModelName
+		}
+		runtimeCfg.Roles[assignment.RoleID] = roleCfg
+	}
+
+	runtime, err := app.NewRuntime(runtimeCfg)
+	if err != nil {
+		return app.Runtime{}, err
+	}
+	runtime.InitialMatch = state.Clone()
+	runtime.Random = seeded.New(runtimeCfg.Random.Seed)
+	return runtime, nil
+}
+
+func defaultSaveSlotName(state domain.MatchState) string {
+	return fmt.Sprintf("%s-r%d-%s", state.ScenarioID, state.CurrentRound, time.Now().UTC().Format("20060102-150405"))
+}
+
+func currentSessionStatus(state domain.MatchState) string {
+	return fmt.Sprintf("Current session: %s round %d cash %d.", scenarioTitle(state.ScenarioID), state.CurrentRound, state.Plant.Cash)
 }

--- a/cmd/herbiego/app_flow.go
+++ b/cmd/herbiego/app_flow.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func runApplication(ctx context.Context, baseRuntime app.Runtime, resumedState domain.MatchState, hasResumedState bool, store persistentStore, rounds int, persistAIDebug bool) error {
+	if err := runSplashScreen(); err != nil {
+		return fmt.Errorf("run splash screen: %w", err)
+	}
+
+	menuConfig := cloneConfig(baseRuntime.Config)
+	pendingState := resumedState.Clone()
+
+	for {
+		if hasResumedState {
+			exitIntent, err := runLiveGameplay(ctx, baseRuntime, pendingState, store, rounds, persistAIDebug)
+			if err != nil {
+				return err
+			}
+			if exitIntent != gameplayExitToMenu {
+				return nil
+			}
+			hasResumedState = false
+			continue
+		}
+
+		action, updatedConfig, err := runStartMenu(menuConfig)
+		if err != nil {
+			return fmt.Errorf("run start menu: %w", err)
+		}
+		menuConfig = updatedConfig
+		if action == startMenuActionExit {
+			return nil
+		}
+
+		runtime, err := app.NewRuntime(runtimeConfigFromMenu(menuConfig))
+		if err != nil {
+			return fmt.Errorf("build runtime from start menu: %w", err)
+		}
+
+		exitIntent, err := runLiveGameplay(ctx, runtime, runtime.InitialMatch, store, rounds, persistAIDebug)
+		if err != nil {
+			return err
+		}
+		if exitIntent != gameplayExitToMenu {
+			return nil
+		}
+	}
+}
+
+func runtimeConfigFromMenu(cfg app.Config) app.Config {
+	cloned := cloneConfig(cfg)
+	definition, ok := scenario.Lookup(cloned.ScenarioID)
+	if !ok {
+		return cloned
+	}
+
+	filteredRoles := make(map[domain.RoleID]app.RoleConfig, len(definition.Setup.RoleRoster))
+	for _, roleID := range definition.Setup.RoleRoster {
+		roleCfg, ok := cloned.Roles[roleID]
+		if !ok {
+			roleCfg = defaultRoleConfig(cloned)
+		}
+		filteredRoles[roleID] = roleCfg
+	}
+
+	cloned.Roles = filteredRoles
+	cloned.RoleConfigs = nil
+	return cloned
+}

--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -68,10 +68,10 @@ const (
 	gameplayExitToMenu
 )
 
-func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState domain.MatchState, store persistentStore, rounds int, persistAIDebug bool) (gameplayExitIntent, error) {
+func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState domain.MatchState, store persistentStore, rounds int, persistAIDebug bool) (gameplayExitIntent, domain.MatchState, error) {
 	definition, err := resolveScenarioForMatch(initialState)
 	if err != nil {
-		return gameplayExitQuit, err
+		return gameplayExitQuit, domain.MatchState{}, err
 	}
 	liveLogger := app.NewDiscardLogger()
 
@@ -79,14 +79,14 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 	if store != nil {
 		persistedSnapshots, err := store.StateSnapshots(initialState.MatchID)
 		if err != nil {
-			return gameplayExitQuit, fmt.Errorf("load persisted state snapshots: %w", err)
+			return gameplayExitQuit, domain.MatchState{}, fmt.Errorf("load persisted state snapshots: %w", err)
 		}
 		stateSnapshots = persistedSnapshots
 	}
 	controller := newLiveGameplayController(initialState, stateSnapshots)
 	players, debugLog, err := buildPlayersWithHumanSubmit(runtime.Config, definition, initialState, controller.SubmitRound, liveLogger)
 	if err != nil {
-		return gameplayExitQuit, fmt.Errorf("player setup: %w", err)
+		return gameplayExitQuit, domain.MatchState{}, fmt.Errorf("player setup: %w", err)
 	}
 	if store != nil && persistAIDebug {
 		configureAICallPersistence(debugLog, liveLogger, store, initialState.MatchID)
@@ -95,7 +95,7 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 	if store != nil {
 		debugRecords, err := store.AICallRecords(initialState.MatchID)
 		if err != nil {
-			return gameplayExitQuit, fmt.Errorf("load persisted ai traces: %w", err)
+			return gameplayExitQuit, domain.MatchState{}, fmt.Errorf("load persisted ai traces: %w", err)
 		}
 		debugSource = combinedDebugSource{
 			live:      debugLog,
@@ -156,20 +156,20 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 	playErr := <-runnerErr
 
 	if err != nil && !errors.Is(err, tea.ErrProgramKilled) {
-		return gameplayExitQuit, fmt.Errorf("bubble tea runtime: %w", err)
+		return gameplayExitQuit, controller.Snapshot(), fmt.Errorf("bubble tea runtime: %w", err)
 	}
 	if playErr != nil && !errors.Is(playErr, context.Canceled) {
-		return gameplayExitQuit, playErr
+		return gameplayExitQuit, controller.Snapshot(), playErr
 	}
 
 	gameplayModel, ok := finalModel.(tui.Model)
 	if !ok {
-		return gameplayExitQuit, nil
+		return gameplayExitQuit, controller.Snapshot(), nil
 	}
 	if gameplayModel.ExitIntent() == tui.ExitIntentReturnToMenu {
-		return gameplayExitToMenu, nil
+		return gameplayExitToMenu, controller.Snapshot(), nil
 	}
-	return gameplayExitQuit, nil
+	return gameplayExitQuit, controller.Snapshot(), nil
 }
 
 func resolveScenarioForMatch(state domain.MatchState) (scenario.Definition, error) {

--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jpconstantineau/herbiego/internal/adapters/tui"
@@ -53,16 +54,24 @@ func main() {
 		defer store.Close()
 	}
 
-	if err := runLiveGameplay(context.Background(), runtime, initialState, store, *rounds, *persistAIDebug); err != nil {
-		fmt.Fprintf(os.Stderr, "match failed:\n%v\n", err)
+	hasResumedState := strings.TrimSpace(*resumeMatchID) != ""
+	if err := runApplication(context.Background(), runtime, initialState, hasResumedState, store, *rounds, *persistAIDebug); err != nil {
+		fmt.Fprintf(os.Stderr, "application failed:\n%v\n", err)
 		os.Exit(1)
 	}
 }
 
-func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState domain.MatchState, store persistentStore, rounds int, persistAIDebug bool) error {
+type gameplayExitIntent int
+
+const (
+	gameplayExitQuit gameplayExitIntent = iota
+	gameplayExitToMenu
+)
+
+func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState domain.MatchState, store persistentStore, rounds int, persistAIDebug bool) (gameplayExitIntent, error) {
 	definition, err := resolveScenarioForMatch(initialState)
 	if err != nil {
-		return err
+		return gameplayExitQuit, err
 	}
 	liveLogger := app.NewDiscardLogger()
 
@@ -70,14 +79,14 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 	if store != nil {
 		persistedSnapshots, err := store.StateSnapshots(initialState.MatchID)
 		if err != nil {
-			return fmt.Errorf("load persisted state snapshots: %w", err)
+			return gameplayExitQuit, fmt.Errorf("load persisted state snapshots: %w", err)
 		}
 		stateSnapshots = persistedSnapshots
 	}
 	controller := newLiveGameplayController(initialState, stateSnapshots)
 	players, debugLog, err := buildPlayersWithHumanSubmit(runtime.Config, definition, initialState, controller.SubmitRound, liveLogger)
 	if err != nil {
-		return fmt.Errorf("player setup: %w", err)
+		return gameplayExitQuit, fmt.Errorf("player setup: %w", err)
 	}
 	if store != nil && persistAIDebug {
 		configureAICallPersistence(debugLog, liveLogger, store, initialState.MatchID)
@@ -86,7 +95,7 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 	if store != nil {
 		debugRecords, err := store.AICallRecords(initialState.MatchID)
 		if err != nil {
-			return fmt.Errorf("load persisted ai traces: %w", err)
+			return gameplayExitQuit, fmt.Errorf("load persisted ai traces: %w", err)
 		}
 		debugSource = combinedDebugSource{
 			live:      debugLog,
@@ -106,11 +115,12 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	program := tui.NewProgram(
+	program := tui.NewProgramWithQuitBehavior(
 		definition,
 		controller,
 		controller.Submit,
 		debugSource,
+		tui.QuitBehaviorReturnToMenu,
 		tea.WithAltScreen(),
 		tea.WithContext(ctx),
 	)
@@ -124,7 +134,7 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 		case err == nil:
 			program.Send(tui.StatusMsg{
 				Text: fmt.Sprintf(
-					"Match complete after round %d. Final cash %d, debt %d, backlog %d, profit %d. Inspect results and press q to exit.",
+					"Match complete after round %d. Final cash %d, debt %d, backlog %d, profit %d. Inspect results and press q to return to the menu.",
 					final.CurrentRound-1,
 					final.Plant.Cash,
 					final.Plant.Debt,
@@ -133,25 +143,33 @@ func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState doma
 				),
 			})
 		case errors.Is(err, context.Canceled):
-			program.Send(tui.StatusMsg{Text: "Match cancelled. Press q to exit."})
+			program.Send(tui.StatusMsg{Text: "Match cancelled. Returning to the start menu."})
 		default:
-			program.Send(tui.StatusMsg{Text: fmt.Sprintf("Match failed: %v. Press q to exit.", err)})
+			program.Send(tui.StatusMsg{Text: fmt.Sprintf("Match failed: %v. Press q to return to the menu.", err)})
 		}
 
 		runnerErr <- err
 	}()
 
-	_, err = program.Run()
+	finalModel, err := program.Run()
 	cancel()
 	playErr := <-runnerErr
 
 	if err != nil && !errors.Is(err, tea.ErrProgramKilled) {
-		return fmt.Errorf("bubble tea runtime: %w", err)
+		return gameplayExitQuit, fmt.Errorf("bubble tea runtime: %w", err)
 	}
 	if playErr != nil && !errors.Is(playErr, context.Canceled) {
-		return playErr
+		return gameplayExitQuit, playErr
 	}
-	return nil
+
+	gameplayModel, ok := finalModel.(tui.Model)
+	if !ok {
+		return gameplayExitQuit, nil
+	}
+	if gameplayModel.ExitIntent() == tui.ExitIntentReturnToMenu {
+		return gameplayExitToMenu, nil
+	}
+	return gameplayExitQuit, nil
 }
 
 func resolveScenarioForMatch(state domain.MatchState) (scenario.Definition, error) {

--- a/cmd/herbiego/persistence.go
+++ b/cmd/herbiego/persistence.go
@@ -17,6 +17,9 @@ type persistentStore interface {
 	AppendAICall(matchID domain.MatchID, record ports.AICallRecord) error
 	AICallRecords(matchID domain.MatchID) ([]ports.AICallRecord, error)
 	StateSnapshots(matchID domain.MatchID) ([]domain.MatchState, error)
+	SaveSlot(slotName string, matchID domain.MatchID) (sqlite.SaveSlotSummary, error)
+	ListSaveSlots() ([]sqlite.SaveSlotSummary, error)
+	LoadSaveSlot(slotName string) (domain.MatchState, sqlite.SaveSlotSummary, error)
 }
 
 func resolveMatchPersistence(runtime app.Runtime, sqlitePath, resumeMatchID string) (persistentStore, domain.MatchState, error) {

--- a/cmd/herbiego/splash_screen.go
+++ b/cmd/herbiego/splash_screen.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var splashFrameDelay = 220 * time.Millisecond
+
+type splashTickMsg struct{}
+
+type splashModel struct {
+	frame    int
+	finished bool
+	width    int
+}
+
+func runSplashScreen() error {
+	_, err := tea.NewProgram(splashModel{}, tea.WithAltScreen()).Run()
+	return err
+}
+
+func (m splashModel) Init() tea.Cmd {
+	return splashTickCmd()
+}
+
+func (m splashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch typed := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = typed.Width
+		return m, nil
+	case tea.KeyMsg:
+		m.finished = true
+		return m, tea.Quit
+	case splashTickMsg:
+		if m.frame >= len(herbieSplashFrames())-1 {
+			m.finished = true
+			return m, tea.Quit
+		}
+		m.frame++
+		return m, splashTickCmd()
+	}
+
+	return m, nil
+}
+
+func (m splashModel) View() string {
+	accent := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("229"))
+	subtitle := lipgloss.NewStyle().Foreground(lipgloss.Color("223"))
+	frame := herbieSplashFrames()[min(m.frame, len(herbieSplashFrames())-1)]
+
+	lines := []string{
+		accent.Render("HerbieGo"),
+		subtitle.Render("Prairie heat. Tight cash. Bottlenecks everywhere."),
+		"",
+		frame,
+		"",
+		subtitle.Render("Launching start menu..."),
+	}
+
+	width := m.width
+	if width <= 0 {
+		width = 96
+	}
+
+	return lipgloss.NewStyle().
+		Padding(1, 2).
+		Width(width).
+		Render(strings.Join(lines, "\n"))
+}
+
+func splashTickCmd() tea.Cmd {
+	return tea.Tick(splashFrameDelay, func(time.Time) tea.Msg {
+		return splashTickMsg{}
+	})
+}
+
+func herbieSplashFrames() []string {
+	brick := lipgloss.NewStyle().Foreground(lipgloss.Color("209")).Render
+	fire := lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render
+	steel := lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Render
+	heat := lipgloss.NewStyle().Foreground(lipgloss.Color("220")).Render
+	glow := lipgloss.NewStyle().Foreground(lipgloss.Color("228")).Render
+
+	baseTop := brick("          __________________________________________")
+	baseMid := brick("         /") + steel("                                        /|")
+	baseBottom := brick("        /________________________________________/ |")
+	chassis := brick("        |  ") + glow("HERBIE") + steel("   heat-treating oven") + brick("           | |")
+	conveyor := steel("        |  rails: ==========>                   | |")
+	feet := brick("        |_______________________________________|/") + "\n" +
+		steel("           O                               O")
+
+	return []string{
+		strings.Join([]string{
+			baseTop,
+			baseMid,
+			baseBottom,
+			chassis,
+			brick("        |  [##############]      ") + fire("(((())))") + brick("     | |"),
+			brick("        |  [##############]      ") + fire("(((())))") + brick("     | |"),
+			conveyor,
+			feet,
+		}, "\n"),
+		strings.Join([]string{
+			baseTop,
+			baseMid,
+			baseBottom,
+			chassis,
+			brick("        | /[##############]      ") + fire("(((())))") + brick("     | |"),
+			brick("        |/ [##############]      ") + fire("(((())))") + brick("     | |"),
+			conveyor,
+			feet,
+		}, "\n"),
+		strings.Join([]string{
+			baseTop,
+			baseMid,
+			baseBottom,
+			chassis,
+			brick("        /  [##############]      ") + heat("  * * * ") + brick("     | |"),
+			brick("       /   [##############]      ") + fire("(((())))") + brick("     | |"),
+			conveyor,
+			feet,
+		}, "\n"),
+		strings.Join([]string{
+			baseTop,
+			baseMid,
+			baseBottom,
+			chassis,
+			brick("      /    [##############]      ") + heat(" *  *  *") + brick("     | |"),
+			brick("     /     [##############]      ") + fire("(((())))") + brick("     | |"),
+			conveyor,
+			feet,
+		}, "\n"),
+	}
+}
+
+func min(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}

--- a/cmd/herbiego/splash_screen.go
+++ b/cmd/herbiego/splash_screen.go
@@ -6,9 +6,15 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
-var splashFrameDelay = 220 * time.Millisecond
+var splashTotalDuration = 3 * time.Second
+
+const (
+	splashCanvasWidth  = 72
+	splashCanvasHeight = 14
+)
 
 type splashTickMsg struct{}
 
@@ -48,13 +54,11 @@ func (m splashModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m splashModel) View() string {
-	accent := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("229"))
 	subtitle := lipgloss.NewStyle().Foreground(lipgloss.Color("223"))
 	frame := herbieSplashFrames()[min(m.frame, len(herbieSplashFrames())-1)]
 
 	lines := []string{
-		accent.Render("HerbieGo"),
-		subtitle.Render("Prairie heat. Tight cash. Bottlenecks everywhere."),
+		subtitle.Render("The line is moving."),
 		"",
 		frame,
 		"",
@@ -73,68 +77,166 @@ func (m splashModel) View() string {
 }
 
 func splashTickCmd() tea.Cmd {
-	return tea.Tick(splashFrameDelay, func(time.Time) tea.Msg {
+	return tea.Tick(splashFrameDelayForFrameCount(len(herbieSplashFrames())), func(time.Time) tea.Msg {
 		return splashTickMsg{}
 	})
 }
 
-func herbieSplashFrames() []string {
-	brick := lipgloss.NewStyle().Foreground(lipgloss.Color("209")).Render
-	fire := lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Render
-	steel := lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Render
-	heat := lipgloss.NewStyle().Foreground(lipgloss.Color("220")).Render
-	glow := lipgloss.NewStyle().Foreground(lipgloss.Color("228")).Render
-
-	baseTop := brick("          __________________________________________")
-	baseMid := brick("         /") + steel("                                        /|")
-	baseBottom := brick("        /________________________________________/ |")
-	chassis := brick("        |  ") + glow("HERBIE") + steel("   heat-treating oven") + brick("           | |")
-	conveyor := steel("        |  rails: ==========>                   | |")
-	feet := brick("        |_______________________________________|/") + "\n" +
-		steel("           O                               O")
-
-	return []string{
-		strings.Join([]string{
-			baseTop,
-			baseMid,
-			baseBottom,
-			chassis,
-			brick("        |  [##############]      ") + fire("(((())))") + brick("     | |"),
-			brick("        |  [##############]      ") + fire("(((())))") + brick("     | |"),
-			conveyor,
-			feet,
-		}, "\n"),
-		strings.Join([]string{
-			baseTop,
-			baseMid,
-			baseBottom,
-			chassis,
-			brick("        | /[##############]      ") + fire("(((())))") + brick("     | |"),
-			brick("        |/ [##############]      ") + fire("(((())))") + brick("     | |"),
-			conveyor,
-			feet,
-		}, "\n"),
-		strings.Join([]string{
-			baseTop,
-			baseMid,
-			baseBottom,
-			chassis,
-			brick("        /  [##############]      ") + heat("  * * * ") + brick("     | |"),
-			brick("       /   [##############]      ") + fire("(((())))") + brick("     | |"),
-			conveyor,
-			feet,
-		}, "\n"),
-		strings.Join([]string{
-			baseTop,
-			baseMid,
-			baseBottom,
-			chassis,
-			brick("      /    [##############]      ") + heat(" *  *  *") + brick("     | |"),
-			brick("     /     [##############]      ") + fire("(((())))") + brick("     | |"),
-			conveyor,
-			feet,
-		}, "\n"),
+func splashFrameDelayForFrameCount(frameCount int) time.Duration {
+	if frameCount <= 0 {
+		return splashTotalDuration
 	}
+	return splashTotalDuration / time.Duration(frameCount)
+}
+
+func herbieSplashFrames() []string {
+	return []string{
+		renderHerbieSplashFrame(-10),
+		renderHerbieSplashFrame(-4),
+		renderHerbieSplashFrame(2),
+		renderHerbieSplashFrame(8),
+		renderHerbieSplashFrame(14),
+		renderHerbieSplashFrame(20),
+	}
+}
+
+func renderHerbieSplashFrame(offset int) string {
+	canvas := newSplashCanvas(splashCanvasWidth, splashCanvasHeight)
+
+	canvas.write(4, 2, "    /---\\                                /---\\")
+	canvas.write(4, 3, "   /     \\______________________________/     \\")
+	canvas.write(4, 4, "  |   __        __                        []   |")
+	canvas.write(4, 5, "  |  /  \\______/  \\                      []    |")
+	canvas.write(4, 6, "  | |   o      o   |________________________   |")
+	canvas.write(4, 7, "  | |      __      |========================\\  |")
+	canvas.write(4, 8, "  | |     /  \\     |                         | |")
+	canvas.write(4, 9, "  | |____/____\\____|                         | |")
+	canvas.write(4, 10, "  |    ~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^~    | |")
+	canvas.write(4, 11, "  |__________________________________________| |")
+	canvas.write(0, 12, "===="+strings.Repeat("#=", 30)+"====")
+	canvas.write(0, 13, "----"+strings.Repeat("#=", 30)+"----")
+
+	canvas.write(14, 7, renderBeltWordmark(offset, 24))
+	canvas.write(7, 13, renderLowerBeltEcho(offset, 16))
+
+	return styleSplashCanvas(canvas.lines())
+}
+
+func renderBeltWordmark(offset, width int) string {
+	base := repeatPattern("=x", width)
+	word := "HERBIEGO"
+	runes := []rune(base)
+	for index := 0; index < width; index++ {
+		wordIndex := index - offset
+		if wordIndex >= 0 && wordIndex < len(word) {
+			runes[index] = rune(word[wordIndex])
+		}
+	}
+	return string(runes)
+}
+
+func renderLowerBeltEcho(offset, width int) string {
+	base := repeatPattern("#=", width)
+	word := strings.ToLower("HERBIEGO")
+	runes := []rune(base)
+	for index := 0; index < width; index++ {
+		wordIndex := index - offset
+		if wordIndex >= 0 && wordIndex < len(word) {
+			runes[index] = rune(word[wordIndex])
+		}
+	}
+	return string(runes)
+}
+
+func styleSplashCanvas(lines []string) string {
+	steel := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	brick := lipgloss.NewStyle().Foreground(lipgloss.Color("209"))
+	fire := lipgloss.NewStyle().Foreground(lipgloss.Color("220"))
+	word := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("214"))
+	heatedWord := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("228"))
+	eyes := lipgloss.NewStyle().Foreground(lipgloss.Color("226"))
+
+	styled := make([]string, 0, len(lines))
+	for index, line := range lines {
+		current := line
+		current = strings.ReplaceAll(current, "HERB", word.Render("HERB"))
+		current = strings.ReplaceAll(current, "IEGO", heatedWord.Render("IEGO"))
+		current = strings.ReplaceAll(current, "herbiego", word.Render("herbiego"))
+		current = strings.ReplaceAll(current, "o o", eyes.Render("o o"))
+		current = strings.ReplaceAll(current, "~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^~", fire.Render("~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^~"))
+
+		switch index {
+		case 12, 13:
+			current = steel.Render(current)
+		default:
+			current = brick.Render(current)
+		}
+		styled = append(styled, current)
+	}
+	return strings.Join(styled, "\n")
+}
+
+type splashCanvas struct {
+	cells [][]rune
+}
+
+func newSplashCanvas(width, height int) splashCanvas {
+	cells := make([][]rune, height)
+	for row := range cells {
+		cells[row] = make([]rune, width)
+		for col := range cells[row] {
+			cells[row][col] = ' '
+		}
+	}
+	return splashCanvas{cells: cells}
+}
+
+func (c splashCanvas) write(col, row int, text string) {
+	if row < 0 || row >= len(c.cells) {
+		return
+	}
+	for index, char := range text {
+		target := col + index
+		if target < 0 || target >= len(c.cells[row]) {
+			continue
+		}
+		c.cells[row][target] = char
+	}
+}
+
+func (c splashCanvas) lines() []string {
+	lines := make([]string, len(c.cells))
+	for row := range c.cells {
+		lines[row] = strings.TrimRight(string(c.cells[row]), " ")
+	}
+	return lines
+}
+
+func repeatPattern(pattern string, width int) string {
+	if width <= 0 || pattern == "" {
+		return ""
+	}
+	var builder strings.Builder
+	for builder.Len() < width {
+		builder.WriteString(pattern)
+	}
+	return builder.String()[:width]
+}
+
+func splashFrameVisibleWidths() []int {
+	frames := herbieSplashFrames()
+	widths := make([]int, len(frames))
+	for index, frame := range frames {
+		lines := strings.Split(frame, "\n")
+		maxWidth := 0
+		for _, line := range lines {
+			if width := ansi.StringWidth(line); width > maxWidth {
+				maxWidth = width
+			}
+		}
+		widths[index] = maxWidth
+	}
+	return widths
 }
 
 func min(left, right int) int {

--- a/cmd/herbiego/start_menu.go
+++ b/cmd/herbiego/start_menu.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+type startMenuAction int
+
+const (
+	startMenuActionStartGame startMenuAction = iota
+	startMenuActionExit
+)
+
+type startMenuModel struct {
+	config     app.Config
+	scenarios  []domain.ScenarioID
+	cursor     int
+	width      int
+	height     int
+	action     startMenuAction
+	cancelled  bool
+	statusLine string
+}
+
+func runStartMenu(cfg app.Config) (startMenuAction, app.Config, error) {
+	model := newStartMenuModel(cfg)
+	final, err := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion()).Run()
+	if err != nil {
+		return startMenuActionExit, cfg, err
+	}
+
+	menu, ok := final.(startMenuModel)
+	if !ok {
+		return startMenuActionExit, cfg, fmt.Errorf("unexpected start menu result type %T", final)
+	}
+	if menu.cancelled {
+		return startMenuActionExit, menu.config, nil
+	}
+	return menu.action, menu.config, nil
+}
+
+func newStartMenuModel(cfg app.Config) startMenuModel {
+	normalized := cloneConfig(cfg)
+	if normalized.Roles == nil {
+		normalized.Roles = make(map[domain.RoleID]app.RoleConfig)
+	}
+	availableScenarios := scenario.RegisteredIDs()
+	if len(availableScenarios) == 0 {
+		availableScenarios = []domain.ScenarioID{scenario.DefaultID}
+	}
+	if !slices.Contains(availableScenarios, normalized.ScenarioID) {
+		normalized.ScenarioID = availableScenarios[0]
+	}
+
+	return startMenuModel{
+		config:     normalized,
+		scenarios:  availableScenarios,
+		statusLine: "Use up/down to move, left/right or enter to change settings, and enter on Start Game to launch.",
+	}
+}
+
+func (m startMenuModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m startMenuModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch typed := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = typed.Width
+		m.height = typed.Height
+		return m, nil
+	case tea.KeyMsg:
+		switch typed.String() {
+		case "ctrl+c", "esc", "q":
+			m.cancelled = true
+			m.action = startMenuActionExit
+			return m, tea.Quit
+		case "up", "k":
+			m.moveCursor(-1)
+		case "down", "j":
+			m.moveCursor(1)
+		case "left", "h":
+			m.adjustSelected(-1)
+		case "right", "l":
+			m.adjustSelected(1)
+		case "enter", " ":
+			if m.activateSelected() {
+				return m, tea.Quit
+			}
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m startMenuModel) View() string {
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("229"))
+	subtitleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	selectedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("230")).Background(lipgloss.Color("62"))
+	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("250"))
+	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	statusStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("223"))
+
+	lines := []string{
+		titleStyle.Render("HerbieGo Start Menu"),
+		subtitleStyle.Render("Set the launch configuration, then start a match or exit."),
+		"",
+	}
+
+	for index, item := range m.items() {
+		line := fmt.Sprintf("  %s", item.label)
+		if index == m.cursor {
+			line = selectedStyle.Render("> " + item.label)
+		} else {
+			line = itemStyle.Render(line)
+		}
+		lines = append(lines, line)
+	}
+
+	lines = append(lines,
+		"",
+		hintStyle.Render("Controls: up/down move | left/right change | enter select"),
+		statusStyle.Render(m.statusLine),
+	)
+
+	width := m.width
+	if width <= 0 {
+		width = 96
+	}
+
+	return lipgloss.NewStyle().
+		Padding(1, 2).
+		Width(width).
+		Render(strings.Join(lines, "\n"))
+}
+
+func (m *startMenuModel) moveCursor(delta int) {
+	itemCount := len(m.items())
+	if itemCount == 0 {
+		return
+	}
+
+	m.cursor = (m.cursor + delta + itemCount) % itemCount
+	m.statusLine = fmt.Sprintf("Selected %s.", m.items()[m.cursor].title)
+}
+
+func (m *startMenuModel) adjustSelected(delta int) {
+	if delta == 0 {
+		return
+	}
+
+	item := m.items()[m.cursor]
+	switch item.kind {
+	case menuItemScenario:
+		m.shiftScenario(delta)
+	case menuItemRole:
+		m.toggleRoleControl(item.roleID)
+	}
+}
+
+func (m *startMenuModel) activateSelected() bool {
+	item := m.items()[m.cursor]
+	switch item.kind {
+	case menuItemStartGame:
+		m.action = startMenuActionStartGame
+		return true
+	case menuItemExit:
+		m.action = startMenuActionExit
+		return true
+	case menuItemScenario:
+		m.shiftScenario(1)
+	case menuItemRole:
+		m.toggleRoleControl(item.roleID)
+	}
+	return false
+}
+
+func (m *startMenuModel) shiftScenario(delta int) {
+	if len(m.scenarios) == 0 {
+		return
+	}
+
+	current := slices.Index(m.scenarios, m.config.ScenarioID)
+	if current < 0 {
+		current = 0
+	}
+	current = (current + delta + len(m.scenarios)) % len(m.scenarios)
+	m.config.ScenarioID = m.scenarios[current]
+	m.statusLine = fmt.Sprintf("Scenario set to %s.", scenarioTitle(m.config.ScenarioID))
+}
+
+func (m *startMenuModel) toggleRoleControl(roleID domain.RoleID) {
+	if m.config.Roles == nil {
+		m.config.Roles = make(map[domain.RoleID]app.RoleConfig)
+	}
+	roleCfg, ok := m.config.Roles[roleID]
+	if !ok {
+		roleCfg = defaultRoleConfig(m.config)
+	}
+	if roleCfg.Kind == app.PlayerKindHuman {
+		roleCfg.Kind = app.PlayerKindAI
+	} else {
+		roleCfg.Kind = app.PlayerKindHuman
+	}
+	m.config.Roles[roleID] = roleCfg
+	m.statusLine = fmt.Sprintf("%s is now %s-controlled.", displayRoleName(roleID), roleControlLabel(roleCfg))
+}
+
+type menuItemKind int
+
+const (
+	menuItemStartGame menuItemKind = iota
+	menuItemScenario
+	menuItemRole
+	menuItemExit
+)
+
+type menuItem struct {
+	kind   menuItemKind
+	title  string
+	label  string
+	roleID domain.RoleID
+}
+
+func (m startMenuModel) items() []menuItem {
+	items := []menuItem{
+		{
+			kind:  menuItemStartGame,
+			title: "Start Game",
+			label: "Start Game",
+		},
+		{
+			kind:  menuItemScenario,
+			title: "Scenario",
+			label: fmt.Sprintf("Scenario: %s", scenarioTitle(m.config.ScenarioID)),
+		},
+	}
+
+	for _, roleID := range selectedScenarioRoster(m.config.ScenarioID) {
+		roleCfg, ok := m.config.Roles[roleID]
+		if !ok {
+			roleCfg = defaultRoleConfig(m.config)
+		}
+		items = append(items, menuItem{
+			kind:   menuItemRole,
+			title:  displayRoleName(roleID),
+			label:  fmt.Sprintf("%s: %s", displayRoleName(roleID), roleControlLabel(roleCfg)),
+			roleID: roleID,
+		})
+	}
+
+	items = append(items, menuItem{
+		kind:  menuItemExit,
+		title: "Exit",
+		label: "Exit",
+	})
+	return items
+}
+
+func selectedScenarioRoster(scenarioID domain.ScenarioID) []domain.RoleID {
+	definition, ok := scenario.Lookup(scenarioID)
+	if !ok {
+		return domain.CanonicalRoles()
+	}
+	return slices.Clone(definition.Setup.RoleRoster)
+}
+
+func scenarioTitle(id domain.ScenarioID) string {
+	definition, ok := scenario.Lookup(id)
+	if !ok {
+		return string(id)
+	}
+	return definition.DisplayName
+}
+
+func roleControlLabel(cfg app.RoleConfig) string {
+	controller := "AI"
+	if cfg.Kind == app.PlayerKindHuman {
+		controller = "Human"
+	}
+	if strings.TrimSpace(string(cfg.Provider)) == "" || strings.TrimSpace(cfg.Model) == "" {
+		return controller
+	}
+	return fmt.Sprintf("%s (%s / %s)", controller, cfg.Provider, cfg.Model)
+}
+
+func defaultRoleConfig(cfg app.Config) app.RoleConfig {
+	if entry, ok := firstCatalogEntry(cfg.LLMCatalog); ok {
+		return app.RoleConfig{
+			Kind:       app.PlayerKindAI,
+			Provider:   entry.Provider,
+			Model:      entry.Model,
+			URL:        entry.URL,
+			APISDKType: entry.APISDKType,
+			APIKey:     entry.APIKey,
+		}
+	}
+	return app.RoleConfig{Kind: app.PlayerKindAI}
+}
+
+func firstCatalogEntry(catalog app.LLMCatalog) (app.LLMCatalogEntry, bool) {
+	if len(catalog.Entries) == 0 {
+		return app.LLMCatalogEntry{}, false
+	}
+	return catalog.Entries[0], true
+}
+
+func cloneConfig(cfg app.Config) app.Config {
+	cloned := cfg
+	cloned.RoleConfigs = slices.Clone(cfg.RoleConfigs)
+	cloned.LLMCatalog.Entries = slices.Clone(cfg.LLMCatalog.Entries)
+	if cfg.Roles != nil {
+		cloned.Roles = make(map[domain.RoleID]app.RoleConfig, len(cfg.Roles))
+		for roleID, roleCfg := range cfg.Roles {
+			cloned.Roles[roleID] = roleCfg
+		}
+	}
+	return cloned
+}
+
+func displayRoleName(roleID domain.RoleID) string {
+	switch roleID {
+	case domain.RoleProcurementManager:
+		return "Procurement Manager"
+	case domain.RoleProductionManager:
+		return "Production Manager"
+	case domain.RoleSalesManager:
+		return "Sales Manager"
+	case domain.RoleFinanceController:
+		return "Finance Controller"
+	default:
+		return string(roleID)
+	}
+}

--- a/cmd/herbiego/start_menu.go
+++ b/cmd/herbiego/start_menu.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/jpconstantineau/herbiego/internal/adapters/persistence/sqlite"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/scenario"
@@ -15,39 +16,84 @@ import (
 type startMenuAction int
 
 const (
-	startMenuActionStartGame startMenuAction = iota
+	startMenuActionStartNewGame startMenuAction = iota
+	startMenuActionResumeGame
+	startMenuActionLoadGame
+	startMenuActionSaveGame
 	startMenuActionExit
 )
+
+type startMenuState struct {
+	ActiveSession     *activeSession
+	SaveSlots         []sqlite.SaveSlotSummary
+	SelectedLoadIndex int
+	SelectedSaveIndex int
+	StoreEnabled      bool
+	StatusText        string
+}
+
+func (s *startMenuState) clampSelections() {
+	if len(s.SaveSlots) == 0 {
+		s.SelectedLoadIndex = 0
+		s.SelectedSaveIndex = 0
+		return
+	}
+	if s.SelectedLoadIndex < 0 {
+		s.SelectedLoadIndex = 0
+	}
+	if s.SelectedLoadIndex >= len(s.SaveSlots) {
+		s.SelectedLoadIndex = len(s.SaveSlots) - 1
+	}
+	saveChoiceCount := len(s.SaveSlots) + 1
+	if s.SelectedSaveIndex < 0 {
+		s.SelectedSaveIndex = 0
+	}
+	if s.SelectedSaveIndex >= saveChoiceCount {
+		s.SelectedSaveIndex = saveChoiceCount - 1
+	}
+}
+
+type startMenuResult struct {
+	Action   startMenuAction
+	Config   app.Config
+	State    startMenuState
+	SlotName string
+}
 
 type startMenuModel struct {
 	config     app.Config
 	scenarios  []domain.ScenarioID
+	state      startMenuState
 	cursor     int
 	width      int
 	height     int
-	action     startMenuAction
+	result     startMenuResult
 	cancelled  bool
 	statusLine string
 }
 
-func runStartMenu(cfg app.Config) (startMenuAction, app.Config, error) {
-	model := newStartMenuModel(cfg)
+func runStartMenu(cfg app.Config, state startMenuState) (startMenuResult, error) {
+	model := newStartMenuModel(cfg, state)
 	final, err := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion()).Run()
 	if err != nil {
-		return startMenuActionExit, cfg, err
+		return startMenuResult{Action: startMenuActionExit, Config: cfg, State: state}, err
 	}
 
 	menu, ok := final.(startMenuModel)
 	if !ok {
-		return startMenuActionExit, cfg, fmt.Errorf("unexpected start menu result type %T", final)
+		return startMenuResult{Action: startMenuActionExit, Config: cfg, State: state}, fmt.Errorf("unexpected start menu result type %T", final)
 	}
 	if menu.cancelled {
-		return startMenuActionExit, menu.config, nil
+		return startMenuResult{
+			Action: startMenuActionExit,
+			Config: menu.config,
+			State:  menu.state,
+		}, nil
 	}
-	return menu.action, menu.config, nil
+	return menu.result, nil
 }
 
-func newStartMenuModel(cfg app.Config) startMenuModel {
+func newStartMenuModel(cfg app.Config, state startMenuState) startMenuModel {
 	normalized := cloneConfig(cfg)
 	if normalized.Roles == nil {
 		normalized.Roles = make(map[domain.RoleID]app.RoleConfig)
@@ -59,11 +105,23 @@ func newStartMenuModel(cfg app.Config) startMenuModel {
 	if !slices.Contains(availableScenarios, normalized.ScenarioID) {
 		normalized.ScenarioID = availableScenarios[0]
 	}
+	state.clampSelections()
+
+	status := state.StatusText
+	if strings.TrimSpace(status) == "" {
+		status = "Use up/down to move, left/right to change menu selections, and enter to confirm."
+	}
 
 	return startMenuModel{
 		config:     normalized,
 		scenarios:  availableScenarios,
-		statusLine: "Use up/down to move, left/right or enter to change settings, and enter on Start Game to launch.",
+		state:      state,
+		statusLine: status,
+		result: startMenuResult{
+			Action: startMenuActionExit,
+			Config: normalized,
+			State:  state,
+		},
 	}
 }
 
@@ -81,7 +139,11 @@ func (m startMenuModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch typed.String() {
 		case "ctrl+c", "esc", "q":
 			m.cancelled = true
-			m.action = startMenuActionExit
+			m.result = startMenuResult{
+				Action: startMenuActionExit,
+				Config: m.config,
+				State:  m.state,
+			}
 			return m, tea.Quit
 		case "up", "k":
 			m.moveCursor(-1)
@@ -109,16 +171,19 @@ func (m startMenuModel) View() string {
 	itemStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("250"))
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
 	statusStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("223"))
+	disabledStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 
 	lines := []string{
 		titleStyle.Render("HerbieGo Start Menu"),
-		subtitleStyle.Render("Set the launch configuration, then start a match or exit."),
+		subtitleStyle.Render("Start a new match, resume the current session, or browse SQL-backed save slots."),
 		"",
 	}
 
 	for index, item := range m.items() {
-		line := fmt.Sprintf("  %s", item.label)
-		if index == m.cursor {
+		line := "  " + item.label
+		if !item.enabled {
+			line = disabledStyle.Render(line)
+		} else if index == m.cursor {
 			line = selectedStyle.Render("> " + item.label)
 		} else {
 			line = itemStyle.Render(line)
@@ -134,7 +199,7 @@ func (m startMenuModel) View() string {
 
 	width := m.width
 	if width <= 0 {
-		width = 96
+		width = 112
 	}
 
 	return lipgloss.NewStyle().
@@ -164,17 +229,35 @@ func (m *startMenuModel) adjustSelected(delta int) {
 		m.shiftScenario(delta)
 	case menuItemRole:
 		m.toggleRoleControl(item.roleID)
+	case menuItemLoadGame:
+		m.shiftLoadSelection(delta)
+	case menuItemSaveGame:
+		m.shiftSaveSelection(delta)
 	}
 }
 
 func (m *startMenuModel) activateSelected() bool {
 	item := m.items()[m.cursor]
+	if !item.enabled {
+		m.statusLine = item.disabledHint
+		return false
+	}
+
 	switch item.kind {
-	case menuItemStartGame:
-		m.action = startMenuActionStartGame
+	case menuItemStartNewGame:
+		m.result = startMenuResult{Action: startMenuActionStartNewGame, Config: m.config, State: m.state}
+		return true
+	case menuItemResumeGame:
+		m.result = startMenuResult{Action: startMenuActionResumeGame, Config: m.config, State: m.state}
+		return true
+	case menuItemLoadGame:
+		m.result = startMenuResult{Action: startMenuActionLoadGame, Config: m.config, State: m.state, SlotName: m.selectedLoadSlotName()}
+		return true
+	case menuItemSaveGame:
+		m.result = startMenuResult{Action: startMenuActionSaveGame, Config: m.config, State: m.state, SlotName: m.selectedSaveSlotName()}
 		return true
 	case menuItemExit:
-		m.action = startMenuActionExit
+		m.result = startMenuResult{Action: startMenuActionExit, Config: m.config, State: m.state}
 		return true
 	case menuItemScenario:
 		m.shiftScenario(1)
@@ -215,33 +298,99 @@ func (m *startMenuModel) toggleRoleControl(roleID domain.RoleID) {
 	m.statusLine = fmt.Sprintf("%s is now %s-controlled.", displayRoleName(roleID), roleControlLabel(roleCfg))
 }
 
+func (m *startMenuModel) shiftLoadSelection(delta int) {
+	if len(m.state.SaveSlots) == 0 {
+		m.statusLine = "No saved games are available yet."
+		return
+	}
+	count := len(m.state.SaveSlots)
+	m.state.SelectedLoadIndex = (m.state.SelectedLoadIndex + delta + count) % count
+	slot := m.state.SaveSlots[m.state.SelectedLoadIndex]
+	m.statusLine = fmt.Sprintf("Selected save slot %s at round %d.", slot.SlotName, slot.CurrentRound)
+}
+
+func (m *startMenuModel) shiftSaveSelection(delta int) {
+	choiceCount := len(m.state.SaveSlots) + 1
+	if choiceCount <= 0 {
+		return
+	}
+	m.state.SelectedSaveIndex = (m.state.SelectedSaveIndex + delta + choiceCount) % choiceCount
+	if slotName := m.selectedSaveSlotName(); slotName != "" {
+		m.statusLine = fmt.Sprintf("Save target set to slot %s.", slotName)
+		return
+	}
+	m.statusLine = "Save target set to a new slot."
+}
+
+func (m startMenuModel) selectedLoadSlotName() string {
+	if len(m.state.SaveSlots) == 0 {
+		return ""
+	}
+	return m.state.SaveSlots[m.state.SelectedLoadIndex].SlotName
+}
+
+func (m startMenuModel) selectedSaveSlotName() string {
+	if len(m.state.SaveSlots) == 0 || m.state.SelectedSaveIndex >= len(m.state.SaveSlots) {
+		return ""
+	}
+	return m.state.SaveSlots[m.state.SelectedSaveIndex].SlotName
+}
+
 type menuItemKind int
 
 const (
-	menuItemStartGame menuItemKind = iota
+	menuItemStartNewGame menuItemKind = iota
+	menuItemResumeGame
+	menuItemLoadGame
+	menuItemSaveGame
 	menuItemScenario
 	menuItemRole
 	menuItemExit
 )
 
 type menuItem struct {
-	kind   menuItemKind
-	title  string
-	label  string
-	roleID domain.RoleID
+	kind         menuItemKind
+	title        string
+	label        string
+	roleID       domain.RoleID
+	enabled      bool
+	disabledHint string
 }
 
 func (m startMenuModel) items() []menuItem {
 	items := []menuItem{
 		{
-			kind:  menuItemStartGame,
-			title: "Start Game",
-			label: "Start Game",
+			kind:    menuItemStartNewGame,
+			title:   "Start New Game",
+			label:   m.startGameLabel(),
+			enabled: true,
 		},
 		{
-			kind:  menuItemScenario,
-			title: "Scenario",
-			label: fmt.Sprintf("Scenario: %s", scenarioTitle(m.config.ScenarioID)),
+			kind:         menuItemResumeGame,
+			title:        "Resume Current Game",
+			label:        m.resumeGameLabel(),
+			enabled:      m.state.ActiveSession != nil,
+			disabledHint: "No current session is available yet.",
+		},
+		{
+			kind:         menuItemLoadGame,
+			title:        "Load Saved Game",
+			label:        m.loadGameLabel(),
+			enabled:      m.state.StoreEnabled && len(m.state.SaveSlots) > 0,
+			disabledHint: m.loadDisabledHint(),
+		},
+		{
+			kind:         menuItemSaveGame,
+			title:        "Save Current Game",
+			label:        m.saveGameLabel(),
+			enabled:      m.state.StoreEnabled && m.state.ActiveSession != nil,
+			disabledHint: m.saveDisabledHint(),
+		},
+		{
+			kind:    menuItemScenario,
+			title:   "Scenario",
+			label:   fmt.Sprintf("Scenario: %s", scenarioTitle(m.config.ScenarioID)),
+			enabled: true,
 		},
 	}
 
@@ -251,19 +400,74 @@ func (m startMenuModel) items() []menuItem {
 			roleCfg = defaultRoleConfig(m.config)
 		}
 		items = append(items, menuItem{
-			kind:   menuItemRole,
-			title:  displayRoleName(roleID),
-			label:  fmt.Sprintf("%s: %s", displayRoleName(roleID), roleControlLabel(roleCfg)),
-			roleID: roleID,
+			kind:    menuItemRole,
+			title:   displayRoleName(roleID),
+			label:   fmt.Sprintf("%s: %s", displayRoleName(roleID), roleControlLabel(roleCfg)),
+			roleID:  roleID,
+			enabled: true,
 		})
 	}
 
 	items = append(items, menuItem{
-		kind:  menuItemExit,
-		title: "Exit",
-		label: "Exit",
+		kind:    menuItemExit,
+		title:   "Exit",
+		label:   "Exit",
+		enabled: true,
 	})
 	return items
+}
+
+func (m startMenuModel) startGameLabel() string {
+	if m.state.ActiveSession == nil {
+		return "Start Game"
+	}
+	return "Start New Game"
+}
+
+func (m startMenuModel) resumeGameLabel() string {
+	if m.state.ActiveSession == nil {
+		return "Resume Current Game: unavailable"
+	}
+	state := m.state.ActiveSession.state
+	return fmt.Sprintf("Resume Current Game: %s round %d cash %d", scenarioTitle(state.ScenarioID), state.CurrentRound, state.Plant.Cash)
+}
+
+func (m startMenuModel) loadGameLabel() string {
+	if !m.state.StoreEnabled {
+		return "Load Saved Game: requires -sqlite-db"
+	}
+	if len(m.state.SaveSlots) == 0 {
+		return "Load Saved Game: no saved games"
+	}
+	slot := m.state.SaveSlots[m.state.SelectedLoadIndex]
+	return fmt.Sprintf("Load Saved Game: %s | %s | round %d | cash %d", slot.SlotName, scenarioTitle(slot.ScenarioID), slot.CurrentRound, slot.Cash)
+}
+
+func (m startMenuModel) saveGameLabel() string {
+	if !m.state.StoreEnabled {
+		return "Save Current Game: requires -sqlite-db"
+	}
+	if m.state.ActiveSession == nil {
+		return "Save Current Game: unavailable until a session exists"
+	}
+	if slotName := m.selectedSaveSlotName(); slotName != "" {
+		return fmt.Sprintf("Save Current Game: overwrite slot %s", slotName)
+	}
+	return "Save Current Game: create new slot"
+}
+
+func (m startMenuModel) loadDisabledHint() string {
+	if !m.state.StoreEnabled {
+		return "Load saved game requires -sqlite-db."
+	}
+	return "No saved games are available yet."
+}
+
+func (m startMenuModel) saveDisabledHint() string {
+	if !m.state.StoreEnabled {
+		return "Save current game requires -sqlite-db."
+	}
+	return "Return from gameplay first so there is a current session to save."
 }
 
 func selectedScenarioRoster(scenarioID domain.ScenarioID) []domain.RoleID {

--- a/cmd/herbiego/start_menu_test.go
+++ b/cmd/herbiego/start_menu_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jpconstantineau/herbiego/internal/app"
@@ -24,6 +26,34 @@ func TestSplashModelFinishesAfterLastFrame(t *testing.T) {
 	model = next.(splashModel)
 	if !model.finished {
 		t.Fatal("splash model did not finish on the last animation frame")
+	}
+}
+
+func TestSplashFrameDelayDefaultsToThreeSecondsAcrossFrames(t *testing.T) {
+	got := splashFrameDelayForFrameCount(len(herbieSplashFrames()))
+	want := 500 * time.Millisecond
+	if got != want {
+		t.Fatalf("splashFrameDelayForFrameCount() = %v, want %v", got, want)
+	}
+}
+
+func TestSplashFrameRendersExpectedCanvasHeight(t *testing.T) {
+	frame := renderHerbieSplashFrame(2)
+	lines := strings.Split(frame, "\n")
+	if len(lines) != splashCanvasHeight {
+		t.Fatalf("renderHerbieSplashFrame() line count = %d, want %d", len(lines), splashCanvasHeight)
+	}
+}
+
+func TestSplashFramesKeepStableVisibleWidth(t *testing.T) {
+	widths := splashFrameVisibleWidths()
+	if len(widths) == 0 {
+		t.Fatal("splashFrameVisibleWidths() returned no frame widths")
+	}
+	for _, width := range widths[1:] {
+		if width != widths[0] {
+			t.Fatalf("splash frame widths = %v, want all frames to share one visible width", widths)
+		}
 	}
 }
 

--- a/cmd/herbiego/start_menu_test.go
+++ b/cmd/herbiego/start_menu_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jpconstantineau/herbiego/internal/adapters/persistence/sqlite"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
 	"github.com/jpconstantineau/herbiego/internal/scenario"
@@ -57,10 +58,16 @@ func TestSplashFramesKeepStableVisibleWidth(t *testing.T) {
 	}
 }
 
-func TestStartMenuCanToggleRoleAndLaunch(t *testing.T) {
-	model := newStartMenuModel(testMenuConfig())
+func TestStartMenuCanToggleRoleAndStartNewGame(t *testing.T) {
+	model := newStartMenuModel(testMenuConfig(), startMenuState{})
 
 	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = next.(startMenuModel)
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = next.(startMenuModel)
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = next.(startMenuModel)
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
 	model = next.(startMenuModel)
 	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
 	model = next.(startMenuModel)
@@ -75,8 +82,8 @@ func TestStartMenuCanToggleRoleAndLaunch(t *testing.T) {
 	model.cursor = 0
 	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = next.(startMenuModel)
-	if model.action != startMenuActionStartGame {
-		t.Fatalf("menu action = %v, want start game", model.action)
+	if model.result.Action != startMenuActionStartNewGame {
+		t.Fatalf("menu action = %v, want start new game", model.result.Action)
 	}
 }
 
@@ -126,13 +133,60 @@ func TestStartMenuCanSwitchScenarios(t *testing.T) {
 		}
 	}
 
-	model := newStartMenuModel(testMenuConfig())
-	model.cursor = 1
+	model := newStartMenuModel(testMenuConfig(), startMenuState{})
+	model.cursor = 4
 
 	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyRight})
 	model = next.(startMenuModel)
 	if model.config.ScenarioID == scenario.StarterID {
 		t.Fatalf("scenario id = %q, want scenario selection to advance", model.config.ScenarioID)
+	}
+}
+
+func TestStartMenuCanSelectSaveAndLoadSlots(t *testing.T) {
+	session := &activeSession{
+		state: domain.MatchState{
+			MatchID:      "match-7",
+			ScenarioID:   scenario.StarterID,
+			CurrentRound: 3,
+			Plant:        domain.PlantState{Cash: 42},
+		},
+	}
+	state := startMenuState{
+		ActiveSession: session,
+		StoreEnabled:  true,
+		SaveSlots: []sqlite.SaveSlotSummary{
+			{SlotName: "slot-a", MatchID: "match-a", ScenarioID: scenario.StarterID, CurrentRound: 2, Cash: 20, SavedAt: time.Now()},
+			{SlotName: "slot-b", MatchID: "match-b", ScenarioID: scenario.StarterID, CurrentRound: 4, Cash: 33, SavedAt: time.Now()},
+		},
+	}
+	model := newStartMenuModel(testMenuConfig(), state)
+
+	model.cursor = 2
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyRight})
+	model = next.(startMenuModel)
+	if model.state.SelectedLoadIndex != 1 {
+		t.Fatalf("SelectedLoadIndex = %d, want 1", model.state.SelectedLoadIndex)
+	}
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(startMenuModel)
+	if model.result.Action != startMenuActionLoadGame || model.result.SlotName != "slot-b" {
+		t.Fatalf("load result = %#v, want slot-b load action", model.result)
+	}
+
+	model = newStartMenuModel(testMenuConfig(), state)
+	model.cursor = 3
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyRight})
+	model = next.(startMenuModel)
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyRight})
+	model = next.(startMenuModel)
+	if model.selectedSaveSlotName() != "" {
+		t.Fatalf("selectedSaveSlotName() = %q, want empty for new-slot target", model.selectedSaveSlotName())
+	}
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(startMenuModel)
+	if model.result.Action != startMenuActionSaveGame || model.result.SlotName != "" {
+		t.Fatalf("save result = %#v, want new-slot save action", model.result)
 	}
 }
 

--- a/cmd/herbiego/start_menu_test.go
+++ b/cmd/herbiego/start_menu_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func TestSplashModelFinishesAfterLastFrame(t *testing.T) {
+	model := splashModel{}
+
+	for i := 0; i < len(herbieSplashFrames())-1; i++ {
+		next, _ := model.Update(splashTickMsg{})
+		model = next.(splashModel)
+		if model.finished {
+			t.Fatalf("frame %d finished early", i)
+		}
+	}
+
+	next, _ := model.Update(splashTickMsg{})
+	model = next.(splashModel)
+	if !model.finished {
+		t.Fatal("splash model did not finish on the last animation frame")
+	}
+}
+
+func TestStartMenuCanToggleRoleAndLaunch(t *testing.T) {
+	model := newStartMenuModel(testMenuConfig())
+
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = next.(startMenuModel)
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = next.(startMenuModel)
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(startMenuModel)
+
+	roleCfg := model.config.Roles[domain.RoleProcurementManager]
+	if roleCfg.Kind != app.PlayerKindHuman {
+		t.Fatalf("procurement role kind = %q, want human after toggle", roleCfg.Kind)
+	}
+
+	model.cursor = 0
+	next, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(startMenuModel)
+	if model.action != startMenuActionStartGame {
+		t.Fatalf("menu action = %v, want start game", model.action)
+	}
+}
+
+func TestStartMenuCanSwitchScenarios(t *testing.T) {
+	const scenarioID = domain.ScenarioID("menu-test-scenario")
+	if _, exists := scenario.Lookup(scenarioID); !exists {
+		err := scenario.Register(scenario.NewDefinition(
+			scenarioID,
+			"Menu Test Scenario",
+			"Verifies the start menu can switch between registered scenarios.",
+			scenario.MatchSetup{
+				ID:          "single-role",
+				DisplayName: "Single Role",
+				RoleRoster:  []domain.RoleID{domain.RoleSalesManager},
+			},
+			scenario.StartingConditions{
+				ID:          "start",
+				DisplayName: "Start",
+				StartingTargets: domain.BudgetTargets{
+					EffectiveRound:        1,
+					RevenueTarget:         10,
+					ProcurementBudget:     1,
+					ProductionSpendBudget: 1,
+					CashFloorTarget:       1,
+					DebtCeilingTarget:     1,
+				},
+			},
+			scenario.MarketModel{
+				ID:                "market",
+				DisplayName:       "Market",
+				DemandAssumptions: scenario.DemandAssumptions{BacklogExpiryRounds: 1},
+			},
+			scenario.ProductionModel{
+				ID:          "production",
+				DisplayName: "Production",
+			},
+			scenario.FinanceModel{
+				ID:                    "finance",
+				DisplayName:           "Finance",
+				ReceivableDelayRounds: 1,
+				PayableDelayRounds:    1,
+				PayrollDelayRounds:    1,
+			},
+		))
+		if err != nil {
+			t.Fatalf("scenario.Register() error = %v", err)
+		}
+	}
+
+	model := newStartMenuModel(testMenuConfig())
+	model.cursor = 1
+
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyRight})
+	model = next.(startMenuModel)
+	if model.config.ScenarioID == scenario.StarterID {
+		t.Fatalf("scenario id = %q, want scenario selection to advance", model.config.ScenarioID)
+	}
+}
+
+func testMenuConfig() app.Config {
+	return app.Config{
+		Environment: "test",
+		ScenarioID:  scenario.StarterID,
+		LLMCatalog: app.LLMCatalog{
+			Entries: []app.LLMCatalogEntry{
+				{Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: app.APISDKTypeOpenAI},
+			},
+		},
+		Roles: map[domain.RoleID]app.RoleConfig{
+			domain.RoleProcurementManager: {Kind: app.PlayerKindAI, Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: app.APISDKTypeOpenAI},
+			domain.RoleProductionManager:  {Kind: app.PlayerKindAI, Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: app.APISDKTypeOpenAI},
+			domain.RoleSalesManager:       {Kind: app.PlayerKindAI, Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: app.APISDKTypeOpenAI},
+			domain.RoleFinanceController:  {Kind: app.PlayerKindAI, Provider: "openrouter", Model: "openai/gpt-5-mini", URL: "https://openrouter.ai/api/v1/", APISDKType: app.APISDKTypeOpenAI},
+		},
+	}
+}

--- a/internal/adapters/persistence/sqlite/store.go
+++ b/internal/adapters/persistence/sqlite/store.go
@@ -13,9 +13,20 @@ import (
 	"github.com/jpconstantineau/herbiego/internal/ports"
 )
 
+var ErrSaveSlotNotFound = errors.New("save slot not found")
+
 type Options struct {
 	Path               string
 	RecentHistoryLimit int
+}
+
+type SaveSlotSummary struct {
+	SlotName     string
+	MatchID      domain.MatchID
+	ScenarioID   domain.ScenarioID
+	CurrentRound domain.RoundNumber
+	Cash         domain.Money
+	SavedAt      time.Time
 }
 
 type Store struct {
@@ -383,6 +394,112 @@ func (s *Store) StateSnapshots(matchID domain.MatchID) ([]domain.MatchState, err
 	return snapshots, nil
 }
 
+func (s *Store) SaveSlot(slotName string, matchID domain.MatchID) (SaveSlotSummary, error) {
+	if slotName == "" {
+		return SaveSlotSummary{}, errors.New("sqlite store: save slot name must not be empty")
+	}
+	state, err := s.CurrentState(matchID)
+	if err != nil {
+		return SaveSlotSummary{}, err
+	}
+
+	now := time.Now().UTC()
+	if _, err := s.db.Exec(`
+		INSERT INTO save_slots(slot_name, match_id, scenario_id, current_round, cash, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(slot_name) DO UPDATE SET
+			match_id = excluded.match_id,
+			scenario_id = excluded.scenario_id,
+			current_round = excluded.current_round,
+			cash = excluded.cash,
+			updated_at = excluded.updated_at
+	`, slotName, matchID, state.ScenarioID, state.CurrentRound, state.Plant.Cash, now.Format(time.RFC3339Nano), now.Format(time.RFC3339Nano)); err != nil {
+		return SaveSlotSummary{}, fmt.Errorf("sqlite store: save slot %q: %w", slotName, err)
+	}
+
+	return SaveSlotSummary{
+		SlotName:     slotName,
+		MatchID:      matchID,
+		ScenarioID:   state.ScenarioID,
+		CurrentRound: state.CurrentRound,
+		Cash:         state.Plant.Cash,
+		SavedAt:      now,
+	}, nil
+}
+
+func (s *Store) ListSaveSlots() ([]SaveSlotSummary, error) {
+	rows, err := s.db.Query(`
+		SELECT slot_name, match_id, scenario_id, current_round, cash, updated_at
+		FROM save_slots
+		ORDER BY updated_at DESC, slot_name ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite store: query save slots: %w", err)
+	}
+	defer rows.Close()
+
+	var slots []SaveSlotSummary
+	for rows.Next() {
+		var (
+			slot       SaveSlotSummary
+			updatedAt  string
+			roundValue int
+			cashValue  int
+		)
+		if err := rows.Scan(&slot.SlotName, &slot.MatchID, &slot.ScenarioID, &roundValue, &cashValue, &updatedAt); err != nil {
+			return nil, fmt.Errorf("sqlite store: scan save slot: %w", err)
+		}
+		slot.CurrentRound = domain.RoundNumber(roundValue)
+		slot.Cash = domain.Money(cashValue)
+		slot.SavedAt, err = time.Parse(time.RFC3339Nano, updatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite store: parse save slot time: %w", err)
+		}
+		slots = append(slots, slot)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite store: iterate save slots: %w", err)
+	}
+	return slots, nil
+}
+
+func (s *Store) LoadSaveSlot(slotName string) (domain.MatchState, SaveSlotSummary, error) {
+	if slotName == "" {
+		return domain.MatchState{}, SaveSlotSummary{}, errors.New("sqlite store: save slot name must not be empty")
+	}
+
+	var (
+		summary    SaveSlotSummary
+		updatedAt  string
+		roundValue int
+		cashValue  int
+	)
+	err := s.db.QueryRow(`
+		SELECT slot_name, match_id, scenario_id, current_round, cash, updated_at
+		FROM save_slots
+		WHERE slot_name = ?
+	`, slotName).Scan(&summary.SlotName, &summary.MatchID, &summary.ScenarioID, &roundValue, &cashValue, &updatedAt)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return domain.MatchState{}, SaveSlotSummary{}, ErrSaveSlotNotFound
+	case err != nil:
+		return domain.MatchState{}, SaveSlotSummary{}, fmt.Errorf("sqlite store: load save slot %q: %w", slotName, err)
+	}
+
+	summary.CurrentRound = domain.RoundNumber(roundValue)
+	summary.Cash = domain.Money(cashValue)
+	summary.SavedAt, err = time.Parse(time.RFC3339Nano, updatedAt)
+	if err != nil {
+		return domain.MatchState{}, SaveSlotSummary{}, fmt.Errorf("sqlite store: parse save slot time: %w", err)
+	}
+
+	state, err := s.CurrentState(summary.MatchID)
+	if err != nil {
+		return domain.MatchState{}, SaveSlotSummary{}, err
+	}
+	return state, summary, nil
+}
+
 func (s *Store) initSchema() error {
 	if _, err := s.db.Exec(`
 		PRAGMA foreign_keys = ON;
@@ -419,6 +536,15 @@ func (s *Store) initSchema() error {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			match_id TEXT NOT NULL,
 			record_json TEXT NOT NULL
+		);
+		CREATE TABLE IF NOT EXISTS save_slots (
+			slot_name TEXT PRIMARY KEY,
+			match_id TEXT NOT NULL,
+			scenario_id TEXT NOT NULL,
+			current_round INTEGER NOT NULL,
+			cash INTEGER NOT NULL,
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
 		);
 	`); err != nil {
 		return fmt.Errorf("sqlite store: initialize schema: %w", err)

--- a/internal/adapters/persistence/sqlite/store_test.go
+++ b/internal/adapters/persistence/sqlite/store_test.go
@@ -198,6 +198,49 @@ func TestStorePersistsStateSnapshotsAcrossRounds(t *testing.T) {
 	}
 }
 
+func TestStoreCanSaveAndLoadNamedSlots(t *testing.T) {
+	store := newStore(t)
+	initial := domain.MatchState{
+		MatchID:      "match-5",
+		ScenarioID:   "starter",
+		CurrentRound: 3,
+		Plant:        domain.PlantState{Cash: 41},
+	}
+	if err := store.CreateMatch(initial); err != nil {
+		t.Fatalf("CreateMatch() error = %v", err)
+	}
+
+	summary, err := store.SaveSlot("starter-slot", initial.MatchID)
+	if err != nil {
+		t.Fatalf("SaveSlot() error = %v", err)
+	}
+	if summary.MatchID != initial.MatchID {
+		t.Fatalf("SaveSlot() match id = %q, want %q", summary.MatchID, initial.MatchID)
+	}
+
+	slots, err := store.ListSaveSlots()
+	if err != nil {
+		t.Fatalf("ListSaveSlots() error = %v", err)
+	}
+	if len(slots) != 1 {
+		t.Fatalf("ListSaveSlots len = %d, want 1", len(slots))
+	}
+	if slots[0].SlotName != "starter-slot" {
+		t.Fatalf("ListSaveSlots slot name = %q, want starter-slot", slots[0].SlotName)
+	}
+
+	state, loaded, err := store.LoadSaveSlot("starter-slot")
+	if err != nil {
+		t.Fatalf("LoadSaveSlot() error = %v", err)
+	}
+	if state.MatchID != initial.MatchID {
+		t.Fatalf("LoadSaveSlot() match id = %q, want %q", state.MatchID, initial.MatchID)
+	}
+	if loaded.CurrentRound != 3 {
+		t.Fatalf("LoadSaveSlot() round = %d, want 3", loaded.CurrentRound)
+	}
+}
+
 func newStore(t *testing.T) *sqlite.Store {
 	t.Helper()
 

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -60,6 +60,22 @@ type StatusMsg struct {
 
 type SubmitFunc func(domain.ActionSubmission) error
 
+// ExitIntent records why the gameplay shell exited.
+type ExitIntent string
+
+const (
+	ExitIntentQuit         ExitIntent = "quit"
+	ExitIntentReturnToMenu ExitIntent = "return_to_menu"
+)
+
+// QuitBehavior controls what pressing q does inside the gameplay shell.
+type QuitBehavior int
+
+const (
+	QuitBehaviorQuitProgram QuitBehavior = iota
+	QuitBehaviorReturnToMenu
+)
+
 // Model is the Bubble Tea shell for the round-based gameplay UI.
 type Model struct {
 	scenario      ScenarioReader
@@ -83,6 +99,8 @@ type Model struct {
 	debugExpanded map[string]bool
 	drafts        map[domain.RoleID]actionDraft
 	lookup        lookupBrowserState
+	quitBehavior  QuitBehavior
+	exitIntent    ExitIntent
 }
 
 // NewModel constructs the main gameplay shell model.
@@ -93,6 +111,12 @@ func NewModel(definition ScenarioReader, source StateSource) Model {
 // NewModelWithSubmit constructs the gameplay shell with an optional live
 // submission hook for forwarding locked human actions into the shared runner.
 func NewModelWithSubmit(definition ScenarioReader, source StateSource, submit SubmitFunc) Model {
+	return NewModelWithSubmitAndQuitBehavior(definition, source, submit, QuitBehaviorQuitProgram)
+}
+
+// NewModelWithSubmitAndQuitBehavior constructs the gameplay shell with a
+// configurable q-key behavior.
+func NewModelWithSubmitAndQuitBehavior(definition ScenarioReader, source StateSource, submit SubmitFunc, quitBehavior QuitBehavior) Model {
 	return Model{
 		scenario:      definition,
 		source:        source,
@@ -102,6 +126,8 @@ func NewModelWithSubmit(definition ScenarioReader, source StateSource, submit Su
 		status:        "Loading round state...",
 		drafts:        make(map[domain.RoleID]actionDraft),
 		debugExpanded: make(map[string]bool),
+		quitBehavior:  quitBehavior,
+		exitIntent:    ExitIntentQuit,
 	}
 }
 
@@ -128,7 +154,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		switch typed.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c":
+			m.exitIntent = ExitIntentQuit
+			return m, tea.Quit
+		case "q":
+			if m.quitBehavior == QuitBehaviorReturnToMenu {
+				m.exitIntent = ExitIntentReturnToMenu
+				m.status = "Returning to the start menu..."
+				return m, tea.Quit
+			}
+			m.exitIntent = ExitIntentQuit
 			return m, tea.Quit
 		case "tab":
 			m.focusedPane = (m.focusedPane + 1) % 4
@@ -255,6 +290,11 @@ func (m Model) View() string {
 		m.renderContentArea(layout, width, contentHeight),
 		m.renderCommandBar(commandWidth, commandHeight),
 	)
+}
+
+// ExitIntent reports whether the shell exited back to the menu or quit fully.
+func (m Model) ExitIntent() ExitIntent {
+	return m.exitIntent
 }
 
 func loadSnapshotCmd(source StateSource) tea.Cmd {

--- a/internal/adapters/tui/navigation_test.go
+++ b/internal/adapters/tui/navigation_test.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func TestModelQReturnsToMenuWhenConfigured(t *testing.T) {
+	initial := scenario.Starter().InitialState("starter-match", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", Provider: "ollama", ModelName: "gemma"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", Provider: "ollama", ModelName: "gemma"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "ollama", ModelName: "gemma"},
+	})
+
+	model := NewModelWithSubmitAndQuitBehavior(scenario.Starter(), testStateSource{snapshot: initial}, nil, QuitBehaviorReturnToMenu)
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	updated := next.(Model)
+
+	if updated.ExitIntent() != ExitIntentReturnToMenu {
+		t.Fatalf("ExitIntent() = %q, want %q", updated.ExitIntent(), ExitIntentReturnToMenu)
+	}
+}
+
+func TestModelQQuitsProgramByDefault(t *testing.T) {
+	initial := scenario.Starter().InitialState("starter-match", []domain.RoleAssignment{
+		{RoleID: domain.RoleProcurementManager, PlayerID: "procurement-player", IsHuman: true},
+		{RoleID: domain.RoleProductionManager, PlayerID: "production-player", Provider: "ollama", ModelName: "gemma"},
+		{RoleID: domain.RoleSalesManager, PlayerID: "sales-player", Provider: "ollama", ModelName: "gemma"},
+		{RoleID: domain.RoleFinanceController, PlayerID: "finance-player", Provider: "ollama", ModelName: "gemma"},
+	})
+
+	model := NewModelWithSubmit(scenario.Starter(), testStateSource{snapshot: initial}, nil)
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	updated := next.(Model)
+
+	if updated.ExitIntent() != ExitIntentQuit {
+		t.Fatalf("ExitIntent() = %q, want %q", updated.ExitIntent(), ExitIntentQuit)
+	}
+}

--- a/internal/adapters/tui/run.go
+++ b/internal/adapters/tui/run.go
@@ -19,12 +19,18 @@ func RunReplay(definition ScenarioReader, current domain.MatchState, snapshots [
 	return err
 }
 
-// NewProgram constructs the Bubble Tea program for the supplied match source.
-func NewProgram(definition ScenarioReader, source StateSource, submit SubmitFunc, debug DebugSource, options ...tea.ProgramOption) *tea.Program {
+// NewProgramWithQuitBehavior constructs the Bubble Tea program for the supplied
+// match source and q-key behavior.
+func NewProgramWithQuitBehavior(definition ScenarioReader, source StateSource, submit SubmitFunc, debug DebugSource, quitBehavior QuitBehavior, options ...tea.ProgramOption) *tea.Program {
 	opts := append([]tea.ProgramOption{tea.WithMouseCellMotion()}, options...)
-	model := NewModelWithSubmit(definition, source, submit)
+	model := NewModelWithSubmitAndQuitBehavior(definition, source, submit, quitBehavior)
 	model.debugLog = debug
 	return tea.NewProgram(model, opts...)
+}
+
+// NewProgram constructs the Bubble Tea program for the supplied match source.
+func NewProgram(definition ScenarioReader, source StateSource, submit SubmitFunc, debug DebugSource, options ...tea.ProgramOption) *tea.Program {
+	return NewProgramWithQuitBehavior(definition, source, submit, debug, QuitBehaviorQuitProgram, options...)
 }
 
 // RunWithSource launches the Bubble Tea shell for a live or static match source.


### PR DESCRIPTION
## Summary
- add a launch-time Herbie splash screen followed by a start menu loop
- let the start menu choose the active scenario and toggle each role between human and AI control before starting a new match
- change gameplay `q` handling to return to the start menu instead of exiting the whole process
- add SQL-backed named save slots plus menu-driven save, load, and resume flows

## Testing
- `go test ./...`

Closes #243
Closes #245
Closes #246
Closes #247
Closes #248
Part of #192