### PR TITLE
Unify splash, menu, and gameplay under one app shell

### DIFF
--- a/cmd/herbiego/app_flow.go
+++ b/cmd/herbiego/app_flow.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jpconstantineau/herbiego/internal/adapters/random/seeded"
+	"github.com/jpconstantineau/herbiego/internal/adapters/tui"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/engine"
 	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
 
@@ -17,11 +21,74 @@ type activeSession struct {
 	state   domain.MatchState
 }
 
+type shellScreen int
+
+const (
+	screenSplash shellScreen = iota
+	screenMenu
+	screenGameplay
+)
+
+type gameplayRunnerDoneMsg struct {
+	err error
+}
+
+type gameplayEventsClosedMsg struct{}
+
+type gameplayScreen struct {
+	model      tui.Model
+	controller *liveGameplayController
+	cancel     context.CancelFunc
+	events     <-chan tea.Msg
+}
+
+type appShellModel struct {
+	ctx            context.Context
+	baseRuntime    app.Runtime
+	store          persistentStore
+	rounds         int
+	persistAIDebug bool
+	autoResume     bool
+
+	screen     shellScreen
+	splash     splashModel
+	menu       startMenuModel
+	gameplay   *gameplayScreen
+	menuConfig app.Config
+	menuState  startMenuState
+	current    *activeSession
+
+	fatalErr error
+}
+
 func runApplication(ctx context.Context, baseRuntime app.Runtime, resumedState domain.MatchState, hasResumedState bool, store persistentStore, rounds int, persistAIDebug bool) error {
-	if err := runSplashScreen(); err != nil {
-		return fmt.Errorf("run splash screen: %w", err)
+	model, err := newAppShellModel(ctx, baseRuntime, resumedState, hasResumedState, store, rounds, persistAIDebug)
+	if err != nil {
+		return err
 	}
 
+	program := tea.NewProgram(
+		model,
+		tea.WithAltScreen(),
+		tea.WithMouseCellMotion(),
+		tea.WithContext(ctx),
+	)
+	finalModel, err := program.Run()
+	if err != nil && !errors.Is(err, tea.ErrProgramKilled) {
+		return fmt.Errorf("run app shell: %w", err)
+	}
+
+	switch shell := finalModel.(type) {
+	case appShellModel:
+		return shell.fatalErr
+	case *appShellModel:
+		return shell.fatalErr
+	default:
+		return nil
+	}
+}
+
+func newAppShellModel(ctx context.Context, baseRuntime app.Runtime, resumedState domain.MatchState, hasResumedState bool, store persistentStore, rounds int, persistAIDebug bool) (appShellModel, error) {
 	menuConfig := cloneConfig(baseRuntime.Config)
 	var current *activeSession
 	menuState := startMenuState{
@@ -30,108 +97,344 @@ func runApplication(ctx context.Context, baseRuntime app.Runtime, resumedState d
 	if hasResumedState {
 		current = &activeSession{runtime: baseRuntime, state: resumedState.Clone()}
 	}
+	if err := refreshMenuState(store, current, &menuState); err != nil {
+		return appShellModel{}, err
+	}
 
-	for {
-		if store != nil {
-			slots, err := store.ListSaveSlots()
-			if err != nil {
-				return fmt.Errorf("list save slots: %w", err)
-			}
-			menuState.SaveSlots = slots
-			menuState.clampSelections()
+	return appShellModel{
+		ctx:            ctx,
+		baseRuntime:    baseRuntime,
+		store:          store,
+		rounds:         rounds,
+		persistAIDebug: persistAIDebug,
+		autoResume:     hasResumedState,
+		screen:         screenSplash,
+		splash:         splashModel{},
+		menuConfig:     menuConfig,
+		menuState:      menuState,
+		current:        current,
+	}, nil
+}
+
+func (m appShellModel) Init() tea.Cmd {
+	return m.splash.Init()
+}
+
+func (m appShellModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m.screen {
+	case screenSplash:
+		return m.updateSplash(msg)
+	case screenMenu:
+		return m.updateMenu(msg)
+	case screenGameplay:
+		return m.updateGameplay(msg)
+	default:
+		return m, nil
+	}
+}
+
+func (m appShellModel) View() string {
+	switch m.screen {
+	case screenSplash:
+		return m.splash.View()
+	case screenGameplay:
+		if m.gameplay != nil {
+			return m.gameplay.model.View()
 		}
+		return ""
+	default:
+		return m.menu.View()
+	}
+}
 
-		if hasResumedState && current != nil {
-			exitIntent, latest, err := runLiveGameplay(ctx, current.runtime, current.state, store, rounds, persistAIDebug)
-			if err != nil {
-				return err
-			}
-			current.state = latest.Clone()
-			menuConfig = cloneConfig(current.runtime.Config)
-			hasResumedState = false
-			if exitIntent != gameplayExitToMenu {
-				return nil
-			}
-			menuState.ActiveSession = current
-			menuState.StatusText = currentSessionStatus(current.state)
-			continue
+func (m appShellModel) updateSplash(msg tea.Msg) (tea.Model, tea.Cmd) {
+	next, cmd := m.splash.Update(msg)
+	m.splash = next.(splashModel)
+	if isQuitCmd(cmd) {
+		return m.finishSplash()
+	}
+	return m, cmd
+}
+
+func (m appShellModel) finishSplash() (tea.Model, tea.Cmd) {
+	if m.autoResume && m.current != nil {
+		m.autoResume = false
+		return m.enterGameplay(m.current)
+	}
+	m.screen = screenMenu
+	m.menu = newStartMenuModel(m.menuConfig, m.menuState)
+	return m, m.menu.Init()
+}
+
+func (m appShellModel) updateMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
+	next, cmd := m.menu.Update(msg)
+	m.menu = next.(startMenuModel)
+	if !isQuitCmd(cmd) {
+		return m, cmd
+	}
+
+	result := m.menu.result
+	m.menuConfig = result.Config
+	m.menuState = result.State
+
+	switch result.Action {
+	case startMenuActionExit:
+		return m, tea.Quit
+	case startMenuActionSaveGame:
+		if m.current == nil || m.store == nil {
+			m.menuState.StatusText = "Saving requires an active session and SQLite persistence."
+			m.menu = newStartMenuModel(m.menuConfig, m.menuState)
+			return m, nil
 		}
-
-		menuState.ActiveSession = current
-		result, err := runStartMenu(menuConfig, menuState)
+		slotName := result.SlotName
+		if strings.TrimSpace(slotName) == "" {
+			slotName = defaultSaveSlotName(m.current.state)
+		}
+		summary, err := m.store.SaveSlot(slotName, m.current.state.MatchID)
 		if err != nil {
-			return fmt.Errorf("run start menu: %w", err)
+			m.menuState.StatusText = fmt.Sprintf("Save failed: %v", err)
+		} else {
+			m.menuState.StatusText = fmt.Sprintf("Saved round %d to slot %s.", summary.CurrentRound, summary.SlotName)
 		}
-		menuConfig = result.Config
-		menuState = result.State
-
-		switch result.Action {
-		case startMenuActionExit:
-			return nil
-		case startMenuActionSaveGame:
-			if current == nil || store == nil {
-				menuState.StatusText = "Saving requires an active session and SQLite persistence."
-				continue
-			}
-
-			slotName := result.SlotName
-			if strings.TrimSpace(slotName) == "" {
-				slotName = defaultSaveSlotName(current.state)
-			}
-			summary, err := store.SaveSlot(slotName, current.state.MatchID)
-			if err != nil {
-				menuState.StatusText = fmt.Sprintf("Save failed: %v", err)
-				continue
-			}
-			menuState.StatusText = fmt.Sprintf("Saved round %d to slot %s.", summary.CurrentRound, summary.SlotName)
-			continue
-		case startMenuActionLoadGame:
-			if store == nil {
-				menuState.StatusText = "Load saved game requires -sqlite-db."
-				continue
-			}
-			state, summary, err := store.LoadSaveSlot(result.SlotName)
-			if err != nil {
-				menuState.StatusText = fmt.Sprintf("Load failed: %v", err)
-				continue
-			}
-			runtime, err := runtimeForLoadedState(menuConfig, state)
-			if err != nil {
-				return fmt.Errorf("build runtime for save slot %q: %w", summary.SlotName, err)
-			}
-			current = &activeSession{runtime: runtime, state: state.Clone()}
-		case startMenuActionResumeGame:
-			if current == nil {
-				menuState.StatusText = "No current session is available to resume."
-				continue
-			}
-		case startMenuActionStartNewGame:
-			runtime, err := app.NewRuntime(runtimeConfigFromMenu(menuConfig))
-			if err != nil {
-				menuState.StatusText = fmt.Sprintf("Start failed: %v", err)
-				continue
-			}
-			current = &activeSession{runtime: runtime, state: runtime.InitialMatch.Clone()}
-		default:
-			continue
+		if err := refreshMenuState(m.store, m.current, &m.menuState); err != nil {
+			m.fatalErr = err
+			return m, tea.Quit
 		}
-
-		if current == nil {
-			continue
+		m.menu = newStartMenuModel(m.menuConfig, m.menuState)
+		return m, nil
+	case startMenuActionLoadGame:
+		if m.store == nil {
+			m.menuState.StatusText = "Load saved game requires -sqlite-db."
+			m.menu = newStartMenuModel(m.menuConfig, m.menuState)
+			return m, nil
 		}
-
-		exitIntent, latest, err := runLiveGameplay(ctx, current.runtime, current.state, store, rounds, persistAIDebug)
+		state, summary, err := m.store.LoadSaveSlot(result.SlotName)
 		if err != nil {
-			return err
+			m.menuState.StatusText = fmt.Sprintf("Load failed: %v", err)
+			m.menu = newStartMenuModel(m.menuConfig, m.menuState)
+			return m, nil
 		}
-		current.state = latest.Clone()
-		menuConfig = cloneConfig(current.runtime.Config)
-		menuState.ActiveSession = current
-		menuState.StatusText = currentSessionStatus(current.state)
-		if exitIntent != gameplayExitToMenu {
-			return nil
+		runtime, err := runtimeForLoadedState(m.menuConfig, state)
+		if err != nil {
+			m.fatalErr = fmt.Errorf("build runtime for save slot %q: %w", summary.SlotName, err)
+			return m, tea.Quit
+		}
+		m.current = &activeSession{runtime: runtime, state: state.Clone()}
+		return m.enterGameplay(m.current)
+	case startMenuActionResumeGame:
+		if m.current == nil {
+			m.menuState.StatusText = "No current session is available to resume."
+			m.menu = newStartMenuModel(m.menuConfig, m.menuState)
+			return m, nil
+		}
+		return m.enterGameplay(m.current)
+	case startMenuActionStartNewGame:
+		runtime, err := app.NewRuntime(runtimeConfigFromMenu(m.menuConfig))
+		if err != nil {
+			m.menuState.StatusText = fmt.Sprintf("Start failed: %v", err)
+			m.menu = newStartMenuModel(m.menuConfig, m.menuState)
+			return m, nil
+		}
+		m.current = &activeSession{runtime: runtime, state: runtime.InitialMatch.Clone()}
+		return m.enterGameplay(m.current)
+	default:
+		return m, nil
+	}
+}
+
+func (m appShellModel) updateGameplay(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch typed := msg.(type) {
+	case gameplayRunnerDoneMsg:
+		if m.gameplay == nil {
+			return m, nil
+		}
+		if typed.err != nil && !errors.Is(typed.err, context.Canceled) {
+			m.fatalErr = typed.err
+			return m, tea.Quit
+		}
+		if m.current != nil {
+			m.current.state = m.gameplay.controller.Snapshot()
+		}
+		if m.gameplay != nil && m.gameplay.events != nil {
+			return m, waitForGameplayEvent(m.gameplay.events)
+		}
+		return m, nil
+	case gameplayEventsClosedMsg:
+		return m, nil
+	}
+
+	if m.gameplay == nil {
+		return m, nil
+	}
+
+	next, cmd := m.gameplay.model.Update(msg)
+	m.gameplay.model = next.(tui.Model)
+	if !isQuitCmd(cmd) {
+		return m, cmd
+	}
+
+	switch m.gameplay.model.ExitIntent() {
+	case tui.ExitIntentReturnToMenu:
+		if m.current != nil {
+			m.current.state = m.gameplay.controller.Snapshot()
+			m.menuConfig = cloneConfig(m.current.runtime.Config)
+			m.menuState.StatusText = currentSessionStatus(m.current.state)
+		}
+		if m.gameplay.cancel != nil {
+			m.gameplay.cancel()
+		}
+		m.gameplay = nil
+		if err := refreshMenuState(m.store, m.current, &m.menuState); err != nil {
+			m.fatalErr = err
+			return m, tea.Quit
+		}
+		m.screen = screenMenu
+		m.menu = newStartMenuModel(m.menuConfig, m.menuState)
+		return m, m.menu.Init()
+	default:
+		if m.gameplay.cancel != nil {
+			m.gameplay.cancel()
+		}
+		m.gameplay = nil
+		return m, tea.Quit
+	}
+}
+
+func (m *appShellModel) enterGameplay(session *activeSession) (tea.Model, tea.Cmd) {
+	screen, cmd, err := newGameplayScreen(m.ctx, session.runtime, session.state, m.store, m.rounds, m.persistAIDebug)
+	if err != nil {
+		m.fatalErr = err
+		return m, tea.Quit
+	}
+	m.screen = screenGameplay
+	m.gameplay = screen
+	return m, cmd
+}
+
+func newGameplayScreen(ctx context.Context, runtime app.Runtime, initialState domain.MatchState, store persistentStore, rounds int, persistAIDebug bool) (*gameplayScreen, tea.Cmd, error) {
+	definition, err := resolveScenarioForMatch(initialState)
+	if err != nil {
+		return nil, nil, err
+	}
+	liveLogger := app.NewDiscardLogger()
+
+	stateSnapshots := []domain.MatchState{initialState.Clone()}
+	if store != nil {
+		persistedSnapshots, err := store.StateSnapshots(initialState.MatchID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load persisted state snapshots: %w", err)
+		}
+		stateSnapshots = persistedSnapshots
+	}
+	controller := newLiveGameplayController(initialState, stateSnapshots)
+	players, debugLog, err := buildPlayersWithHumanSubmit(runtime.Config, definition, initialState, controller.SubmitRound, liveLogger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("player setup: %w", err)
+	}
+	if store != nil && persistAIDebug {
+		configureAICallPersistence(debugLog, liveLogger, store, initialState.MatchID)
+	}
+	debugSource := tui.DebugSource(debugLog)
+	if store != nil {
+		debugRecords, err := store.AICallRecords(initialState.MatchID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("load persisted ai traces: %w", err)
+		}
+		debugSource = combinedDebugSource{
+			live:      debugLog,
+			persisted: debugRecords,
 		}
 	}
+
+	gameplayModel := tui.NewModelWithSubmitDebugAndQuitBehavior(
+		definition,
+		controller,
+		controller.Submit,
+		debugSource,
+		tui.QuitBehaviorReturnToMenu,
+	)
+
+	runner := app.MatchRunner{
+		Collector: app.RoundCollector{Players: players, Logger: liveLogger},
+		Resolver:  engine.NewResolver(definition.ResolverOptions()),
+		Random:    runtime.Random,
+		Store:     store,
+		OnState:   controller.Publish,
+		Logger:    liveLogger,
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	events := make(chan tea.Msg, 4)
+	go func() {
+		defer controller.Close()
+		defer close(events)
+
+		final, _, err := runner.Play(runCtx, initialState, rounds)
+		switch {
+		case err == nil:
+			events <- tui.StatusMsg{
+				Text: fmt.Sprintf(
+					"Match complete after round %d. Final cash %d, debt %d, backlog %d, profit %d. Inspect results and press q to return to the menu.",
+					final.CurrentRound-1,
+					final.Plant.Cash,
+					final.Plant.Debt,
+					len(final.Plant.Backlog),
+					final.Metrics.RoundProfit,
+				),
+			}
+		case errors.Is(err, context.Canceled):
+		default:
+			events <- tui.StatusMsg{Text: fmt.Sprintf("Match failed: %v. Press q to return to the menu.", err)}
+		}
+
+		events <- gameplayRunnerDoneMsg{err: err}
+	}()
+
+	screen := &gameplayScreen{
+		model:      gameplayModel,
+		controller: controller,
+		cancel:     cancel,
+		events:     events,
+	}
+	return screen, tea.Batch(gameplayModel.Init(), waitForGameplayEvent(events)), nil
+}
+
+func waitForGameplayEvent(events <-chan tea.Msg) tea.Cmd {
+	if events == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg, ok := <-events
+		if !ok {
+			return gameplayEventsClosedMsg{}
+		}
+		return msg
+	}
+}
+
+func refreshMenuState(store persistentStore, current *activeSession, state *startMenuState) error {
+	if state == nil {
+		return nil
+	}
+	state.ActiveSession = current
+	if current != nil && strings.TrimSpace(state.StatusText) == "" {
+		state.StatusText = currentSessionStatus(current.state)
+	}
+	if store == nil {
+		state.StoreEnabled = false
+		state.SaveSlots = nil
+		state.clampSelections()
+		return nil
+	}
+
+	slots, err := store.ListSaveSlots()
+	if err != nil {
+		return fmt.Errorf("list save slots: %w", err)
+	}
+	state.StoreEnabled = true
+	state.SaveSlots = slots
+	state.clampSelections()
+	return nil
 }
 
 func runtimeConfigFromMenu(cfg app.Config) app.Config {
@@ -189,4 +492,8 @@ func defaultSaveSlotName(state domain.MatchState) string {
 
 func currentSessionStatus(state domain.MatchState) string {
 	return fmt.Sprintf("Current session: %s round %d cash %d.", scenarioTitle(state.ScenarioID), state.CurrentRound, state.Plant.Cash)
+}
+
+func isQuitCmd(cmd tea.Cmd) bool {
+	return fmt.Sprintf("%p", cmd) == fmt.Sprintf("%p", tea.Quit)
 }

--- a/cmd/herbiego/app_flow_test.go
+++ b/cmd/herbiego/app_flow_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jpconstantineau/herbiego/internal/app"
+	"github.com/jpconstantineau/herbiego/internal/domain"
+	"github.com/jpconstantineau/herbiego/internal/scenario"
+)
+
+func TestAppShellTransitionsFromSplashToMenu(t *testing.T) {
+	runtime, err := app.NewRuntime(testMenuConfig())
+	if err != nil {
+		t.Fatalf("NewRuntime() error = %v", err)
+	}
+
+	model, err := newAppShellModel(context.Background(), runtime, domain.MatchState{}, false, nil, 1, false)
+	if err != nil {
+		t.Fatalf("newAppShellModel() error = %v", err)
+	}
+
+	next, _ := model.Update(splashTickMsg{})
+	model = unwrapShellModel(t, next)
+	for model.screen != screenMenu {
+		next, _ = model.Update(splashTickMsg{})
+		model = unwrapShellModel(t, next)
+	}
+
+	if model.screen != screenMenu {
+		t.Fatalf("screen = %v, want screenMenu", model.screen)
+	}
+}
+
+func TestAppShellRoutesStartNewGameIntoGameplay(t *testing.T) {
+	runtime, err := app.NewRuntime(testMenuConfig())
+	if err != nil {
+		t.Fatalf("NewRuntime() error = %v", err)
+	}
+
+	model, err := newAppShellModel(context.Background(), runtime, domain.MatchState{}, false, nil, 1, false)
+	if err != nil {
+		t.Fatalf("newAppShellModel() error = %v", err)
+	}
+
+	model.screen = screenMenu
+	model.menu = newStartMenuModel(model.menuConfig, model.menuState)
+	next, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = unwrapShellModel(t, next)
+
+	if model.screen != screenGameplay {
+		t.Fatalf("screen = %v, want screenGameplay", model.screen)
+	}
+	if model.current == nil {
+		t.Fatal("current session = nil, want active session after starting game")
+	}
+}
+
+func unwrapShellModel(t *testing.T, model tea.Model) appShellModel {
+	t.Helper()
+
+	switch typed := model.(type) {
+	case appShellModel:
+		return typed
+	case *appShellModel:
+		return *typed
+	default:
+		t.Fatalf("unexpected shell model type %T", model)
+		return appShellModel{}
+	}
+}
+
+func TestRuntimeConfigFromMenuFiltersRolesToScenarioRoster(t *testing.T) {
+	const scenarioID = domain.ScenarioID("shell-test-scenario")
+	if _, exists := scenario.Lookup(scenarioID); !exists {
+		err := scenario.Register(scenario.NewDefinition(
+			scenarioID,
+			"Shell Test Scenario",
+			"Verifies runtime config role filtering.",
+			scenario.MatchSetup{
+				ID:          "single-role",
+				DisplayName: "Single Role",
+				RoleRoster:  []domain.RoleID{domain.RoleSalesManager},
+			},
+			scenario.StartingConditions{
+				ID:          "start",
+				DisplayName: "Start",
+				StartingTargets: domain.BudgetTargets{
+					EffectiveRound:        1,
+					RevenueTarget:         10,
+					ProcurementBudget:     1,
+					ProductionSpendBudget: 1,
+					CashFloorTarget:       1,
+					DebtCeilingTarget:     1,
+				},
+			},
+			scenario.MarketModel{
+				ID:                "market",
+				DisplayName:       "Market",
+				DemandAssumptions: scenario.DemandAssumptions{BacklogExpiryRounds: 1},
+			},
+			scenario.ProductionModel{
+				ID:          "production",
+				DisplayName: "Production",
+			},
+			scenario.FinanceModel{
+				ID:                    "finance",
+				DisplayName:           "Finance",
+				ReceivableDelayRounds: 1,
+				PayableDelayRounds:    1,
+				PayrollDelayRounds:    1,
+			},
+		))
+		if err != nil {
+			t.Fatalf("scenario.Register() error = %v", err)
+		}
+	}
+
+	cfg := testMenuConfig()
+	cfg.ScenarioID = scenarioID
+	filtered := runtimeConfigFromMenu(cfg)
+	if len(filtered.Roles) != 1 {
+		t.Fatalf("len(filtered.Roles) = %d, want 1", len(filtered.Roles))
+	}
+	if _, ok := filtered.Roles[domain.RoleSalesManager]; !ok {
+		t.Fatal("filtered roles missing sales_manager")
+	}
+}

--- a/cmd/herbiego/main.go
+++ b/cmd/herbiego/main.go
@@ -2,17 +2,13 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
 
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/jpconstantineau/herbiego/internal/adapters/tui"
 	"github.com/jpconstantineau/herbiego/internal/app"
 	"github.com/jpconstantineau/herbiego/internal/domain"
-	"github.com/jpconstantineau/herbiego/internal/engine"
 	"github.com/jpconstantineau/herbiego/internal/ports"
 	"github.com/jpconstantineau/herbiego/internal/scenario"
 )
@@ -59,117 +55,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "application failed:\n%v\n", err)
 		os.Exit(1)
 	}
-}
-
-type gameplayExitIntent int
-
-const (
-	gameplayExitQuit gameplayExitIntent = iota
-	gameplayExitToMenu
-)
-
-func runLiveGameplay(ctx context.Context, runtime app.Runtime, initialState domain.MatchState, store persistentStore, rounds int, persistAIDebug bool) (gameplayExitIntent, domain.MatchState, error) {
-	definition, err := resolveScenarioForMatch(initialState)
-	if err != nil {
-		return gameplayExitQuit, domain.MatchState{}, err
-	}
-	liveLogger := app.NewDiscardLogger()
-
-	stateSnapshots := []domain.MatchState{initialState.Clone()}
-	if store != nil {
-		persistedSnapshots, err := store.StateSnapshots(initialState.MatchID)
-		if err != nil {
-			return gameplayExitQuit, domain.MatchState{}, fmt.Errorf("load persisted state snapshots: %w", err)
-		}
-		stateSnapshots = persistedSnapshots
-	}
-	controller := newLiveGameplayController(initialState, stateSnapshots)
-	players, debugLog, err := buildPlayersWithHumanSubmit(runtime.Config, definition, initialState, controller.SubmitRound, liveLogger)
-	if err != nil {
-		return gameplayExitQuit, domain.MatchState{}, fmt.Errorf("player setup: %w", err)
-	}
-	if store != nil && persistAIDebug {
-		configureAICallPersistence(debugLog, liveLogger, store, initialState.MatchID)
-	}
-	debugSource := tui.DebugSource(debugLog)
-	if store != nil {
-		debugRecords, err := store.AICallRecords(initialState.MatchID)
-		if err != nil {
-			return gameplayExitQuit, domain.MatchState{}, fmt.Errorf("load persisted ai traces: %w", err)
-		}
-		debugSource = combinedDebugSource{
-			live:      debugLog,
-			persisted: debugRecords,
-		}
-	}
-
-	runner := app.MatchRunner{
-		Collector: app.RoundCollector{Players: players, Logger: liveLogger},
-		Resolver:  engine.NewResolver(definition.ResolverOptions()),
-		Random:    runtime.Random,
-		Store:     store,
-		OnState:   controller.Publish,
-		Logger:    liveLogger,
-	}
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	program := tui.NewProgramWithQuitBehavior(
-		definition,
-		controller,
-		controller.Submit,
-		debugSource,
-		tui.QuitBehaviorReturnToMenu,
-		tea.WithAltScreen(),
-		tea.WithContext(ctx),
-	)
-
-	runnerErr := make(chan error, 1)
-	go func() {
-		defer controller.Close()
-
-		final, _, err := runner.Play(ctx, initialState, rounds)
-		switch {
-		case err == nil:
-			program.Send(tui.StatusMsg{
-				Text: fmt.Sprintf(
-					"Match complete after round %d. Final cash %d, debt %d, backlog %d, profit %d. Inspect results and press q to return to the menu.",
-					final.CurrentRound-1,
-					final.Plant.Cash,
-					final.Plant.Debt,
-					len(final.Plant.Backlog),
-					final.Metrics.RoundProfit,
-				),
-			})
-		case errors.Is(err, context.Canceled):
-			program.Send(tui.StatusMsg{Text: "Match cancelled. Returning to the start menu."})
-		default:
-			program.Send(tui.StatusMsg{Text: fmt.Sprintf("Match failed: %v. Press q to return to the menu.", err)})
-		}
-
-		runnerErr <- err
-	}()
-
-	finalModel, err := program.Run()
-	cancel()
-	playErr := <-runnerErr
-
-	if err != nil && !errors.Is(err, tea.ErrProgramKilled) {
-		return gameplayExitQuit, controller.Snapshot(), fmt.Errorf("bubble tea runtime: %w", err)
-	}
-	if playErr != nil && !errors.Is(playErr, context.Canceled) {
-		return gameplayExitQuit, controller.Snapshot(), playErr
-	}
-
-	gameplayModel, ok := finalModel.(tui.Model)
-	if !ok {
-		return gameplayExitQuit, controller.Snapshot(), nil
-	}
-	if gameplayModel.ExitIntent() == tui.ExitIntentReturnToMenu {
-		return gameplayExitToMenu, controller.Snapshot(), nil
-	}
-	return gameplayExitQuit, controller.Snapshot(), nil
 }
 
 func resolveScenarioForMatch(state domain.MatchState) (scenario.Definition, error) {

--- a/cmd/herbiego/splash_screen.go
+++ b/cmd/herbiego/splash_screen.go
@@ -24,11 +24,6 @@ type splashModel struct {
 	width    int
 }
 
-func runSplashScreen() error {
-	_, err := tea.NewProgram(splashModel{}, tea.WithAltScreen()).Run()
-	return err
-}
-
 func (m splashModel) Init() tea.Cmd {
 	return splashTickCmd()
 }

--- a/cmd/herbiego/start_menu.go
+++ b/cmd/herbiego/start_menu.go
@@ -72,27 +72,6 @@ type startMenuModel struct {
 	statusLine string
 }
 
-func runStartMenu(cfg app.Config, state startMenuState) (startMenuResult, error) {
-	model := newStartMenuModel(cfg, state)
-	final, err := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion()).Run()
-	if err != nil {
-		return startMenuResult{Action: startMenuActionExit, Config: cfg, State: state}, err
-	}
-
-	menu, ok := final.(startMenuModel)
-	if !ok {
-		return startMenuResult{Action: startMenuActionExit, Config: cfg, State: state}, fmt.Errorf("unexpected start menu result type %T", final)
-	}
-	if menu.cancelled {
-		return startMenuResult{
-			Action: startMenuActionExit,
-			Config: menu.config,
-			State:  menu.state,
-		}, nil
-	}
-	return menu.result, nil
-}
-
 func newStartMenuModel(cfg app.Config, state startMenuState) startMenuModel {
 	normalized := cloneConfig(cfg)
 	if normalized.Roles == nil {

--- a/internal/adapters/tui/run.go
+++ b/internal/adapters/tui/run.go
@@ -23,9 +23,16 @@ func RunReplay(definition ScenarioReader, current domain.MatchState, snapshots [
 // match source and q-key behavior.
 func NewProgramWithQuitBehavior(definition ScenarioReader, source StateSource, submit SubmitFunc, debug DebugSource, quitBehavior QuitBehavior, options ...tea.ProgramOption) *tea.Program {
 	opts := append([]tea.ProgramOption{tea.WithMouseCellMotion()}, options...)
+	model := NewModelWithSubmitDebugAndQuitBehavior(definition, source, submit, debug, quitBehavior)
+	return tea.NewProgram(model, opts...)
+}
+
+// NewModelWithSubmitDebugAndQuitBehavior constructs the gameplay model with
+// live submission, debug data, and a configurable q-key behavior.
+func NewModelWithSubmitDebugAndQuitBehavior(definition ScenarioReader, source StateSource, submit SubmitFunc, debug DebugSource, quitBehavior QuitBehavior) Model {
 	model := NewModelWithSubmitAndQuitBehavior(definition, source, submit, quitBehavior)
 	model.debugLog = debug
-	return tea.NewProgram(model, opts...)
+	return model
 }
 
 // NewProgram constructs the Bubble Tea program for the supplied match source.


### PR DESCRIPTION
## Summary
- replace the sequential splash/menu/gameplay launch loop with one top-level Bubble Tea shell
- route between splash, start menu, and gameplay inside the same Tea program while preserving the existing session/save-slot behavior
- add shell-focused tests for splash-to-menu and menu-to-gameplay transitions

## Testing
- `go test ./...`

Closes #242
Closes #244
Closes #192